### PR TITLE
Wrong sub command name for stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brew install fctl
 fctl login
 
 # create a sandbox stack deployment
-fctl sandbox create foobar
+fctl stack create foobar
 
 # commit your first ledger transaction
 fctl ledger send world foo 100 EUR/2 --ledger=demo


### PR DESCRIPTION
Currently in the README file, the command for create a sandbox is wrong.