### PR TITLE
feat: move bulk insert to copy with bun

### DIFF
--- a/components/ledger/pkg/ledger/ledger.go
+++ b/components/ledger/pkg/ledger/ledger.go
@@ -180,7 +180,6 @@ func (l *Ledger) GetBalancesAggregated(ctx context.Context, q BalancesQuery) (co
 }
 
 func (l *Ledger) SaveMeta(ctx context.Context, targetType string, targetID interface{}, m core.Metadata) waitLogsAndPostProcessing {
-
 	if targetType == "" {
 		return func(_ context.Context) error { return NewValidationError("empty target type") }
 	}

--- a/components/ledger/pkg/storage/sqlstorage/errors/errors.go
+++ b/components/ledger/pkg/storage/sqlstorage/errors/errors.go
@@ -1,22 +1,23 @@
 package errors
 
 import (
-	"errors"
-
 	"github.com/formancehq/ledger/pkg/storage"
-	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/lib/pq"
 )
 
 // postgresError is an helper to wrap postgres errors into storage errors
 func PostgresError(err error) error {
-	var pgConnError *pgconn.PgError
-	if errors.As(err, &pgConnError) {
-		switch pgConnError.Code {
-		case "23505":
-			return storage.NewError(storage.ConstraintFailed, err)
-		case "53300":
-			return storage.NewError(storage.TooManyClient, err)
+	if err != nil {
+		switch pge := err.(type) {
+		case *pq.Error:
+			switch pge.Code {
+			case "23505":
+				return storage.NewError(storage.ConstraintFailed, err)
+			case "53300":
+				return storage.NewError(storage.TooManyClient, err)
+			}
 		}
 	}
+
 	return err
 }

--- a/components/ledger/pkg/storage/sqlstorage/module.go
+++ b/components/ledger/pkg/storage/sqlstorage/module.go
@@ -1,12 +1,12 @@
 package sqlstorage
 
 import (
+	"database/sql"
+
 	"github.com/formancehq/ledger/pkg/storage"
 	ledgerstore "github.com/formancehq/ledger/pkg/storage/sqlstorage/ledger"
 	"github.com/formancehq/ledger/pkg/storage/sqlstorage/schema"
 	"github.com/formancehq/stack/libs/go-libs/health"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"go.uber.org/fx"
@@ -21,13 +21,10 @@ type ModuleConfig struct {
 }
 
 func OpenSQLDB(dataSourceName string) (*bun.DB, error) {
-	config, err := pgx.ParseConfig(dataSourceName)
+	sqldb, err := sql.Open("postgres", dataSourceName)
 	if err != nil {
 		return nil, err
 	}
-	config.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
-
-	sqldb := stdlib.OpenDB(*config)
 
 	db := bun.NewDB(sqldb, pgdialect.New())
 

--- a/libs/go-libs/go.mod
+++ b/libs/go-libs/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/imdario/mergo v0.3.13
 	github.com/jackc/pgx/v5 v5.3.0
+	github.com/lib/pq v1.10.7
 	github.com/nats-io/nats-server/v2 v2.9.8
 	github.com/nats-io/nats.go v1.23.0
 	github.com/ory/dockertest/v3 v3.9.1
@@ -88,7 +89,6 @@ require (
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
-	github.com/lib/pq v1.10.7 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect


### PR DESCRIPTION
Bulk insert were done thanks to bun and mulitple
values for the insert postgres method. In order to improve the performances, let's move to copy for
these bulk inserts.

Also, using copy wiuth bun is not working if the pgx driver is used when creating the bun db.