### PR TITLE
feat: Add Speakeasy Workflow files

### DIFF
--- a/.github/workflows/speakeasy_go_generate.yaml
+++ b/.github/workflows/speakeasy_go_generate.yaml
@@ -1,0 +1,25 @@
+name: Generate Go SDK
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow to generate SDK
+    inputs:
+      force:
+        description: "Force generation of SDKs"
+        type: boolean
+        default: false
+  schedule:
+    - cron: 0 0 * * * # Runs every day at midnight
+
+jobs:
+  generate:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14 # Import the sdk generation workflow which will handle the generation of the SDKs and publishing to the package managers in 'direct' mode.
+    with:
+      speakeasy_version: latest
+      openapi_doc_location: ./openapi/base.yaml
+      languages: |-
+        - go: ./sdks/go
+      mode: pr
+      force: ${{ github.event.inputs.force }}
+    secrets:
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/speakeasy_go_publish.yaml
+++ b/.github/workflows/speakeasy_go_publish.yaml
@@ -1,0 +1,17 @@
+name: Publish Go SDK
+
+on:
+  push: # Will trigger when the RELEASES.md file is updated by the merged PR from the generation workflow
+    paths:
+      - "./sdks/go/RELEASES.md"
+    branches:
+      - main
+
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14 # Import the sdk publish workflow which will handle the publishing to the package managers
+    with:
+      create_release: true
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/speakeasy_java_generate.yaml
+++ b/.github/workflows/speakeasy_java_generate.yaml
@@ -1,0 +1,28 @@
+name: Generate Java SDK
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow to generate SDK
+    inputs:
+      force:
+        description: "Force generation of SDKs"
+        type: boolean
+        default: false
+  schedule:
+    - cron: 0 0 * * * # Runs every day at midnight
+
+jobs:
+  generate:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14 # Import the sdk generation workflow which will handle the generation of the SDKs and publishing to the package managers in 'direct' mode.
+    with:
+      speakeasy_version: latest
+      openapi_doc_location: ./openapi/base.yaml
+      languages: |-
+        - java: ./sdks/java
+      # publish_java: true # Tells the generation action to generate artifacts for publishing to Maven
+      mode: pr
+      force: ${{ github.event.inputs.force }}
+    secrets:
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      # maven_username: ${{ secrets.MAVEN_USERNAME }}
+      # maven_password: ${{ secrets.MAVEN_PASSWORD }}

--- a/.github/workflows/speakeasy_java_generate.yaml
+++ b/.github/workflows/speakeasy_java_generate.yaml
@@ -18,7 +18,6 @@ jobs:
       openapi_doc_location: ./openapi/base.yaml
       languages: |-
         - java: ./sdks/java
-      # publish_java: true # Tells the generation action to generate artifacts for publishing to Maven
       mode: pr
       force: ${{ github.event.inputs.force }}
     secrets:

