### PR TITLE
feat: combine logs before insertion

### DIFF
--- a/components/ledger/cmd/container_test.go
+++ b/components/ledger/cmd/container_test.go
@@ -163,8 +163,10 @@ func TestContainers(t *testing.T) {
 							}
 							errCh := make(chan error, 1)
 							go func() {
-								waitAndPostProcess := l.SaveMeta(ctx, core.MetaTargetTypeAccount, "world", core.Metadata{"foo": []byte(`"bar"`)})
-								err := waitAndPostProcess(ctx)
+								logs, err := l.SaveMeta(ctx, core.MetaTargetTypeAccount, "world", core.Metadata{"foo": []byte(`"bar"`)})
+								if err == nil {
+									err = logs.Wait(ctx)
+								}
 								if err != nil {
 									errCh <- err
 								}

--- a/components/ledger/pkg/api/controllers/account_controller.go
+++ b/components/ledger/pkg/api/controllers/account_controller.go
@@ -150,9 +150,14 @@ func (ctl *AccountController) PostAccountMetadata(w http.ResponseWriter, r *http
 		return
 	}
 
-	waitAndPostProcess := l.SaveMeta(r.Context(),
+	logs, err := l.SaveMeta(r.Context(),
 		core.MetaTargetTypeAccount, chi.URLParam(r, "address"), m)
-	if err := waitAndPostProcess(r.Context()); err != nil {
+	if err != nil {
+		apierrors.ResponseError(w, r, err)
+		return
+	}
+
+	if err := logs.Wait(r.Context()); err != nil {
 		apierrors.ResponseError(w, r, err)
 		return
 	}

--- a/components/ledger/pkg/ledger/benchmarks_test.go
+++ b/components/ledger/pkg/ledger/benchmarks_test.go
@@ -37,8 +37,9 @@ func BenchmarkLedger_PostTransactions_Scripts_Single_FixedAccounts(b *testing.B)
 			b.StopTimer()
 			script := txToScriptData(txData)
 			b.StartTimer()
-			_res, waitAndPostProcess := l.ExecuteScript(context.Background(), true, script)
-			require.NoError(b, waitAndPostProcess(context.Background()))
+			_res, logs, err := l.ProcessScript(context.Background(), true, true, script)
+			require.NoError(b, err)
+			require.NoError(b, logs.Wait(context.Background()))
 			require.Len(b, res.Postings, nbPostings)
 			res = _res
 		}
@@ -70,8 +71,9 @@ func BenchmarkLedger_PostTransactions_Postings_Single_FixedAccounts(b *testing.B
 			_, err := txData.Postings.Validate()
 			require.NoError(b, err)
 
-			tx, waitAndPostProcess := l.ExecuteScript(context.Background(), true, core.TxToScriptData(txData))
-			require.NoError(b, waitAndPostProcess(context.Background()))
+			tx, logs, err := l.ProcessScript(context.Background(), true, true, core.TxToScriptData(txData))
+			require.NoError(b, err)
+			require.NoError(b, logs.Wait(context.Background()))
 			require.Len(b, res, 1)
 			require.Len(b, res[0].Postings, nbPostings)
 			res = append(res, tx)
@@ -99,8 +101,9 @@ func BenchmarkLedger_PostTransactions_Postings_Batch_FixedAccounts(b *testing.B)
 				require.NoError(b, err)
 			}
 			for _, script := range core.TxsToScriptsData(txsData...) {
-				tx, waitAndPostProcess := l.ExecuteScript(context.Background(), true, script)
-				require.NoError(b, waitAndPostProcess(context.Background()))
+				tx, logs, err := l.ProcessScript(context.Background(), true, true, script)
+				require.NoError(b, err)
+				require.NoError(b, logs.Wait(context.Background()))
 				res = append(res, tx)
 			}
 
@@ -144,8 +147,9 @@ func BenchmarkLedger_PostTransactions_Postings_Batch_VaryingAccounts(b *testing.
 				require.NoError(b, err)
 			}
 			for _, script := range core.TxsToScriptsData(txsData...) {
-				tx, waitAndPostProcess := l.ExecuteScript(context.Background(), true, script)
-				require.NoError(b, waitAndPostProcess(context.Background()))
+				tx, logs, err := l.ProcessScript(context.Background(), true, true, script)
+				require.NoError(b, err)
+				require.NoError(b, logs.Wait(context.Background()))
 				res = append(res, tx)
 			}
 			require.Len(b, res, 7)

--- a/components/ledger/pkg/ledger/logs.go
+++ b/components/ledger/pkg/ledger/logs.go
@@ -1,0 +1,70 @@
+package ledger
+
+import (
+	"context"
+
+	"github.com/formancehq/ledger/pkg/core"
+	"github.com/pkg/errors"
+)
+
+type appendLog func(context.Context, ...core.Log) <-chan error
+type postProcessing func(context.Context) error
+
+type Logs struct {
+	appendLog       appendLog
+	logs            []core.Log
+	postProcessings []postProcessing
+
+	errChan <-chan error
+}
+
+func NewLogs(appendLog appendLog, logs []core.Log, postProcessings []postProcessing) *Logs {
+	return &Logs{
+		appendLog:       appendLog,
+		logs:            logs,
+		postProcessings: postProcessings,
+	}
+}
+
+func (ls *Logs) AddLog(log core.Log) {
+	ls.logs = append(ls.logs, log)
+}
+
+func (ls *Logs) AddPostProcessing(postProcessing postProcessing) {
+	ls.postProcessings = append(ls.postProcessings, postProcessing)
+}
+
+func (ls *Logs) Write(ctx context.Context) error {
+	if len(ls.logs) == 0 {
+		// Nothing to do, return early
+		return nil
+	}
+
+	ls.errChan = ls.appendLog(ctx, ls.logs...)
+
+	return nil
+}
+
+func (ls *Logs) Wait(ctx context.Context) error {
+	if ls.errChan == nil {
+		// Nothing to wait on
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-ls.errChan:
+		if err != nil {
+			return errors.Wrap(err, "appending logs")
+		}
+	}
+
+	for _, postProcessing := range ls.postProcessings {
+		if err := postProcessing(ctx); err != nil {
+			return errors.Wrap(err, "post processing")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
We want to make only one logs insertion in order to fail all when the query fails.