### PR TITLE
fix: tests with postgres server

### DIFF
--- a/components/ledger/cmd/container_test.go
+++ b/components/ledger/cmd/container_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/ThreeDotsLabs/watermill/pubsub/gochannel"
 	"github.com/formancehq/stack/libs/go-libs/otlp/otlptraces"
-	"github.com/numary/ledger/internal/pgtesting"
+	"github.com/formancehq/stack/libs/go-libs/pgtesting"
 	"github.com/numary/ledger/pkg/api/middlewares"
 	"github.com/numary/ledger/pkg/bus"
 	"github.com/numary/ledger/pkg/core"
@@ -29,16 +29,7 @@ import (
 )
 
 func TestContainers(t *testing.T) {
-	pgServer, err := pgtesting.PostgresServer()
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer func(pgServer *pgtesting.PGServer) {
-		err := pgServer.Close()
-		if err != nil {
-			panic(err)
-		}
-	}(pgServer)
+	db := pgtesting.NewPostgresDatabase(t)
 
 	type testCase struct {
 		name    string
@@ -146,7 +137,7 @@ func TestContainers(t *testing.T) {
 			name: "pg",
 			init: func(v *viper.Viper) {
 				v.Set(storageDriverFlag, sqlstorage.PostgreSQL.String())
-				v.Set(storagePostgresConnectionStringFlag, pgServer.ConnString())
+				v.Set(storagePostgresConnectionStringFlag, db.ConnString())
 			},
 			options: []fx.Option{
 				fx.Invoke(func(lc fx.Lifecycle, t *testing.T, driver storage.Driver[storage.LedgerStore], storageFactory storage.Driver[storage.LedgerStore]) {

--- a/components/ledger/cmd/main_test.go
+++ b/components/ledger/cmd/main_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/formancehq/stack/libs/go-libs/pgtesting"
+)
+
+func TestMain(t *testing.M) {
+	if err := pgtesting.CreatePostgresServer(); err != nil {
+		panic(err)
+	}
+
+	code := t.Run()
+	_ = pgtesting.DestroyPostgresServer()
+	os.Exit(code)
+}

--- a/components/ledger/cmd/root_test.go
+++ b/components/ledger/cmd/root_test.go
@@ -8,20 +8,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/numary/ledger/internal/pgtesting"
+	"github.com/formancehq/stack/libs/go-libs/pgtesting"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestServer(t *testing.T) {
 
-	pgServer, err := pgtesting.PostgresServer()
-	assert.NoError(t, err)
-	defer func(pgServer *pgtesting.PGServer) {
-		if err := pgServer.Close(); err != nil {
-			panic(err)
-		}
-	}(pgServer)
+	db := pgtesting.NewPostgresDatabase(t)
 
 	type env struct {
 		key   string
@@ -46,7 +40,7 @@ func TestServer(t *testing.T) {
 		},
 		{
 			name: "pg",
-			args: []string{"--storage.driver", "postgres", "--storage.postgres.conn_string", pgServer.ConnString()},
+			args: []string{"--storage.driver", "postgres", "--storage.postgres.conn_string", db.ConnString()},
 		},
 		{
 			name: "pg-with-env-var",
@@ -57,7 +51,7 @@ func TestServer(t *testing.T) {
 				},
 				{
 					key:   "NUMARY_STORAGE_POSTGRES_CONN_STRING",
-					value: pgServer.ConnString(),
+					value: db.ConnString(),
 				},
 			},
 		},

--- a/components/ledger/cmd/script_check.go
+++ b/components/ledger/cmd/script_check.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/numary/ledger/pkg/machine/script/compiler"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -13,18 +12,19 @@ func NewScriptCheck() *cobra.Command {
 	return &cobra.Command{
 		Use:  "check [script]",
 		Args: cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			b, err := os.ReadFile(args[0])
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			_, err = compiler.Compile(string(b))
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			} else {
 				fmt.Println("Script is correct ✅")
 			}
+			return nil
 		},
 	}
 }

--- a/components/ledger/cmd/script_exec.go
+++ b/components/ledger/cmd/script_exec.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/numary/ledger/pkg/api/controllers"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -24,10 +25,10 @@ func NewScriptExec() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "exec [ledger] [script]",
 		Args: cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			b, err := os.ReadFile(args[1])
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			r := regexp.MustCompile(`^\n`)
@@ -38,7 +39,7 @@ func NewScriptExec() *cobra.Command {
 				"plain": s,
 			})
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			logrus.Debugln(string(b))
@@ -47,7 +48,7 @@ func NewScriptExec() *cobra.Command {
 				viper.Get(serverHttpBindAddressFlag),
 				args[0]), bytes.NewReader(b))
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			values := url.Values{}
@@ -59,21 +60,21 @@ func NewScriptExec() *cobra.Command {
 
 			res, err := http.DefaultClient.Do(req)
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			result := controllers.ScriptResponse{}
 			err = json.NewDecoder(res.Body).Decode(&result)
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			if result.ErrorCode != "" {
 				switch result.ErrorCode {
 				case "INTERNAL":
-					logrus.Fatal("unexpected error occured")
+					return errors.New("unexpected error occurred")
 				default:
-					logrus.Fatal(result.ErrorCode, result.ErrorMessage)
+					return fmt.Errorf("unexpected error: %s", result.ErrorMessage)
 				}
 			}
 
@@ -96,6 +97,7 @@ func NewScriptExec() *cobra.Command {
 					args[0],
 					result.Transaction.ID)
 			}
+			return nil
 		},
 	}
 	cmd.Flags().Bool(previewFlag, false, "Preview mode (does not save transactions)")

