### PR TITLE
fix: fix ldflags for Version with goreleaser

### DIFF
--- a/components/auth/.goreleaser.yml
+++ b/components/auth/.goreleaser.yml
@@ -8,9 +8,9 @@ builds:
   - binary: auth
     id: auth
     ldflags:
-      - -X github.com/numary/auth/cmd.BuildDate={{ .Date }}
-      - -X github.com/numary/auth/cmd.Version={{ .Version }}
-      - -X github.com/numary/auth/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/formancehq/auth/cmd.BuildDate={{ .Date }}
+      - -X github.com/formancehq/auth/cmd.Version={{ .Version }}
+      - -X github.com/formancehq/auth/cmd.Commit={{ .ShortCommit }}
       - -extldflags "-static"
     env:
       - CGO_ENABLED=0

--- a/components/fctl/.goreleaser.yml
+++ b/components/fctl/.goreleaser.yml
@@ -8,10 +8,10 @@ builds:
   - binary: fctl
     id: fctl
     ldflags:
-      - -X github.com/numary/fctl/cmd.BuildDate={{ .Date }}
-      - -X github.com/numary/fctl/cmd.Version={{ .Version }}
-      - -X github.com/numary/fctl/cmd.Commit={{ .ShortCommit }}
-      - -X github.com/numary/fctl/pkg.DefaultSegmentWriteKey={{ .Env.SEGMENT_WRITE_KEY }}
+      - -X github.com/formancehq/fctl/cmd.BuildDate={{ .Date }}
+      - -X github.com/formancehq/fctl/cmd.Version={{ .Version }}
+      - -X github.com/formancehq/fctl/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/formancehq/fctl/pkg.DefaultSegmentWriteKey={{ .Env.SEGMENT_WRITE_KEY }}
       - -extldflags "-static"
     env:
       - CGO_ENABLED=0

--- a/components/operator/.goreleaser.yml
+++ b/components/operator/.goreleaser.yml
@@ -8,9 +8,9 @@ builds:
   - binary: operator
     id: operator
     ldflags:
-      - -X github.com/numary/operator/cmd.BuildDate={{ .Date }}
-      - -X github.com/numary/operator/cmd.Version={{ .Version }}
-      - -X github.com/numary/operator/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/formancehq/operator/cmd.BuildDate={{ .Date }}
+      - -X github.com/formancehq/operator/cmd.Version={{ .Version }}
+      - -X github.com/formancehq/operator/cmd.Commit={{ .ShortCommit }}
       - -extldflags "-static"
     env:
       - CGO_ENABLED=0

--- a/components/orchestration/.goreleaser.yml
+++ b/components/orchestration/.goreleaser.yml
@@ -8,9 +8,9 @@ builds:
   - binary: orchestration
     id: orchestration
     ldflags:
-      - -X github.com/numary/orchestration/cmd.BuildDate={{ .Date }}
-      - -X github.com/numary/orchestration/cmd.Version={{ .Version }}
-      - -X github.com/numary/orchestration/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/formancehq/orchestration/cmd.BuildDate={{ .Date }}
+      - -X github.com/formancehq/orchestration/cmd.Version={{ .Version }}
+      - -X github.com/formancehq/orchestration/cmd.Commit={{ .ShortCommit }}
       - -extldflags "-static"
     env:
       - CGO_ENABLED=0

--- a/components/payments/.goreleaser.yml
+++ b/components/payments/.goreleaser.yml
@@ -8,9 +8,9 @@ builds:
   - binary: payments
     id: payments
     ldflags:
-      - -X github.com/numary/payments/cmd.BuildDate={{ .Date }}
-      - -X github.com/numary/payments/cmd.Version={{ .Version }}
-      - -X github.com/numary/payments/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/formancehq/payments/cmd.BuildDate={{ .Date }}
+      - -X github.com/formancehq/payments/cmd.Version={{ .Version }}
+      - -X github.com/formancehq/payments/cmd.Commit={{ .ShortCommit }}
       - -extldflags "-static"
     env:
       - CGO_ENABLED=0

--- a/components/search/.goreleaser.yml
+++ b/components/search/.goreleaser.yml
@@ -8,9 +8,9 @@ builds:
   - binary: search
     id: search
     ldflags:
-      - -X github.com/numary/search/cmd.BuildDate={{ .Date }}
-      - -X github.com/numary/search/cmd.Version={{ .Version }}
-      - -X github.com/numary/search/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/formancehq/search/cmd.BuildDate={{ .Date }}
+      - -X github.com/formancehq/search/cmd.Version={{ .Version }}
+      - -X github.com/formancehq/search/cmd.Commit={{ .ShortCommit }}
       - -extldflags "-static"
     env:
       - CGO_ENABLED=0

--- a/components/wallets/.goreleaser.yml
+++ b/components/wallets/.goreleaser.yml
@@ -8,9 +8,9 @@ builds:
   - binary: wallets
     id: wallets
     ldflags:
-      - -X github.com/numary/wallets/cmd.BuildDate={{ .Date }}
-      - -X github.com/numary/wallets/cmd.Version={{ .Version }}
-      - -X github.com/numary/wallets/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/formancehq/wallets/cmd.BuildDate={{ .Date }}
+      - -X github.com/formancehq/wallets/cmd.Version={{ .Version }}
+      - -X github.com/formancehq/wallets/cmd.Commit={{ .ShortCommit }}
       - -extldflags "-static"
     env:
       - CGO_ENABLED=0

--- a/components/webhooks/.goreleaser.yml
+++ b/components/webhooks/.goreleaser.yml
@@ -8,9 +8,9 @@ builds:
   - binary: webhooks
     id: webhooks
     ldflags:
-      - -X github.com/numary/webhooks/cmd.BuildDate={{ .Date }}
-      - -X github.com/numary/webhooks/cmd.Version={{ .Version }}
-      - -X github.com/numary/webhooks/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/formancehq/webhooks/cmd.BuildDate={{ .Date }}
+      - -X github.com/formancehq/webhooks/cmd.Version={{ .Version }}
+      - -X github.com/formancehq/webhooks/cmd.Commit={{ .ShortCommit }}
       - -extldflags "-static"
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
## Description

Component versions are set to "develop" on all components instead of the current versions/tag.

## Fix

In order to set package variable using ldflags, we have to use the importpath from the go.mod file in every components, which was wrong for all components, hence the version set to the default version "develop"