--- a/.github/workflows/speakeasy_java_publish.yaml
+++ b/.github/workflows/speakeasy_java_publish.yaml
@@ -1,0 +1,20 @@
+name: Publish Java SDK
+
+on:
+  push: # Will trigger when the RELEASES.md file is updated by the merged PR from the generation workflow
+    paths:
+      - "./sdks/java/RELEASES.md"
+    branches:
+      - main
+
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14 # Import the sdk publish workflow which will handle the publishing to the package managers
+    with:
+      publish_java: true
+      create_release: true
+    secrets:
+      maven_username: ${{ secrets.MAVEN_USERNAME }}
+      maven_password: ${{ secrets.MAVEN_PASSWORD }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/speakeasy_php_generate.yaml
+++ b/.github/workflows/speakeasy_php_generate.yaml
@@ -1,4 +1,4 @@
-name: Generate Typescript SDK
+name: Generate Php SDK
 
 on:
   workflow_dispatch: # Allows manual triggering of the workflow to generate SDK
@@ -17,9 +17,9 @@ jobs:
       speakeasy_version: latest
       openapi_doc_location: ./openapi/base.yaml
       languages: |-
-        - typescript: ./sdks/typescript-node
+        - php: ./sdks/php
       mode: pr
       force: ${{ github.event.inputs.force }}
     secrets:
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/speakeasy_php_publish.yaml
+++ b/.github/workflows/speakeasy_php_publish.yaml
@@ -1,0 +1,20 @@
+name: Publish Php SDK
+
+on:
+  push: # Will trigger when the RELEASES.md file is updated by the merged PR from the generation workflow
+    paths:
+      - "./sdks/php/RELEASES.md"
+    branches:
+      - main
+
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14 # Import the sdk publish workflow which will handle the publishing to the package managers
+    with:
+      publish_php: true
+      create_release: true
+    secrets:
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      packagist_username: ${{ secrets.PACKAGIST_USERNAME }}
+      packagist_token: ${{ secrets.PACKAGIST_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/speakeasy_python_generate.yaml
+++ b/.github/workflows/speakeasy_python_generate.yaml
@@ -18,10 +18,8 @@ jobs:
       openapi_doc_location: ./openapi/base.yaml
       languages: |-
         - python: ./sdks/python
-      # publish_python: true # Tells the generation action to generate artifacts for publishing to PyPi
       mode: pr
       force: ${{ github.event.inputs.force }}
     secrets:
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      # pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/speakeasy_python_generate.yaml
+++ b/.github/workflows/speakeasy_python_generate.yaml
@@ -1,0 +1,27 @@
+name: Generate Python SDK
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow to generate SDK
+    inputs:
+      force:
+        description: "Force generation of SDKs"
+        type: boolean
+        default: false
+  schedule:
+    - cron: 0 0 * * * # Runs every day at midnight
+
+jobs:
+  generate:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14 # Import the sdk generation workflow which will handle the generation of the SDKs and publishing to the package managers in 'direct' mode.
+    with:
+      speakeasy_version: latest
+      openapi_doc_location: ./openapi/base.yaml
+      languages: |-
+        - python: ./sdks/python
+      # publish_python: true # Tells the generation action to generate artifacts for publishing to PyPi
+      mode: pr
+      force: ${{ github.event.inputs.force }}
+    secrets:
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      # pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/speakeasy_python_publish.yaml
+++ b/.github/workflows/speakeasy_python_publish.yaml
@@ -1,0 +1,19 @@
+name: Publish Python SDK
+
+on:
+  push: # Will trigger when the RELEASES.md file is updated by the merged PR from the generation workflow
+    paths:
+      - "./sdks/python/RELEASES.md"
+    branches:
+      - main
+
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14 # Import the sdk publish workflow which will handle the publishing to the package managers
+    with:
+      publish_python: true
+      create_release: true
+    secrets:
+      pypi_token: ${{ secrets.PYPI_TOKEN }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/speakeasy_ts_generate.yaml
+++ b/.github/workflows/speakeasy_ts_generate.yaml
@@ -1,0 +1,27 @@
+name: Generate Typescript SDK
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow to generate SDK
+    inputs:
+      force:
+        description: "Force generation of SDKs"
+        type: boolean
+        default: false
+  schedule:
+    - cron: 0 0 * * * # Runs every day at midnight
+
+jobs:
+  generate:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14 # Import the sdk generation workflow which will handle the generation of the SDKs and publishing to the package managers in 'direct' mode.
+    with:
+      speakeasy_version: latest
+      openapi_doc_location: ./openapi/base.yaml
+      languages: |-
+        - typescript: ./sdks/typescript-node
+      # publish_typescript: true # Tells the generation action to generate artifacts for publishing to NPM
+      mode: pr
+      force: ${{ github.event.inputs.force }}
+    secrets:
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      # npm_token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/speakeasy_ts_publish.yaml
+++ b/.github/workflows/speakeasy_ts_publish.yaml
@@ -1,0 +1,19 @@
+name: Publish Typescript SDK
+
+on:
+  push: # Will trigger when the RELEASES.md file is updated by the merged PR from the generation workflow
+    paths:
+      - "./sdks/typescript-node/RELEASES.md"
+    branches:
+      - main
+
+jobs:
+  publish:
+    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14 # Import the sdk publish workflow which will handle the publishing to the package managers
+    with:
+      publish_typescript: true
+      create_release: true
+    secrets:
+      npm_token: ${{secrets.NPM_TOKEN}}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
- Adding Github workflow files for Speakeasy SDK generation and publishing
- Note: PHP workflow will only generate for the moment as monorepo publishing is not clearly supported through `composer` yet. 