### PR TITLE
fix: always send health field in /versions json response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 vendor
 .gitpod/_output
 .garden
+go.work
+go.work.sum

--- a/components/gateway/pkg/plugins/versions.go
+++ b/components/gateway/pkg/plugins/versions.go
@@ -133,7 +133,8 @@ func (v Versions) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 type serviceInfo struct {
 	Name    string `json:"name,omitempty"`
 	Version string `json:"version,omitempty"`
-	Health  bool   `json:"health,omitempty"`
+	// We do not want to omit empty values in the json response
+	Health bool `json:"health"`
 }
 
 type versionsResponse struct {


### PR DESCRIPTION
## Description

This PR fix the fact that the health field in the /versions json response was omitted if set to false.

Before:
```
{
    "name": "payments",
    "version": "develop"
},
```

After:
```
{
    "name": "payments",
    "version": "develop",
    "health": false
},
```

## Tests

Tested using local env.