### PR TITLE
feat: add environment to versions endpoint

### DIFF
--- a/components/gateway/Caddyfile
+++ b/components/gateway/Caddyfile
@@ -72,6 +72,7 @@ localhost:80 {
 	handle /versions {
 		versions {
 			region "us-east-1"
+			env "staging"
 			endpoints {
 				auth http://127.0.0.1:8080/_info http://127.0.0.1:8080/_healthcheck
 				ledger http://ledger:3068/_info http://ledger:3068/_healthcheck

--- a/components/operator/internal/controllers/stack/stack_reconciler.go
+++ b/components/operator/internal/controllers/stack/stack_reconciler.go
@@ -53,9 +53,13 @@ const (
 
 // Reconciler reconciles a Stack object
 type Reconciler struct {
+	// Cloud region where the stack is deployed
 	region string
-	client client.Client
-	scheme *runtime.Scheme
+	// Cloud environment where the stack is deployed: staging, production,
+	// sandbox, etc.
+	environment string
+	client      client.Client
+	scheme      *runtime.Scheme
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -206,6 +210,7 @@ func (r *Reconciler) reconcileStack(ctx context.Context, stack *stackv1beta3.Sta
 	resolveContext := modules.Context{
 		Context:       ctx,
 		Region:        r.region,
+		Environment:   r.environment,
 		Stack:         stack,
 		Configuration: configuration,
 		Versions:      versions,
@@ -214,11 +219,12 @@ func (r *Reconciler) reconcileStack(ctx context.Context, stack *stackv1beta3.Sta
 	return modules.HandleStack(resolveContext, deployer)
 }
 
-func NewReconciler(client client.Client, scheme *runtime.Scheme, region string) *Reconciler {
+func NewReconciler(client client.Client, scheme *runtime.Scheme, region, environment string) *Reconciler {
 	return &Reconciler{
-		region: region,
-		client: client,
-		scheme: scheme,
+		region:      region,
+		environment: environment,
+		client:      client,
+		scheme:      scheme,
 	}
 }
 

--- a/components/operator/internal/controllers/stack/suite_test.go
+++ b/components/operator/internal/controllers/stack/suite_test.go
@@ -91,7 +91,7 @@ var _ = ginkgo.BeforeEach(func() {
 	})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	err = stack.NewReconciler(mgr.GetClient(), mgr.GetScheme(), "us-west-1").SetupWithManager(mgr)
+	err = stack.NewReconciler(mgr.GetClient(), mgr.GetScheme(), "us-west-1", "staging").SetupWithManager(mgr)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	go func() {

--- a/components/operator/internal/controllers/stack/testdata/resources/configmaps--v1/gateway-config.yaml
+++ b/components/operator/internal/controllers/stack/testdata/resources/configmaps--v1/gateway-config.yaml
@@ -77,6 +77,7 @@ data:
         	handle /versions {
         		versions {
         			region "us-west-1"
+        			env "staging"
         			endpoints {
         				auth http://auth:8080/_info http://auth:8080/_healthcheck
         				ledger http://ledger:8080/_info http://ledger:8080/_healthcheck

--- a/components/operator/internal/handlers/handler_gateway.go
+++ b/components/operator/internal/handlers/handler_gateway.go
@@ -91,6 +91,7 @@ func createCaddyfile(context modules.InstallContext) string {
 
 	if err := tpl.Execute(buf, map[string]any{
 		"Region":   context.Region,
+		"Env":      context.Environment,
 		"Issuer":   fmt.Sprintf("%s/api/auth", context.Stack.URL()),
 		"Services": services,
 		"Debug":    context.Stack.Spec.Debug,
@@ -183,6 +184,7 @@ const caddyfile = `(cors) {
 	handle /versions {
 		versions {
 			region "{{ .Region }}"
+			env "{{ .Env }}"
 			endpoints {
 				{{- range $i, $service := .Services }}
 					{{- if $service.HasVersionEndpoint }}

--- a/components/operator/internal/modules/service.go
+++ b/components/operator/internal/modules/service.go
@@ -252,7 +252,11 @@ func (h ConfigHandle) GetMountPath() string {
 
 type Context struct {
 	context.Context
-	Region        string
+	// Region is the cloud region the stack is deployed to
+	Region string
+	// Environment is the environment the stack is deployed to: staging,
+	// production, sandbox, etc.
+	Environment   string
 	Stack         *stackv1beta3.Stack
 	Configuration *stackv1beta3.Configuration
 	Versions      *stackv1beta3.Versions

--- a/components/operator/main.go
+++ b/components/operator/main.go
@@ -65,6 +65,7 @@ func init() {
 func main() {
 	var (
 		region               string
+		env                  string
 		metricsAddr          string
 		enableLeaderElection bool
 		probeAddr            string
@@ -73,6 +74,7 @@ func main() {
 		disableWebhooks      bool
 	)
 	flag.StringVar(&region, "region", "eu-west-1", "The cloud region in use for the operator")
+	flag.StringVar(&env, "env", "staging", "The current environment in use for the operator")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -129,7 +131,7 @@ func main() {
 		}
 	}
 
-	stackReconciler := stack.NewReconciler(mgr.GetClient(), mgr.GetScheme(), region)
+	stackReconciler := stack.NewReconciler(mgr.GetClient(), mgr.GetScheme(), region, env)
 	if err = stackReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Stack")
 		os.Exit(1)

--- a/config/gateway/Caddyfile
+++ b/config/gateway/Caddyfile
@@ -72,6 +72,7 @@ localhost:80 {
 	handle /versions {
 		versions {
 			region "us-east-1"
+			env "staging"
 			endpoints {
 				auth http://127.0.0.1:8080/_info http://127.0.0.1:8080/_healthcheck
 				ledger http://ledger:3068/_info http://ledger:3068/_healthcheck


### PR DESCRIPTION
## Description

```
{
    "region": "eu-west-1",
    "env": "sandbox" // or "production" or "staging" or ? idk !
    "versions": [
        {
            "name": "wallets",
            "version": "develop",
            "health": true
        },
...
```

We want to expose the environment the stack is running on: staging, sandbox, etc...

## How ?

By passing a flag to the operator down to the gateway using the caddy file for the versions endpoint

## Tests

Tested using local env.