--- a/components/ledger/cmd/script_test.go
+++ b/components/ledger/cmd/script_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/formancehq/stack/libs/go-libs/api"
+	"github.com/formancehq/stack/libs/go-libs/pgtesting"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/numary/ledger/pkg/api/controllers"
@@ -21,8 +22,13 @@ import (
 )
 
 func Test_ScriptCommands(t *testing.T) {
+
+	db := pgtesting.NewPostgresDatabase(t)
+
 	ledger := uuid.NewString()
 	viper.Set("name", ledger)
+	viper.Set(storageDriverFlag, "postgres")
+	viper.Set(storagePostgresConnectionStringFlag, db.ConnString())
 	require.NoError(t, NewStorageInit().Execute())
 
 	d1 := []byte(`

--- a/components/ledger/cmd/storage_test.go
+++ b/components/ledger/cmd/storage_test.go
@@ -3,12 +3,18 @@ package cmd
 import (
 	"testing"
 
+	"github.com/formancehq/stack/libs/go-libs/pgtesting"
 	"github.com/google/uuid"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_StorageCommands(t *testing.T) {
+	db := pgtesting.NewPostgresDatabase(t)
+
+	viper.Set(storageDriverFlag, "postgres")
+	viper.Set(storagePostgresConnectionStringFlag, db.ConnString())
+
 	require.NoError(t, NewStorageList().Execute())
 
 	viper.Set("name", "")

--- a/components/ledger/go.mod
+++ b/components/ledger/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/jackc/pgproto3/v2 v2.3.1 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgtype v1.12.0 // indirect
+	github.com/jackc/pgx/v5 v5.3.0 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
 	github.com/jcmturner/gofork v1.7.6 // indirect

--- a/components/ledger/go.sum
+++ b/components/ledger/go.sum
@@ -372,6 +372,8 @@ github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQ
 github.com/jackc/pgx/v4 v4.12.1-0.20210724153913-640aa07df17c/go.mod h1:1QD0+tgSXP7iUjYm9C1NxKhny7lq6ee99u/z+IHFcgs=
 github.com/jackc/pgx/v4 v4.17.2 h1:0Ut0rpeKwvIVbMQ1KbMBU4h6wxehBI535LK6Flheh8E=
 github.com/jackc/pgx/v4 v4.17.2/go.mod h1:lcxIZN44yMIrWI78a5CpucdD14hX0SBDbNRvjDBItsw=
+github.com/jackc/pgx/v5 v5.3.0 h1:/NQi8KHMpKWHInxXesC8yD4DhkXPrVhmnwYkjp9AmBA=
+github.com/jackc/pgx/v5 v5.3.0/go.mod h1:t3JDKnCBlYIc0ewLF0Q7B8MXmoIaBOZj/ic7iHozM/8=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=


### PR DESCRIPTION
The recently added tests inside cmd/ was not starting a dedicated pg server instance, breaking a simple "go test" which was working on all other tests.
Also, changes really check errors of the commands.
And changes fix viper missing flags (was working only because tests inside root_test.go was configuring global env var).