### PR TITLE
fix: remove missing extra files for go releaser

### DIFF
--- a/components/gateway/.goreleaser.yml
+++ b/components/gateway/.goreleaser.yml
@@ -66,7 +66,6 @@ dockers:
   - image_templates: ["ghcr.io/formancehq/{{ .ProjectName }}:v{{ .Version }}-amd64"]
     dockerfile: build.Dockerfile
     extra_files:
-      - builder-config.json
       - Caddyfile
     use: buildx
     build_flag_templates:
@@ -83,7 +82,6 @@ dockers:
     goarch: arm64
     dockerfile: build.Dockerfile
     extra_files:
-      - builder-config.json
       - Caddyfile
     use: buildx
     build_flag_templates:


### PR DESCRIPTION
builder-config.json was removed since we are not building it from a config file anymore