### PR TITLE
refactor: separate machine code

### DIFF
--- a/components/ledger/go.mod
+++ b/components/ledger/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/formancehq/stack/libs/go-libs v0.0.0-20230222164357-55840b21a337
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/cors v1.2.1
-	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/jackc/pgx/v5 v5.3.0
 	github.com/lib/pq v1.10.7

--- a/components/ledger/go.sum
+++ b/components/ledger/go.sum
@@ -214,7 +214,6 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/components/ledger/pkg/api/controllers/account_controller_test.go
+++ b/components/ledger/pkg/api/controllers/account_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/url"
 	"testing"
@@ -42,13 +43,13 @@ func TestGetAccounts(t *testing.T) {
 		require.NoError(t, store.UpdateAccountMetadata(context.Background(), "bob", meta))
 		require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 			"world": {
-				"USD": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(250)),
+				"USD": core.NewEmptyVolumes().WithOutput(big.NewInt(250)),
 			},
 			"alice": {
-				"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(150)),
+				"USD": core.NewEmptyVolumes().WithInput(big.NewInt(150)),
 			},
 			"bob": {
-				"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+				"USD": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 			},
 		}))
 
@@ -421,7 +422,7 @@ func TestGetAccount(t *testing.T) {
 		}))
 		require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 			"alice": {
-				"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+				"USD": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 			},
 		}))
 
@@ -439,8 +440,8 @@ func TestGetAccount(t *testing.T) {
 				},
 				Volumes: core.AssetsVolumes{
 					"USD": {
-						Input:  core.NewMonetaryInt(100),
-						Output: core.NewMonetaryInt(0),
+						Input:  big.NewInt(100),
+						Output: big.NewInt(0),
 					},
 				},
 			}, resp)

--- a/components/ledger/pkg/api/controllers/balance_controller_test.go
+++ b/components/ledger/pkg/api/controllers/balance_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/url"
 	"testing"
@@ -28,13 +29,13 @@ func TestGetBalancesAggregated(t *testing.T) {
 
 		require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 			"world": {
-				"USD": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(250)),
+				"USD": core.NewEmptyVolumes().WithOutput(big.NewInt(250)),
 			},
 			"alice": {
-				"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(150)),
+				"USD": core.NewEmptyVolumes().WithInput(big.NewInt(150)),
 			},
 			"bob": {
-				"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+				"USD": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 			},
 		}))
 
@@ -44,7 +45,7 @@ func TestGetBalancesAggregated(t *testing.T) {
 
 			resp, ok := internal.DecodeSingleResponse[core.AssetsBalances](t, rsp.Body)
 			require.Equal(t, ok, true)
-			require.Equal(t, core.AssetsBalances{"USD": core.NewMonetaryInt(0)}, resp)
+			require.Equal(t, core.AssetsBalances{"USD": big.NewInt(0)}, resp)
 		})
 
 		t.Run("filter by address", func(t *testing.T) {
@@ -53,7 +54,7 @@ func TestGetBalancesAggregated(t *testing.T) {
 
 			resp, ok := internal.DecodeSingleResponse[core.AssetsBalances](t, rsp.Body)
 			require.Equal(t, true, ok)
-			require.Equal(t, core.AssetsBalances{"USD": core.NewMonetaryInt(-250)}, resp)
+			require.Equal(t, core.AssetsBalances{"USD": big.NewInt(-250)}, resp)
 		})
 
 		t.Run("filter by address no result", func(t *testing.T) {
@@ -77,17 +78,17 @@ func TestGetBalances(t *testing.T) {
 
 		require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 			"world": {
-				"USD": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(250)),
-				"CAD": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(200)),
-				"EUR": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(400)),
+				"USD": core.NewEmptyVolumes().WithOutput(big.NewInt(250)),
+				"CAD": core.NewEmptyVolumes().WithOutput(big.NewInt(200)),
+				"EUR": core.NewEmptyVolumes().WithOutput(big.NewInt(400)),
 			},
 			"alice": {
-				"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(150)),
-				"CAD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(200)),
-				"EUR": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(400)),
+				"USD": core.NewEmptyVolumes().WithInput(big.NewInt(150)),
+				"CAD": core.NewEmptyVolumes().WithInput(big.NewInt(200)),
+				"EUR": core.NewEmptyVolumes().WithInput(big.NewInt(400)),
 			},
 			"bob": {
-				"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+				"USD": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 			},
 		}))
 
@@ -126,9 +127,9 @@ func TestGetBalances(t *testing.T) {
 
 			resp := internal.DecodeCursorResponse[core.AccountsBalances](t, rsp.Body)
 			require.Equal(t, []core.AccountsBalances{
-				{"world": core.AssetsBalances{"USD": core.NewMonetaryInt(-250), "EUR": core.NewMonetaryInt(-400), "CAD": core.NewMonetaryInt(-200)}},
-				{"bob": core.AssetsBalances{"USD": core.NewMonetaryInt(100)}},
-				{"alice": core.AssetsBalances{"USD": core.NewMonetaryInt(150), "EUR": core.NewMonetaryInt(400), "CAD": core.NewMonetaryInt(200)}},
+				{"world": core.AssetsBalances{"USD": big.NewInt(-250), "EUR": big.NewInt(-400), "CAD": big.NewInt(-200)}},
+				{"bob": core.AssetsBalances{"USD": big.NewInt(100)}},
+				{"alice": core.AssetsBalances{"USD": big.NewInt(150), "EUR": big.NewInt(400), "CAD": big.NewInt(200)}},
 			}, resp.Data)
 		})
 
@@ -138,7 +139,7 @@ func TestGetBalances(t *testing.T) {
 
 			resp := internal.DecodeCursorResponse[core.AccountsBalances](t, rsp.Body)
 			require.Equal(t, []core.AccountsBalances{
-				{"alice": core.AssetsBalances{"USD": core.NewMonetaryInt(150), "EUR": core.NewMonetaryInt(400), "CAD": core.NewMonetaryInt(200)}},
+				{"alice": core.AssetsBalances{"USD": big.NewInt(150), "EUR": big.NewInt(400), "CAD": big.NewInt(200)}},
 			}, resp.Data)
 		})
 
@@ -148,7 +149,7 @@ func TestGetBalances(t *testing.T) {
 
 			resp := internal.DecodeCursorResponse[core.AccountsBalances](t, rsp.Body)
 			require.Equal(t, []core.AccountsBalances{
-				{"world": core.AssetsBalances{"USD": core.NewMonetaryInt(-250), "EUR": core.NewMonetaryInt(-400), "CAD": core.NewMonetaryInt(-200)}},
+				{"world": core.AssetsBalances{"USD": big.NewInt(-250), "EUR": big.NewInt(-400), "CAD": big.NewInt(-200)}},
 			}, resp.Data)
 		})
 

--- a/components/ledger/pkg/api/controllers/ledger_controller_test.go
+++ b/components/ledger/pkg/api/controllers/ledger_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/url"
 	"testing"
@@ -57,12 +58,12 @@ func TestGetStats(t *testing.T) {
 
 		require.NoError(t, store.InsertTransactions(context.Background(), core.ExpandTransactionFromEmptyPreCommitVolumes(
 			core.NewTransaction().WithPostings(
-				core.NewPosting("world", "alice", "USD", core.NewMonetaryInt(100)),
+				core.NewPosting("world", "alice", "USD", big.NewInt(100)),
 			),
 		)))
 		require.NoError(t, store.InsertTransactions(context.Background(), core.ExpandTransactionFromEmptyPreCommitVolumes(
 			core.NewTransaction().
-				WithPostings(core.NewPosting("world", "bob", "USD", core.NewMonetaryInt(100))).
+				WithPostings(core.NewPosting("world", "bob", "USD", big.NewInt(100))).
 				WithID(1),
 		)))
 		require.NoError(t, store.EnsureAccountExists(context.Background(), "world"))
@@ -92,7 +93,7 @@ func TestGetLogs(t *testing.T) {
 						{
 							Source:      "world",
 							Destination: "alice",
-							Amount:      core.NewMonetaryInt(100),
+							Amount:      big.NewInt(100),
 							Asset:       "USD",
 						},
 					},
@@ -108,7 +109,7 @@ func TestGetLogs(t *testing.T) {
 						{
 							Source:      "world",
 							Destination: "bob",
-							Amount:      core.NewMonetaryInt(200),
+							Amount:      big.NewInt(200),
 							Asset:       "USD",
 						},
 					},

--- a/components/ledger/pkg/api/controllers/pagination_test.go
+++ b/components/ledger/pkg/api/controllers/pagination_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/url"
 	"testing"
@@ -48,7 +49,7 @@ func testGetPagination(t *testing.T, api chi.Router, storageDriver storage.Drive
 			for i := 0; i < numTxs; i++ {
 				require.NoError(t, store.InsertTransactions(context.Background(), core.ExpandTransactionFromEmptyPreCommitVolumes(
 					core.NewTransaction().
-						WithPostings(core.NewPosting("world", fmt.Sprintf("accounts:%06d", i), "USD", core.NewMonetaryInt(10))).
+						WithPostings(core.NewPosting("world", fmt.Sprintf("accounts:%06d", i), "USD", big.NewInt(10))).
 						WithReference(fmt.Sprintf("ref:%06d", i)),
 				)))
 			}
@@ -445,7 +446,7 @@ func TestCursor(t *testing.T) {
 		for i := 0; i < 30; i++ {
 			date := timestamp.Add(time.Duration(i) * time.Second)
 			tx := core.NewTransaction().
-				WithPostings(core.NewPosting("world", fmt.Sprintf("accounts:%02d", i), "USD", core.NewMonetaryInt(1))).
+				WithPostings(core.NewPosting("world", fmt.Sprintf("accounts:%02d", i), "USD", big.NewInt(1))).
 				WithReference(fmt.Sprintf("ref:%02d", i)).
 				WithMetadata(core.Metadata{"ref": "abc"}).
 				WithTimestamp(date).
@@ -459,7 +460,7 @@ func TestCursor(t *testing.T) {
 			}))
 			require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 				fmt.Sprintf("accounts:%02d", i): {
-					"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(1)),
+					"USD": core.NewEmptyVolumes().WithInput(big.NewInt(1)),
 				},
 			}))
 		}

--- a/components/ledger/pkg/api/controllers/transaction_controller_test.go
+++ b/components/ledger/pkg/api/controllers/transaction_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/url"
 	"testing"
@@ -43,7 +44,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "central_bank",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "USB",
 					},
 				},
@@ -57,7 +58,7 @@ func TestPostTransactions(t *testing.T) {
 								{
 									Source:      "world",
 									Destination: "central_bank",
-									Amount:      core.NewMonetaryInt(1000),
+									Amount:      big.NewInt(1000),
 									Asset:       "USB",
 								},
 							},
@@ -73,7 +74,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "central_bank",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "US1234D",
 					},
 				},
@@ -87,7 +88,7 @@ func TestPostTransactions(t *testing.T) {
 								{
 									Source:      "world",
 									Destination: "central_bank",
-									Amount:      core.NewMonetaryInt(1000),
+									Amount:      big.NewInt(1000),
 									Asset:       "US1234D",
 								},
 							},
@@ -126,13 +127,13 @@ func TestPostTransactions(t *testing.T) {
 								{
 									Source:      "world",
 									Destination: "centralbank",
-									Amount:      core.NewMonetaryInt(100),
+									Amount:      big.NewInt(100),
 									Asset:       "COIN",
 								},
 								{
 									Source:      "centralbank",
 									Destination: "users:001",
-									Amount:      core.NewMonetaryInt(100),
+									Amount:      big.NewInt(100),
 									Asset:       "COIN",
 								},
 							},
@@ -163,7 +164,7 @@ func TestPostTransactions(t *testing.T) {
 								{
 									Source:      "world",
 									Destination: "bar",
-									Amount:      core.NewMonetaryInt(1000),
+									Amount:      big.NewInt(1000),
 									Asset:       "TOK",
 								},
 							},
@@ -188,7 +189,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "central_bank",
-						Amount:      core.NewMonetaryInt(-1000),
+						Amount:      big.NewInt(-1000),
 						Asset:       "USB",
 					},
 				},
@@ -206,7 +207,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "central_bank",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "@TOK",
 					},
 				},
@@ -224,7 +225,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "central_bank",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "1TOK",
 					},
 				},
@@ -242,7 +243,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "#fake",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "TOK",
 					},
 				},
@@ -260,7 +261,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "foo",
 						Destination: "bar",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "TOK",
 					},
 				},
@@ -279,7 +280,7 @@ func TestPostTransactions(t *testing.T) {
 						{
 							Source:      "world",
 							Destination: "bar",
-							Amount:      core.NewMonetaryInt(1000),
+							Amount:      big.NewInt(1000),
 							Asset:       "TOK",
 						},
 					},
@@ -291,7 +292,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "bar",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "TOK",
 					},
 				},
@@ -416,7 +417,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "alice",
-						Amount:      core.NewMonetaryInt(100),
+						Amount:      big.NewInt(100),
 						Asset:       "COIN",
 					},
 				},
@@ -441,7 +442,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "bar",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "TOK",
 					},
 				},
@@ -456,7 +457,7 @@ func TestPostTransactions(t *testing.T) {
 								{
 									Source:      "world",
 									Destination: "bar",
-									Amount:      core.NewMonetaryInt(1000),
+									Amount:      big.NewInt(1000),
 									Asset:       "TOK",
 								},
 							},
@@ -487,7 +488,7 @@ func TestPostTransactions(t *testing.T) {
 								{
 									Source:      "world",
 									Destination: "bar",
-									Amount:      core.NewMonetaryInt(1000),
+									Amount:      big.NewInt(1000),
 									Asset:       "TOK",
 								},
 							},
@@ -504,7 +505,7 @@ func TestPostTransactions(t *testing.T) {
 						{
 							Source:      "world",
 							Destination: "bar",
-							Amount:      core.NewMonetaryInt(1000),
+							Amount:      big.NewInt(1000),
 							Asset:       "TOK",
 						},
 					},
@@ -516,7 +517,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "bar",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "TOK",
 					},
 				},
@@ -532,7 +533,7 @@ func TestPostTransactions(t *testing.T) {
 			name: "script with specified timestamp prior to last tx",
 			initialTransactions: []core.Transaction{
 				core.NewTransaction().
-					WithPostings(core.NewPosting("world", "bob", "COIN", core.NewMonetaryInt(100))).
+					WithPostings(core.NewPosting("world", "bob", "COIN", big.NewInt(100))).
 					WithTimestamp(timestamp2),
 			},
 			payload: controllers.PostTransactionRequest{
@@ -558,7 +559,7 @@ func TestPostTransactions(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "bank",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "F/9",
 					},
 				},
@@ -573,7 +574,7 @@ func TestPostTransactions(t *testing.T) {
 								{
 									Source:      "world",
 									Destination: "bank",
-									Amount:      core.NewMonetaryInt(1000),
+									Amount:      big.NewInt(1000),
 									Asset:       "F/9",
 								},
 							},
@@ -643,7 +644,7 @@ func TestPostTransactionsPreview(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "central_bank",
-						Amount:      core.NewMonetaryInt(1000),
+						Amount:      big.NewInt(1000),
 						Asset:       "USD",
 					},
 				},
@@ -712,7 +713,7 @@ func TestPostTransactionMetadata(t *testing.T) {
 
 		require.NoError(t, store.InsertTransactions(context.Background(), core.ExpandTransactionFromEmptyPreCommitVolumes(
 			core.NewTransaction().WithPostings(
-				core.NewPosting("world", "central_bank", "USD", core.NewMonetaryInt(1000)),
+				core.NewPosting("world", "central_bank", "USD", big.NewInt(1000)),
 			),
 		)))
 
@@ -783,7 +784,7 @@ func TestGetTransaction(t *testing.T) {
 
 		require.NoError(t, store.InsertTransactions(context.Background(), core.ExpandTransactionFromEmptyPreCommitVolumes(
 			core.NewTransaction().
-				WithPostings(core.NewPosting("world", "central_bank", "USD", core.NewMonetaryInt(1000))).
+				WithPostings(core.NewPosting("world", "central_bank", "USD", big.NewInt(1000))).
 				WithReference("ref").
 				WithTimestamp(core.Now()),
 		)))
@@ -797,7 +798,7 @@ func TestGetTransaction(t *testing.T) {
 				{
 					Source:      "world",
 					Destination: "central_bank",
-					Amount:      core.NewMonetaryInt(1000),
+					Amount:      big.NewInt(1000),
 					Asset:       "USD",
 				},
 			}, ret.Postings)
@@ -808,28 +809,28 @@ func TestGetTransaction(t *testing.T) {
 			require.EqualValues(t, core.AccountsAssetsVolumes{
 				"world": core.AssetsVolumes{
 					"USD": {
-						Input:  core.NewMonetaryInt(0),
-						Output: core.NewMonetaryInt(0),
+						Input:  big.NewInt(0),
+						Output: big.NewInt(0),
 					},
 				},
 				"central_bank": core.AssetsVolumes{
 					"USD": {
-						Input:  core.NewMonetaryInt(0),
-						Output: core.NewMonetaryInt(0),
+						Input:  big.NewInt(0),
+						Output: big.NewInt(0),
 					},
 				},
 			}, ret.PreCommitVolumes)
 			require.EqualValues(t, core.AccountsAssetsVolumes{
 				"world": core.AssetsVolumes{
 					"USD": {
-						Input:  core.NewMonetaryInt(0),
-						Output: core.NewMonetaryInt(1000),
+						Input:  big.NewInt(0),
+						Output: big.NewInt(1000),
 					},
 				},
 				"central_bank": core.AssetsVolumes{
 					"USD": {
-						Input:  core.NewMonetaryInt(1000),
-						Output: core.NewMonetaryInt(0),
+						Input:  big.NewInt(1000),
+						Output: big.NewInt(0),
 					},
 				},
 			}, ret.PostCommitVolumes)
@@ -871,7 +872,7 @@ func TestTransactions(t *testing.T) {
 						{
 							Source:      "world",
 							Destination: "central_bank1",
-							Amount:      core.NewMonetaryInt(1000),
+							Amount:      big.NewInt(1000),
 							Asset:       "USD",
 						},
 					},
@@ -888,7 +889,7 @@ func TestTransactions(t *testing.T) {
 						{
 							Source:      "world",
 							Destination: "central_bank2",
-							Amount:      core.NewMonetaryInt(1000),
+							Amount:      big.NewInt(1000),
 							Asset:       "USD",
 						},
 					},
@@ -908,7 +909,7 @@ func TestTransactions(t *testing.T) {
 						{
 							Source:      "central_bank1",
 							Destination: "alice",
-							Amount:      core.NewMonetaryInt(10),
+							Amount:      big.NewInt(10),
 							Asset:       "USD",
 						},
 					},
@@ -1236,7 +1237,7 @@ func TestGetTransactionsWithPageSize(t *testing.T) {
 							{
 								Source:      "world",
 								Destination: fmt.Sprintf("account:%d", i),
-								Amount:      core.NewMonetaryInt(1000),
+								Amount:      big.NewInt(1000),
 								Asset:       "USD",
 							},
 						},
@@ -1309,7 +1310,7 @@ func TestRevertTransaction(t *testing.T) {
 		require.NoError(t, err)
 
 		tx1 := core.NewTransaction().
-			WithPostings(core.NewPosting("world", "alice", "USD", core.NewMonetaryInt(100))).
+			WithPostings(core.NewPosting("world", "alice", "USD", big.NewInt(100))).
 			WithReference("ref:23434656").
 			WithMetadata(core.Metadata{
 				"foo1": "bar1",
@@ -1320,7 +1321,7 @@ func TestRevertTransaction(t *testing.T) {
 		require.NoError(t, store.AppendLog(context.Background(), &log))
 
 		tx2 := core.NewTransaction().
-			WithPostings(core.NewPosting("world", "bob", "USD", core.NewMonetaryInt(100))).
+			WithPostings(core.NewPosting("world", "bob", "USD", big.NewInt(100))).
 			WithReference("ref:534646").
 			WithMetadata(core.Metadata{
 				"foo2": "bar2",
@@ -1332,7 +1333,7 @@ func TestRevertTransaction(t *testing.T) {
 		require.NoError(t, store.AppendLog(context.Background(), &log2))
 
 		tx3 := core.NewTransaction().
-			WithPostings(core.NewPosting("alice", "bob", "USD", core.NewMonetaryInt(3))).
+			WithPostings(core.NewPosting("alice", "bob", "USD", big.NewInt(3))).
 			WithMetadata(core.Metadata{
 				"foo2": "bar2",
 			}).
@@ -1347,13 +1348,13 @@ func TestRevertTransaction(t *testing.T) {
 		require.NoError(t, store.EnsureAccountExists(context.Background(), "alice"))
 		require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 			"world": {
-				"USD": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(200)),
+				"USD": core.NewEmptyVolumes().WithOutput(big.NewInt(200)),
 			},
 			"alice": {
-				"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)).WithOutput(core.NewMonetaryInt(3)),
+				"USD": core.NewEmptyVolumes().WithInput(big.NewInt(100)).WithOutput(big.NewInt(3)),
 			},
 			"bob": {
-				"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(103)),
+				"USD": core.NewEmptyVolumes().WithInput(big.NewInt(103)),
 			},
 		}))
 
@@ -1417,7 +1418,7 @@ func TestPostTransactionsScriptConflict(t *testing.T) {
 		require.NoError(t, err)
 		log := core.NewTransactionLog(
 			core.NewTransaction().
-				WithPostings(core.NewPosting("world", "centralbank", "COIN", core.NewMonetaryInt(100))).
+				WithPostings(core.NewPosting("world", "centralbank", "COIN", big.NewInt(100))).
 				WithReference("1234"),
 			nil,
 		)

--- a/components/ledger/pkg/core/account.go
+++ b/components/ledger/pkg/core/account.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"encoding/json"
-	"fmt"
 	"regexp"
 )
 
@@ -49,24 +48,6 @@ func (v AccountWithVolumes) Copy() AccountWithVolumes {
 	return v
 }
 
-const accountPattern = "^[a-zA-Z_]+[a-zA-Z0-9_:]*$"
+const AccountPattern = "^[a-zA-Z_]+[a-zA-Z0-9_:]*$"
 
-var accountRegexp = regexp.MustCompile(accountPattern)
-
-type AccountAddress string
-
-func (AccountAddress) GetType() Type { return TypeAccount }
-func (a AccountAddress) String() string {
-	return fmt.Sprintf("@%v", string(a))
-}
-
-func ParseAccountAddress(acc AccountAddress) error {
-	// TODO: handle properly in ledger v1.10
-	if acc == "" {
-		return nil
-	}
-	if !accountRegexp.MatchString(string(acc)) {
-		return fmt.Errorf("accounts should respect pattern %s", accountPattern)
-	}
-	return nil
-}
+var AccountRegexp = regexp.MustCompile(AccountPattern)

--- a/components/ledger/pkg/core/asset.go
+++ b/components/ledger/pkg/core/asset.go
@@ -1,34 +1,13 @@
 package core
 
 import (
-	"fmt"
 	"regexp"
 )
 
-const assetPattern = `^[A-Z][A-Z0-9]{0,16}(\/\d{1,6})?$`
+const AssetPattern = `^[A-Z][A-Z0-9]{0,16}(\/\d{1,6})?$`
 
-var assetRegexp = regexp.MustCompile(assetPattern)
+var AssetRegexp = regexp.MustCompile(AssetPattern)
 
 func AssetIsValid(v string) bool {
-	return assetRegexp.Match([]byte(v))
-}
-
-type Asset string
-
-func (Asset) GetType() Type { return TypeAsset }
-func (a Asset) String() string {
-	return fmt.Sprintf("%v", string(a))
-}
-
-type HasAsset interface {
-	GetAsset() Asset
-}
-
-func (a Asset) GetAsset() Asset { return a }
-
-func ParseAsset(ass Asset) error {
-	if !assetRegexp.MatchString(string(ass)) {
-		return fmt.Errorf("asset should respect pattern '%s'", assetPattern)
-	}
-	return nil
+	return AssetRegexp.Match([]byte(v))
 }

--- a/components/ledger/pkg/core/bigint.go
+++ b/components/ledger/pkg/core/bigint.go
@@ -1,0 +1,7 @@
+package core
+
+import (
+	"math/big"
+)
+
+var Zero = big.NewInt(0)

--- a/components/ledger/pkg/core/posting.go
+++ b/components/ledger/pkg/core/posting.go
@@ -3,19 +3,20 @@ package core
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"math/big"
 	"regexp"
 
 	"github.com/pkg/errors"
 )
 
 type Posting struct {
-	Source      string       `json:"source"`
-	Destination string       `json:"destination"`
-	Amount      *MonetaryInt `json:"amount"`
-	Asset       string       `json:"asset"`
+	Source      string   `json:"source"`
+	Destination string   `json:"destination"`
+	Amount      *big.Int `json:"amount"`
+	Asset       string   `json:"asset"`
 }
 
-func NewPosting(source string, destination string, asset string, amount *MonetaryInt) Posting {
+func NewPosting(source string, destination string, asset string, amount *big.Int) Posting {
 	return Posting{
 		Source:      source,
 		Destination: destination,
@@ -70,7 +71,7 @@ func ValidateAddress(addr string) bool {
 
 func (p Postings) Validate() (int, error) {
 	for i, p := range p {
-		if p.Amount.Ltz() {
+		if p.Amount.Cmp(Zero) < 0 {
 			return i, errors.New("negative amount")
 		}
 		if !ValidateAddress(p.Source) {

--- a/components/ledger/pkg/core/posting_test.go
+++ b/components/ledger/pkg/core/posting_test.go
@@ -1,9 +1,10 @@
 package core
 
 import (
+	"math/big"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReverseMultiple(t *testing.T) {
@@ -11,13 +12,13 @@ func TestReverseMultiple(t *testing.T) {
 		{
 			Source:      "world",
 			Destination: "users:001",
-			Amount:      NewMonetaryInt(100),
+			Amount:      big.NewInt(100),
 			Asset:       "COIN",
 		},
 		{
 			Source:      "users:001",
 			Destination: "payments:001",
-			Amount:      NewMonetaryInt(100),
+			Amount:      big.NewInt(100),
 			Asset:       "COIN",
 		},
 	}
@@ -26,22 +27,19 @@ func TestReverseMultiple(t *testing.T) {
 		{
 			Source:      "payments:001",
 			Destination: "users:001",
-			Amount:      NewMonetaryInt(100),
+			Amount:      big.NewInt(100),
 			Asset:       "COIN",
 		},
 		{
 			Source:      "users:001",
 			Destination: "world",
-			Amount:      NewMonetaryInt(100),
+			Amount:      big.NewInt(100),
 			Asset:       "COIN",
 		},
 	}
 
 	p.Reverse()
-
-	if diff := cmp.Diff(expected, p); diff != "" {
-		t.Errorf("Reverse() mismatch (-want +got):\n%s", diff)
-	}
+	require.Equal(t, expected, p)
 }
 
 func TestReverseSingle(t *testing.T) {
@@ -49,7 +47,7 @@ func TestReverseSingle(t *testing.T) {
 		{
 			Source:      "world",
 			Destination: "users:001",
-			Amount:      NewMonetaryInt(100),
+			Amount:      big.NewInt(100),
 			Asset:       "COIN",
 		},
 	}
@@ -58,14 +56,11 @@ func TestReverseSingle(t *testing.T) {
 		{
 			Source:      "users:001",
 			Destination: "world",
-			Amount:      NewMonetaryInt(100),
+			Amount:      big.NewInt(100),
 			Asset:       "COIN",
 		},
 	}
 
 	p.Reverse()
-
-	if diff := cmp.Diff(expected, p); diff != "" {
-		t.Errorf("Reverse() mismatch (-want +got):\n%s", diff)
-	}
+	require.Equal(t, expected, p)
 }

--- a/components/ledger/pkg/core/transaction.go
+++ b/components/ledger/pkg/core/transaction.go
@@ -99,10 +99,8 @@ func (t *ExpandedTransaction) IsReverted() bool {
 func ExpandTransaction(tx Transaction, preCommitVolumes AccountsAssetsVolumes) ExpandedTransaction {
 	postCommitVolumes := preCommitVolumes.copy()
 	for _, posting := range tx.Postings {
-		preCommitVolumes.AddOutput(posting.Source, posting.Asset, NewMonetaryInt(0))
-		preCommitVolumes.AddInput(posting.Source, posting.Asset, NewMonetaryInt(0))
-		preCommitVolumes.AddInput(posting.Destination, posting.Asset, NewMonetaryInt(0))
-		preCommitVolumes.AddOutput(posting.Destination, posting.Asset, NewMonetaryInt(0))
+		preCommitVolumes.AddInput(posting.Destination, posting.Asset, Zero)
+		preCommitVolumes.AddOutput(posting.Source, posting.Asset, Zero)
 		postCommitVolumes.AddOutput(posting.Source, posting.Asset, posting.Amount)
 		postCommitVolumes.AddInput(posting.Destination, posting.Asset, posting.Amount)
 	}

--- a/components/ledger/pkg/core/transaction_test.go
+++ b/components/ledger/pkg/core/transaction_test.go
@@ -1,9 +1,10 @@
 package core
 
 import (
+	"math/big"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReverseTransaction(t *testing.T) {
@@ -14,13 +15,13 @@ func TestReverseTransaction(t *testing.T) {
 					{
 						Source:      "world",
 						Destination: "users:001",
-						Amount:      NewMonetaryInt(100),
+						Amount:      big.NewInt(100),
 						Asset:       "COIN",
 					},
 					{
 						Source:      "users:001",
 						Destination: "payments:001",
-						Amount:      NewMonetaryInt(100),
+						Amount:      big.NewInt(100),
 						Asset:       "COIN",
 					},
 				},
@@ -34,20 +35,17 @@ func TestReverseTransaction(t *testing.T) {
 			{
 				Source:      "payments:001",
 				Destination: "users:001",
-				Amount:      NewMonetaryInt(100),
+				Amount:      big.NewInt(100),
 				Asset:       "COIN",
 			},
 			{
 				Source:      "users:001",
 				Destination: "world",
-				Amount:      NewMonetaryInt(100),
+				Amount:      big.NewInt(100),
 				Asset:       "COIN",
 			},
 		},
 		Reference: "revert_foo",
 	}
-
-	if diff := cmp.Diff(expected, tx.Reverse()); diff != "" {
-		t.Errorf("Reverse() mismatch (-want +got):\n%s", diff)
-	}
+	require.Equal(t, expected, tx.Reverse())
 }

--- a/components/ledger/pkg/ledger/aggregator/aggregator.go
+++ b/components/ledger/pkg/ledger/aggregator/aggregator.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/formancehq/ledger/pkg/core"
 	"github.com/pkg/errors"
@@ -29,11 +30,12 @@ func (tva *TxVolumeAggregator) FindInPreviousTxs(addr, asset string) *core.Volum
 func (tva *TxVolumeAggregator) Transfer(
 	ctx context.Context,
 	from, to, asset string,
-	amount *core.MonetaryInt,
+	amount *big.Int,
 ) error {
 	for _, addr := range []string{from, to} {
 		if !tva.PreCommitVolumes.HasAccountAndAsset(addr, asset) {
 			previousVolumes := tva.FindInPreviousTxs(addr, asset)
+
 			if previousVolumes != nil {
 				tva.PreCommitVolumes.SetVolumes(addr, asset, *previousVolumes)
 			} else {

--- a/components/ledger/pkg/ledger/cache/cache.go
+++ b/components/ledger/pkg/ledger/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"math/big"
 	"strings"
 	"sync"
 
@@ -71,20 +72,18 @@ func (c *Cache) withLockOnAccount(address string, callback func(account *core.Ac
 	callback(entry.account)
 }
 
-func (c *Cache) addOutput(address, asset string, amount *core.MonetaryInt) {
+func (c *Cache) addOutput(address, asset string, amount *big.Int) {
 	c.withLockOnAccount(address, func(account *core.AccountWithVolumes) {
-		volumes := account.Volumes[asset]
-		volumes.Output = volumes.Output.OrZero().Add(amount)
-		volumes.Input = volumes.Input.OrZero()
+		volumes := account.Volumes[asset].CopyWithZerosIfNeeded()
+		volumes.Output.Add(volumes.Output, amount)
 		account.Volumes[asset] = volumes
 	})
 }
 
-func (c *Cache) addInput(address, asset string, amount *core.MonetaryInt) {
+func (c *Cache) addInput(address, asset string, amount *big.Int) {
 	c.withLockOnAccount(address, func(account *core.AccountWithVolumes) {
-		volumes := account.Volumes[asset]
-		volumes.Input = volumes.Input.OrZero().Add(amount)
-		volumes.Output = volumes.Output.OrZero()
+		volumes := account.Volumes[asset].CopyWithZerosIfNeeded()
+		volumes.Input.Add(volumes.Input, amount)
 		account.Volumes[asset] = volumes
 	})
 }

--- a/components/ledger/pkg/ledger/cache/cache_test.go
+++ b/components/ledger/pkg/ledger/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/formancehq/ledger/pkg/core"
@@ -41,8 +42,8 @@ func TestParallelRead(t *testing.T) {
 				},
 				Volumes: map[string]core.Volumes{
 					"USD/2": {
-						Input:  core.NewMonetaryInt(100),
-						Output: core.NewMonetaryInt(0),
+						Input:  big.NewInt(100),
+						Output: big.NewInt(0),
 					},
 				},
 			},
@@ -55,8 +56,8 @@ func TestParallelRead(t *testing.T) {
 				},
 				Volumes: map[string]core.Volumes{
 					"USD/2": {
-						Input:  core.NewMonetaryInt(10),
-						Output: core.NewMonetaryInt(0),
+						Input:  big.NewInt(10),
+						Output: big.NewInt(0),
 					},
 				},
 			},
@@ -79,8 +80,8 @@ func TestParallelRead(t *testing.T) {
 				},
 				Volumes: map[string]core.Volumes{
 					"USD/2": {
-						Input:  core.NewMonetaryInt(10),
-						Output: core.NewMonetaryInt(0),
+						Input:  big.NewInt(10),
+						Output: big.NewInt(0),
 					},
 				},
 			}, *account)
@@ -120,7 +121,7 @@ func TestUpdateVolumes(t *testing.T) {
 	require.NoError(t, err)
 
 	cache.UpdateVolumeWithTX(core.NewTransaction().WithPostings(
-		core.NewPosting("world", "bank", "USD", core.NewMonetaryInt(100)),
+		core.NewPosting("world", "bank", "USD", big.NewInt(100)),
 	))
 	worldAccount, err := cache.GetAccountWithVolumes(context.Background(), "world")
 	require.NoError(t, err)
@@ -130,7 +131,7 @@ func TestUpdateVolumes(t *testing.T) {
 			Metadata: core.Metadata{},
 		},
 		Volumes: map[string]core.Volumes{
-			"USD": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(100)),
+			"USD": core.NewEmptyVolumes().WithOutput(big.NewInt(100)),
 		},
 	}, *worldAccount)
 
@@ -142,7 +143,7 @@ func TestUpdateVolumes(t *testing.T) {
 			Metadata: core.Metadata{},
 		},
 		Volumes: map[string]core.Volumes{
-			"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+			"USD": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 		},
 	}, *worldAccount)
 }

--- a/components/ledger/pkg/ledger/query/worker_test.go
+++ b/components/ledger/pkg/ledger/query/worker_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"math/big"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func TestWorker(t *testing.T) {
 			Postings: []core.Posting{{
 				Source:      "world",
 				Destination: "bank",
-				Amount:      core.NewMonetaryInt(100),
+				Amount:      big.NewInt(100),
 				Asset:       "USD/2",
 			}},
 			Timestamp: now,
@@ -62,7 +63,7 @@ func TestWorker(t *testing.T) {
 			Postings: []core.Posting{{
 				Source:      "bank",
 				Destination: "user:1",
-				Amount:      core.NewMonetaryInt(10),
+				Amount:      big.NewInt(10),
 				Asset:       "USD/2",
 			}},
 			Timestamp: now,
@@ -128,28 +129,28 @@ func TestWorker(t *testing.T) {
 		PreCommitVolumes: map[string]core.AssetsVolumes{
 			"bank": {
 				"USD/2": {
-					Input:  core.NewMonetaryInt(100),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(100),
+					Output: big.NewInt(0),
 				},
 			},
 			"user:1": {
 				"USD/2": {
-					Output: core.NewMonetaryInt(0),
-					Input:  core.NewMonetaryInt(0),
+					Output: big.NewInt(0),
+					Input:  big.NewInt(0),
 				},
 			},
 		},
 		PostCommitVolumes: map[string]core.AssetsVolumes{
 			"bank": {
 				"USD/2": {
-					Input:  core.NewMonetaryInt(100),
-					Output: core.NewMonetaryInt(10),
+					Input:  big.NewInt(100),
+					Output: big.NewInt(10),
 				},
 			},
 			"user:1": {
 				"USD/2": {
-					Input:  core.NewMonetaryInt(10),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(10),
+					Output: big.NewInt(0),
 				},
 			},
 		},
@@ -164,8 +165,8 @@ func TestWorker(t *testing.T) {
 		},
 		Volumes: map[string]core.Volumes{
 			"USD/2": {
-				Input:  core.NewMonetaryInt(100),
-				Output: core.NewMonetaryInt(10),
+				Input:  big.NewInt(100),
+				Output: big.NewInt(10),
 			},
 		},
 	}, accountWithVolumes)

--- a/components/ledger/pkg/ledger/runner/runner_test.go
+++ b/components/ledger/pkg/ledger/runner/runner_test.go
@@ -204,10 +204,6 @@ func TestExecuteScript(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, ret)
 				tc.expectedTx.Timestamp = now
-				//data, _ := json.MarshalIndent(tc.expectedTx, "", "  ")
-				//fmt.Println(string(data))
-				//data, _ = json.MarshalIndent(*ret, "", "  ")
-				//fmt.Println(string(data))
 				require.Equal(t, tc.expectedTx, *ret)
 
 				logs, err := store.ReadLogsStartingFromID(context.Background(), 0)

--- a/components/ledger/pkg/ledger/runner/runner_test.go
+++ b/components/ledger/pkg/ledger/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/formancehq/ledger/pkg/core"
@@ -37,7 +38,7 @@ var testCases = []testCase{
 			)`,
 		expectedTx: core.ExpandedTransaction{
 			Transaction: core.NewTransaction().WithPostings(
-				core.NewPosting("world", "mint", "GEM", core.NewMonetaryInt(100)),
+				core.NewPosting("world", "mint", "GEM", big.NewInt(100)),
 			),
 			PreCommitVolumes: map[string]core.AssetsVolumes{
 				"world": {
@@ -49,17 +50,17 @@ var testCases = []testCase{
 			},
 			PostCommitVolumes: map[string]core.AssetsVolumes{
 				"world": {
-					"GEM": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(100)),
+					"GEM": core.NewEmptyVolumes().WithOutput(big.NewInt(100)),
 				},
 				"mint": {
-					"GEM": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+					"GEM": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 				},
 			},
 		},
 		expectedLogs: []core.Log{
 			core.NewTransactionLog(
 				core.NewTransaction().WithPostings(
-					core.NewPosting("world", "mint", "GEM", core.NewMonetaryInt(100))),
+					core.NewPosting("world", "mint", "GEM", big.NewInt(100))),
 				map[string]core.Metadata{},
 			),
 		},
@@ -67,7 +68,7 @@ var testCases = []testCase{
 			"mint": {
 				Account: core.NewAccount("mint"),
 				Volumes: core.AssetsVolumes{
-					"GEM": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+					"GEM": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 				},
 			},
 		},
@@ -86,7 +87,7 @@ var testCases = []testCase{
 		name: "set reference conflict",
 		setup: func(t *testing.T, l *Runner) {
 			tx := core.NewTransaction().
-				WithPostings(core.NewPosting("world", "mint", "GEM", core.NewMonetaryInt(100))).
+				WithPostings(core.NewPosting("world", "mint", "GEM", big.NewInt(100))).
 				WithReference("tx_ref")
 			log := core.NewTransactionLog(tx, nil).WithReference("tx_ref")
 			require.NoError(t, l.store.AppendLog(
@@ -113,7 +114,7 @@ var testCases = []testCase{
 		expectedTx: core.ExpandedTransaction{
 			Transaction: core.NewTransaction().
 				WithPostings(
-					core.NewPosting("world", "mint", "GEM", core.NewMonetaryInt(100)),
+					core.NewPosting("world", "mint", "GEM", big.NewInt(100)),
 				).
 				WithReference("tx_ref"),
 			PreCommitVolumes: map[string]core.AssetsVolumes{
@@ -126,10 +127,10 @@ var testCases = []testCase{
 			},
 			PostCommitVolumes: map[string]core.AssetsVolumes{
 				"world": {
-					"GEM": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(100)),
+					"GEM": core.NewEmptyVolumes().WithOutput(big.NewInt(100)),
 				},
 				"mint": {
-					"GEM": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+					"GEM": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 				},
 			},
 		},
@@ -137,7 +138,7 @@ var testCases = []testCase{
 			core.NewTransactionLog(
 				core.NewTransaction().
 					WithPostings(
-						core.NewPosting("world", "mint", "GEM", core.NewMonetaryInt(100)),
+						core.NewPosting("world", "mint", "GEM", big.NewInt(100)),
 					).
 					WithReference("tx_ref"),
 				map[string]core.Metadata{},
@@ -147,7 +148,7 @@ var testCases = []testCase{
 			"mint": {
 				Account: core.NewAccount("mint"),
 				Volumes: core.AssetsVolumes{
-					"GEM": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+					"GEM": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 				},
 			},
 		},
@@ -203,6 +204,10 @@ func TestExecuteScript(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, ret)
 				tc.expectedTx.Timestamp = now
+				//data, _ := json.MarshalIndent(tc.expectedTx, "", "  ")
+				//fmt.Println(string(data))
+				//data, _ = json.MarshalIndent(*ret, "", "  ")
+				//fmt.Println(string(data))
 				require.Equal(t, tc.expectedTx, *ret)
 
 				logs, err := store.ReadLogsStartingFromID(context.Background(), 0)

--- a/components/ledger/pkg/machine/examples/basic.go
+++ b/components/ledger/pkg/machine/examples/basic.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/formancehq/ledger/pkg/machine/script/compiler"
 	"github.com/formancehq/ledger/pkg/machine/vm"
 )
@@ -33,18 +35,18 @@ func main() {
 	m := vm.NewMachine(*program)
 	m.Debug = true
 
-	if err = m.SetVars(map[string]core.Value{
-		"dest": core.AccountAddress("charlie"),
+	if err = m.SetVars(map[string]internal.Value{
+		"dest": internal.AccountAddress("charlie"),
 	}); err != nil {
 		panic(err)
 	}
 
 	initialVolumes := map[string]map[string]core.Volumes{
 		"alice": {
-			"COIN": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(10)),
+			"COIN": core.NewEmptyVolumes().WithInput(big.NewInt(10)),
 		},
 		"bob": {
-			"COIN": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(100)),
+			"COIN": core.NewEmptyVolumes().WithInput(big.NewInt(100)),
 		},
 	}
 

--- a/components/ledger/pkg/machine/internal/account.go
+++ b/components/ledger/pkg/machine/internal/account.go
@@ -1,0 +1,25 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/formancehq/ledger/pkg/core"
+)
+
+type AccountAddress string
+
+func (AccountAddress) GetType() Type { return TypeAccount }
+func (a AccountAddress) String() string {
+	return fmt.Sprintf("@%v", string(a))
+}
+
+func ParseAccountAddress(acc AccountAddress) error {
+	// TODO: handle properly in ledger v1.10
+	if acc == "" {
+		return nil
+	}
+	if !core.AccountRegexp.MatchString(string(acc)) {
+		return fmt.Errorf("accounts should respect pattern %s", core.AccountPattern)
+	}
+	return nil
+}

--- a/components/ledger/pkg/machine/internal/address.go
+++ b/components/ledger/pkg/machine/internal/address.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import "encoding/binary"
 

--- a/components/ledger/pkg/machine/internal/allotment.go
+++ b/components/ledger/pkg/machine/internal/allotment.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"errors"

--- a/components/ledger/pkg/machine/internal/allotment_test.go
+++ b/components/ledger/pkg/machine/internal/allotment_test.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"math/big"

--- a/components/ledger/pkg/machine/internal/asset.go
+++ b/components/ledger/pkg/machine/internal/asset.go
@@ -1,0 +1,27 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/formancehq/ledger/pkg/core"
+)
+
+type Asset string
+
+func (Asset) GetType() Type { return TypeAsset }
+func (a Asset) String() string {
+	return fmt.Sprintf("%v", string(a))
+}
+
+type HasAsset interface {
+	GetAsset() Asset
+}
+
+func (a Asset) GetAsset() Asset { return a }
+
+func ParseAsset(ass Asset) error {
+	if !core.AssetRegexp.MatchString(string(ass)) {
+		return fmt.Errorf("asset should respect pattern '%s'", core.AssetPattern)
+	}
+	return nil
+}

--- a/components/ledger/pkg/machine/internal/funding.go
+++ b/components/ledger/pkg/machine/internal/funding.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"errors"

--- a/components/ledger/pkg/machine/internal/funding_test.go
+++ b/components/ledger/pkg/machine/internal/funding_test.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"testing"

--- a/components/ledger/pkg/machine/internal/json.go
+++ b/components/ledger/pkg/machine/internal/json.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"encoding/json"

--- a/components/ledger/pkg/machine/internal/json_test.go
+++ b/components/ledger/pkg/machine/internal/json_test.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"encoding/json"

--- a/components/ledger/pkg/machine/internal/monetary.go
+++ b/components/ledger/pkg/machine/internal/monetary.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"fmt"
@@ -142,6 +142,10 @@ func (a *MonetaryInt) UnmarshalText(b []byte) error {
 
 func NewMonetaryInt(i int64) *MonetaryInt {
 	return (*MonetaryInt)(big.NewInt(i))
+}
+
+func NewMonetaryIntFromBigInt(v *big.Int) *MonetaryInt {
+	return (*MonetaryInt)(v)
 }
 
 func ParseMonetaryInt(s string) (*MonetaryInt, error) {

--- a/components/ledger/pkg/machine/internal/number.go
+++ b/components/ledger/pkg/machine/internal/number.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 type Number = *MonetaryInt
 

--- a/components/ledger/pkg/machine/internal/portion.go
+++ b/components/ledger/pkg/machine/internal/portion.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"errors"

--- a/components/ledger/pkg/machine/internal/portion_test.go
+++ b/components/ledger/pkg/machine/internal/portion_test.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"strings"

--- a/components/ledger/pkg/machine/internal/value.go
+++ b/components/ledger/pkg/machine/internal/value.go
@@ -1,4 +1,4 @@
-package core
+package internal
 
 import (
 	"fmt"

--- a/components/ledger/pkg/machine/machine.go
+++ b/components/ledger/pkg/machine/machine.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 
 	"github.com/formancehq/ledger/pkg/core"
 	"github.com/formancehq/ledger/pkg/machine/vm"
@@ -72,7 +73,7 @@ func Run(ctx context.Context, store Store, prog *program.Program, script core.Ru
 		result.Postings[j] = core.Posting{
 			Source:      posting.Source,
 			Destination: posting.Destination,
-			Amount:      posting.Amount,
+			Amount:      (*big.Int)(posting.Amount),
 			Asset:       posting.Asset,
 		}
 	}

--- a/components/ledger/pkg/machine/machine_test.go
+++ b/components/ledger/pkg/machine/machine_test.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/formancehq/ledger/pkg/core"
@@ -36,7 +37,7 @@ var testCases = []testCase{
 			)`,
 		expectResult: Result{
 			Postings: []core.Posting{
-				core.NewPosting("world", "user:001", "USD/2", core.NewMonetaryInt(99)),
+				core.NewPosting("world", "user:001", "USD/2", big.NewInt(99)),
 			},
 			Metadata:        map[string]any{},
 			AccountMetadata: map[string]core.Metadata{},
@@ -99,7 +100,7 @@ var testCases = []testCase{
 		},
 		expectResult: Result{
 			Postings: []core.Posting{
-				core.NewPosting("world", "user:001", "CAD/2", core.NewMonetaryInt(42)),
+				core.NewPosting("world", "user:001", "CAD/2", big.NewInt(42)),
 			},
 			Metadata:        map[string]any{},
 			AccountMetadata: map[string]core.Metadata{},
@@ -143,8 +144,8 @@ var testCases = []testCase{
 		},
 		expectResult: Result{
 			Postings: []core.Posting{
-				core.NewPosting("world", "bob", "EUR", core.NewMonetaryInt(1)),
-				core.NewPosting("bob", "alice", "EUR", core.NewMonetaryInt(1)),
+				core.NewPosting("world", "bob", "EUR", big.NewInt(1)),
+				core.NewPosting("bob", "alice", "EUR", big.NewInt(1)),
 			},
 			Metadata:        map[string]any{},
 			AccountMetadata: map[string]core.Metadata{},
@@ -173,8 +174,8 @@ var testCases = []testCase{
 			require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 				"sales:001": {
 					"COIN": {
-						Input:  core.NewMonetaryInt(100),
-						Output: core.NewMonetaryInt(0),
+						Input:  big.NewInt(100),
+						Output: big.NewInt(0),
 					},
 				},
 			}))
@@ -211,8 +212,8 @@ var testCases = []testCase{
 		},
 		expectResult: Result{
 			Postings: []core.Posting{
-				core.NewPosting("sales:001", "users:001", "COIN", core.NewMonetaryInt(85)),
-				core.NewPosting("sales:001", "platform", "COIN", core.NewMonetaryInt(15)),
+				core.NewPosting("sales:001", "users:001", "COIN", big.NewInt(85)),
+				core.NewPosting("sales:001", "platform", "COIN", big.NewInt(15)),
 			},
 			Metadata:        core.Metadata{},
 			AccountMetadata: map[string]core.Metadata{},
@@ -230,7 +231,7 @@ var testCases = []testCase{
 		},
 		expectResult: Result{
 			Postings: []core.Posting{
-				core.NewPosting("world", "users:001", "USD/2", core.NewMonetaryInt(99)),
+				core.NewPosting("world", "users:001", "USD/2", big.NewInt(99)),
 			},
 			Metadata: core.Metadata{
 				"priority": "low",
@@ -248,7 +249,7 @@ var testCases = []testCase{
 			)`,
 		expectResult: Result{
 			Postings: []core.Posting{
-				core.NewPosting("world", "users:001", "USD/2", core.NewMonetaryInt(99)),
+				core.NewPosting("world", "users:001", "USD/2", big.NewInt(99)),
 			},
 			Metadata: core.Metadata{
 				"priority": map[string]any{
@@ -287,7 +288,7 @@ var testCases = []testCase{
 		`,
 		expectResult: Result{
 			Postings: []core.Posting{
-				core.NewPosting("world", "users:001", "USD/2", core.NewMonetaryInt(99)),
+				core.NewPosting("world", "users:001", "USD/2", big.NewInt(99)),
 			},
 			Metadata: core.Metadata{},
 			AccountMetadata: map[string]core.Metadata{
@@ -308,8 +309,8 @@ var testCases = []testCase{
 			require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 				"users:001": map[string]core.Volumes{
 					"COIN": {
-						Input:  core.NewMonetaryInt(100),
-						Output: core.NewMonetaryInt(0),
+						Input:  big.NewInt(100),
+						Output: big.NewInt(0),
 					},
 				},
 			}))
@@ -324,7 +325,7 @@ var testCases = []testCase{
 			)`,
 		expectResult: Result{
 			Postings: []core.Posting{
-				core.NewPosting("users:001", "world", "COIN", core.NewMonetaryInt(100)),
+				core.NewPosting("users:001", "world", "COIN", big.NewInt(100)),
 			},
 			Metadata:        core.Metadata{},
 			AccountMetadata: map[string]core.Metadata{},
@@ -337,8 +338,8 @@ var testCases = []testCase{
 			require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 				"users:001": map[string]core.Volumes{
 					"COIN": {
-						Input:  core.NewMonetaryInt(0),
-						Output: core.NewMonetaryInt(100),
+						Input:  big.NewInt(0),
+						Output: big.NewInt(100),
 					},
 				},
 			}))
@@ -362,7 +363,7 @@ var testCases = []testCase{
 		)`,
 		expectResult: Result{
 			Postings: []core.Posting{
-				core.NewPosting("users:001", "users:002", "USD/2", core.NewMonetaryInt(100)),
+				core.NewPosting("users:001", "users:002", "USD/2", big.NewInt(100)),
 			},
 			Metadata:        core.Metadata{},
 			AccountMetadata: map[string]core.Metadata{},

--- a/components/ledger/pkg/machine/script/compiler/allotment.go
+++ b/components/ledger/pkg/machine/script/compiler/allotment.go
@@ -6,7 +6,7 @@ import (
 	"math/big"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/formancehq/ledger/pkg/machine/script/parser"
 	"github.com/formancehq/ledger/pkg/machine/vm/program"
 )
@@ -19,7 +19,7 @@ func (p *parseVisitor) VisitAllotment(c antlr.ParserRuleContext, portions []pars
 		c := portions[i]
 		switch c := c.(type) {
 		case *parser.AllotmentPortionConstContext:
-			portion, err := core.ParsePortionSpecific(c.GetText())
+			portion, err := internal.ParsePortionSpecific(c.GetText())
 			if err != nil {
 				return LogicError(c, err)
 			}
@@ -35,7 +35,7 @@ func (p *parseVisitor) VisitAllotment(c antlr.ParserRuleContext, portions []pars
 			if err != nil {
 				return err
 			}
-			if ty != core.TypePortion {
+			if ty != internal.TypePortion {
 				return LogicError(c,
 					fmt.Errorf("wrong type: expected type portion for variable: %v", ty),
 				)
@@ -47,7 +47,7 @@ func (p *parseVisitor) VisitAllotment(c antlr.ParserRuleContext, portions []pars
 					errors.New("two uses of `remaining` in the same allocation"),
 				)
 			}
-			addr, err := p.AllocateResource(program.Constant{Inner: core.NewPortionRemaining()})
+			addr, err := p.AllocateResource(program.Constant{Inner: internal.NewPortionRemaining()})
 			if err != nil {
 				return LogicError(c, err)
 			}
@@ -75,7 +75,7 @@ func (p *parseVisitor) VisitAllotment(c antlr.ParserRuleContext, portions []pars
 			errors.New("known portions are already equal to 100%"),
 		)
 	}
-	err := p.PushInteger(core.NewNumber(int64(len(portions))))
+	err := p.PushInteger(internal.NewNumber(int64(len(portions))))
 	if err != nil {
 		return LogicError(c, err)
 	}

--- a/components/ledger/pkg/machine/script/compiler/compiler.go
+++ b/components/ledger/pkg/machine/script/compiler/compiler.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/antlr/antlr4/runtime/Go/antlr"
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/formancehq/ledger/pkg/machine/script/parser"
 	"github.com/formancehq/ledger/pkg/machine/vm/program"
 	"github.com/pkg/errors"
@@ -19,20 +19,20 @@ type parseVisitor struct {
 	resources []program.Resource
 	// sources store all source accounts
 	// a source can be also a destination of another posting
-	sources map[core.Address]struct{}
+	sources map[internal.Address]struct{}
 	// varIdx maps name to resource index
-	varIdx map[string]core.Address
+	varIdx map[string]internal.Address
 	// needBalances store for each account, the set of assets needed
-	neededBalances map[core.Address]map[core.Address]struct{}
+	neededBalances map[internal.Address]map[internal.Address]struct{}
 }
 
 // Allocates constants if it hasn't already been,
 // and returns its resource address.
-func (p *parseVisitor) findConstant(constant program.Constant) (*core.Address, bool) {
+func (p *parseVisitor) findConstant(constant program.Constant) (*internal.Address, bool) {
 	for i := 0; i < len(p.resources); i++ {
 		if c, ok := p.resources[i].(program.Constant); ok {
-			if core.ValueEquals(c.Inner, constant.Inner) {
-				addr := core.Address(i)
+			if internal.ValueEquals(c.Inner, constant.Inner) {
+				addr := internal.Address(i)
 				return &addr, true
 			}
 		}
@@ -40,7 +40,7 @@ func (p *parseVisitor) findConstant(constant program.Constant) (*core.Address, b
 	return nil, false
 }
 
-func (p *parseVisitor) AllocateResource(res program.Resource) (*core.Address, error) {
+func (p *parseVisitor) AllocateResource(res program.Resource) (*internal.Address, error) {
 	if c, ok := res.(program.Constant); ok {
 		idx, ok := p.findConstant(c)
 		if ok {
@@ -51,15 +51,15 @@ func (p *parseVisitor) AllocateResource(res program.Resource) (*core.Address, er
 		return nil, errors.New("number of unique constants exceeded 65536")
 	}
 	p.resources = append(p.resources, res)
-	addr := core.NewAddress(uint16(len(p.resources) - 1))
+	addr := internal.NewAddress(uint16(len(p.resources) - 1))
 	return &addr, nil
 }
 
-func (p *parseVisitor) isWorld(addr core.Address) bool {
+func (p *parseVisitor) isWorld(addr internal.Address) bool {
 	idx := int(addr)
 	if idx < len(p.resources) {
 		if c, ok := p.resources[idx].(program.Constant); ok {
-			if acc, ok := c.Inner.(core.AccountAddress); ok {
+			if acc, ok := c.Inner.(internal.AccountAddress); ok {
 				if string(acc) == "world" {
 					return true
 				}
@@ -69,7 +69,7 @@ func (p *parseVisitor) isWorld(addr core.Address) bool {
 	return false
 }
 
-func (p *parseVisitor) VisitVariable(c parser.IVariableContext, push bool) (core.Type, *core.Address, *CompileError) {
+func (p *parseVisitor) VisitVariable(c parser.IVariableContext, push bool) (internal.Type, *internal.Address, *CompileError) {
 	name := c.GetText()[1:] // strip '$' prefix
 	if idx, ok := p.varIdx[name]; ok {
 		res := p.resources[idx]
@@ -82,21 +82,21 @@ func (p *parseVisitor) VisitVariable(c parser.IVariableContext, push bool) (core
 	}
 }
 
-func (p *parseVisitor) VisitExpr(c parser.IExpressionContext, push bool) (core.Type, *core.Address, *CompileError) {
+func (p *parseVisitor) VisitExpr(c parser.IExpressionContext, push bool) (internal.Type, *internal.Address, *CompileError) {
 	switch c := c.(type) {
 	case *parser.ExprAddSubContext:
 		ty, _, err := p.VisitExpr(c.GetLhs(), push)
 		if err != nil {
 			return 0, nil, err
 		}
-		if ty != core.TypeNumber {
+		if ty != internal.TypeNumber {
 			return 0, nil, LogicError(c, errors.New("tried to do arithmetic with wrong type"))
 		}
 		ty, _, err = p.VisitExpr(c.GetRhs(), push)
 		if err != nil {
 			return 0, nil, err
 		}
-		if ty != core.TypeNumber {
+		if ty != internal.TypeNumber {
 			return 0, nil, LogicError(c, errors.New("tried to do arithmetic with wrong type"))
 		}
 		if push {
@@ -107,7 +107,7 @@ func (p *parseVisitor) VisitExpr(c parser.IExpressionContext, push bool) (core.T
 				p.AppendInstruction(program.OP_ISUB)
 			}
 		}
-		return core.TypeNumber, nil, nil
+		return internal.TypeNumber, nil, nil
 	case *parser.ExprLiteralContext:
 		ty, addr, err := p.VisitLit(c.GetLit(), push)
 		if err != nil {
@@ -123,10 +123,10 @@ func (p *parseVisitor) VisitExpr(c parser.IExpressionContext, push bool) (core.T
 }
 
 // pushes a value from a literal onto the stack
-func (p *parseVisitor) VisitLit(c parser.ILiteralContext, push bool) (core.Type, *core.Address, *CompileError) {
+func (p *parseVisitor) VisitLit(c parser.ILiteralContext, push bool) (internal.Type, *internal.Address, *CompileError) {
 	switch c := c.(type) {
 	case *parser.LitAccountContext:
-		account := core.AccountAddress(c.GetText()[1:])
+		account := internal.AccountAddress(c.GetText()[1:])
 		addr, err := p.AllocateResource(program.Constant{Inner: account})
 		if err != nil {
 			return 0, nil, LogicError(c, err)
@@ -134,9 +134,9 @@ func (p *parseVisitor) VisitLit(c parser.ILiteralContext, push bool) (core.Type,
 		if push {
 			p.PushAddress(*addr)
 		}
-		return core.TypeAccount, addr, nil
+		return internal.TypeAccount, addr, nil
 	case *parser.LitAssetContext:
-		asset := core.Asset(c.GetText())
+		asset := internal.Asset(c.GetText())
 		addr, err := p.AllocateResource(program.Constant{Inner: asset})
 		if err != nil {
 			return 0, nil, LogicError(c, err)
@@ -144,9 +144,9 @@ func (p *parseVisitor) VisitLit(c parser.ILiteralContext, push bool) (core.Type,
 		if push {
 			p.PushAddress(*addr)
 		}
-		return core.TypeAsset, addr, nil
+		return internal.TypeAsset, addr, nil
 	case *parser.LitNumberContext:
-		number, err := core.ParseNumber(c.GetText())
+		number, err := internal.ParseNumber(c.GetText())
 		if err != nil {
 			return 0, nil, LogicError(c, err)
 		}
@@ -156,10 +156,10 @@ func (p *parseVisitor) VisitLit(c parser.ILiteralContext, push bool) (core.Type,
 				return 0, nil, LogicError(c, err)
 			}
 		}
-		return core.TypeNumber, nil, nil
+		return internal.TypeNumber, nil, nil
 	case *parser.LitStringContext:
 		addr, err := p.AllocateResource(program.Constant{
-			Inner: core.String(strings.Trim(c.GetText(), `"`)),
+			Inner: internal.String(strings.Trim(c.GetText(), `"`)),
 		})
 		if err != nil {
 			return 0, nil, LogicError(c, err)
@@ -167,9 +167,9 @@ func (p *parseVisitor) VisitLit(c parser.ILiteralContext, push bool) (core.Type,
 		if push {
 			p.PushAddress(*addr)
 		}
-		return core.TypeString, addr, nil
+		return internal.TypeString, addr, nil
 	case *parser.LitPortionContext:
-		portion, err := core.ParsePortionSpecific(c.GetText())
+		portion, err := internal.ParsePortionSpecific(c.GetText())
 		if err != nil {
 			return 0, nil, LogicError(c, err)
 		}
@@ -180,15 +180,15 @@ func (p *parseVisitor) VisitLit(c parser.ILiteralContext, push bool) (core.Type,
 		if push {
 			p.PushAddress(*addr)
 		}
-		return core.TypePortion, addr, nil
+		return internal.TypePortion, addr, nil
 	case *parser.LitMonetaryContext:
 		asset := c.Monetary().GetAsset().GetText()
-		amt, err := core.ParseMonetaryInt(c.Monetary().GetAmt().GetText())
+		amt, err := internal.ParseMonetaryInt(c.Monetary().GetAmt().GetText())
 		if err != nil {
 			return 0, nil, LogicError(c, err)
 		}
-		monetary := core.Monetary{
-			Asset:  core.Asset(asset),
+		monetary := internal.Monetary{
+			Asset:  internal.Asset(asset),
 			Amount: amt,
 		}
 		addr, err := p.AllocateResource(program.Constant{Inner: monetary})
@@ -198,7 +198,7 @@ func (p *parseVisitor) VisitLit(c parser.ILiteralContext, push bool) (core.Type,
 		if push {
 			p.PushAddress(*addr)
 		}
-		return core.TypeMonetary, addr, nil
+		return internal.TypeMonetary, addr, nil
 	default:
 		return 0, nil, InternalError(c)
 	}
@@ -206,10 +206,10 @@ func (p *parseVisitor) VisitLit(c parser.ILiteralContext, push bool) (core.Type,
 
 // send statement
 func (p *parseVisitor) VisitSend(c *parser.SendContext) *CompileError {
-	var assetAddr core.Address
-	var neededAccounts map[core.Address]struct{}
+	var assetAddr internal.Address
+	var neededAccounts map[internal.Address]struct{}
 	if mon := c.GetMonAll(); mon != nil {
-		asset := core.Asset(mon.GetAsset().GetText())
+		asset := internal.Asset(mon.GetAsset().GetText())
 		addr, err := p.AllocateResource(program.Constant{Inner: asset})
 		if err != nil {
 			return LogicError(c, err)
@@ -228,7 +228,7 @@ func (p *parseVisitor) VisitSend(c *parser.SendContext) *CompileError {
 		if err != nil {
 			return err
 		}
-		if ty != core.TypeMonetary {
+		if ty != internal.TypeMonetary {
 			return LogicError(c, errors.New("wrong type for monetary value"))
 		}
 		assetAddr = *monAddr
@@ -246,7 +246,7 @@ func (p *parseVisitor) VisitSend(c *parser.SendContext) *CompileError {
 		if b, ok := p.neededBalances[acc]; ok {
 			b[assetAddr] = struct{}{}
 		} else {
-			p.neededBalances[acc] = map[core.Address]struct{}{
+			p.neededBalances[acc] = map[internal.Address]struct{}{
 				assetAddr: {},
 			}
 		}
@@ -266,7 +266,7 @@ func (p *parseVisitor) VisitSetTxMeta(ctx *parser.SetTxMetaContext) *CompileErro
 	}
 
 	keyAddr, err := p.AllocateResource(program.Constant{
-		Inner: core.String(strings.Trim(ctx.GetKey().GetText(), `"`)),
+		Inner: internal.String(strings.Trim(ctx.GetKey().GetText(), `"`)),
 	})
 	if err != nil {
 		return LogicError(ctx, err)
@@ -286,7 +286,7 @@ func (p *parseVisitor) VisitSetAccountMeta(ctx *parser.SetAccountMetaContext) *C
 	}
 
 	keyAddr, err := p.AllocateResource(program.Constant{
-		Inner: core.String(strings.Trim(ctx.GetKey().GetText(), `"`)),
+		Inner: internal.String(strings.Trim(ctx.GetKey().GetText(), `"`)),
 	})
 	if err != nil {
 		return LogicError(ctx, err)
@@ -297,7 +297,7 @@ func (p *parseVisitor) VisitSetAccountMeta(ctx *parser.SetAccountMetaContext) *C
 	if compErr != nil {
 		return compErr
 	}
-	if ty != core.TypeAccount {
+	if ty != internal.TypeAccount {
 		return LogicError(ctx, fmt.Errorf(
 			"variable is of type %s, and should be of type account", ty))
 	}
@@ -331,23 +331,23 @@ func (p *parseVisitor) VisitVars(c *parser.VarListDeclContext) *CompileError {
 		if _, ok := p.varIdx[name]; ok {
 			return LogicError(c, errors.New("duplicate variable"))
 		}
-		var ty core.Type
+		var ty internal.Type
 		switch v.GetTy().GetText() {
 		case "account":
-			ty = core.TypeAccount
+			ty = internal.TypeAccount
 		case "number":
-			ty = core.TypeNumber
+			ty = internal.TypeNumber
 		case "string":
-			ty = core.TypeString
+			ty = internal.TypeString
 		case "monetary":
-			ty = core.TypeMonetary
+			ty = internal.TypeMonetary
 		case "portion":
-			ty = core.TypePortion
+			ty = internal.TypePortion
 		default:
 			return InternalError(c)
 		}
 
-		var addr *core.Address
+		var addr *internal.Address
 		var err error
 		if v.GetOrig() == nil {
 			addr, err = p.AllocateResource(program.Variable{Typ: ty, Name: name})
@@ -367,7 +367,7 @@ func (p *parseVisitor) VisitVars(c *parser.VarListDeclContext) *CompileError {
 			if compErr != nil {
 				return compErr
 			}
-			if srcTy != core.TypeAccount {
+			if srcTy != internal.TypeAccount {
 				return LogicError(c, errors.New(
 					"variable type should be 'account' to pull account metadata"))
 			}
@@ -379,7 +379,7 @@ func (p *parseVisitor) VisitVars(c *parser.VarListDeclContext) *CompileError {
 				Key:     key,
 			})
 		case *parser.OriginAccountBalanceContext:
-			if ty != core.TypeMonetary {
+			if ty != internal.TypeMonetary {
 				return LogicError(c, fmt.Errorf(
 					"variable type should be 'monetary' to pull account balance"))
 			}
@@ -387,12 +387,12 @@ func (p *parseVisitor) VisitVars(c *parser.VarListDeclContext) *CompileError {
 			if compErr != nil {
 				return compErr
 			}
-			if accTy != core.TypeAccount {
+			if accTy != internal.TypeAccount {
 				return LogicError(c, errors.New(
 					"variable type should be 'account' to pull account balance"))
 			}
 
-			asset := core.Asset(c.GetAsset().GetText())
+			asset := internal.Asset(c.GetAsset().GetText())
 			addr, err = p.AllocateResource(program.VariableAccountBalance{
 				Name:    name,
 				Account: *accAddr,
@@ -493,9 +493,9 @@ func CompileFull(input string) CompileArtifacts {
 		errListener:    errListener,
 		instructions:   make([]byte, 0),
 		resources:      make([]program.Resource, 0),
-		varIdx:         make(map[string]core.Address),
-		neededBalances: make(map[core.Address]map[core.Address]struct{}),
-		sources:        map[core.Address]struct{}{},
+		varIdx:         make(map[string]internal.Address),
+		neededBalances: make(map[internal.Address]map[internal.Address]struct{}),
+		sources:        map[internal.Address]struct{}{},
 	}
 
 	err := visitor.VisitScript(tree)
@@ -504,7 +504,7 @@ func CompileFull(input string) CompileArtifacts {
 		return artifacts
 	}
 
-	sources := make(core.Addresses, 0)
+	sources := make(internal.Addresses, 0)
 	for address := range visitor.sources {
 		sources = append(sources, address)
 	}

--- a/components/ledger/pkg/machine/script/compiler/compiler_test.go
+++ b/components/ledger/pkg/machine/script/compiler/compiler_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/formancehq/ledger/pkg/machine/vm/program"
 )
 
@@ -78,7 +78,7 @@ func checkResourcesEqual(res, expected program.Resource) bool {
 	}
 	switch res := res.(type) {
 	case program.Constant:
-		return core.ValueEquals(res.Inner, expected.(program.Constant).Inner)
+		return internal.ValueEquals(res.Inner, expected.(program.Constant).Inner)
 	case program.Variable:
 		e := expected.(program.Variable)
 		return res.Typ == e.Typ && res.Name == e.Name
@@ -105,7 +105,7 @@ func TestSimplePrint(t *testing.T) {
 				program.OP_PRINT,
 			},
 			Resources: []program.Resource{
-				program.Constant{Inner: core.NewMonetaryInt(1)},
+				program.Constant{Inner: internal.NewMonetaryInt(1)},
 			},
 		},
 	})
@@ -124,9 +124,9 @@ func TestCompositeExpr(t *testing.T) {
 				program.OP_PRINT,
 			},
 			Resources: []program.Resource{
-				program.Constant{Inner: core.NewMonetaryInt(29)},
-				program.Constant{Inner: core.NewMonetaryInt(15)},
-				program.Constant{Inner: core.NewMonetaryInt(2)},
+				program.Constant{Inner: internal.NewMonetaryInt(29)},
+				program.Constant{Inner: internal.NewMonetaryInt(15)},
+				program.Constant{Inner: internal.NewMonetaryInt(2)},
 			},
 		},
 	})
@@ -151,15 +151,15 @@ func TestCRLF(t *testing.T) {
 				program.OP_APUSH, 01, 00, program.OP_PRINT,
 			},
 			Resources: []program.Resource{
-				program.Constant{Inner: core.AccountAddress("a")},
-				program.Constant{Inner: core.AccountAddress("b")},
+				program.Constant{Inner: internal.AccountAddress("a")},
+				program.Constant{Inner: internal.AccountAddress("b")},
 			},
 		},
 	})
 }
 
 func TestConstant(t *testing.T) {
-	user := core.AccountAddress("user:U001")
+	user := internal.AccountAddress("user:U001")
 	test(t, TestCase{
 		Case: "print @user:U001",
 		Expected: CaseResult{
@@ -201,24 +201,24 @@ func TestSetTxMeta(t *testing.T) {
 				program.OP_TX_META,
 			},
 			Resources: []program.Resource{
-				program.Constant{Inner: core.AccountAddress("platform")},
-				program.Constant{Inner: core.String("aaa")},
-				program.Constant{Inner: core.Asset("GEM")},
-				program.Constant{Inner: core.String("bbb")},
-				program.Constant{Inner: core.NewNumber(42)},
-				program.Constant{Inner: core.String("ccc")},
-				program.Constant{Inner: core.String("test")},
-				program.Constant{Inner: core.String("ddd")},
-				program.Constant{Inner: core.Monetary{
+				program.Constant{Inner: internal.AccountAddress("platform")},
+				program.Constant{Inner: internal.String("aaa")},
+				program.Constant{Inner: internal.Asset("GEM")},
+				program.Constant{Inner: internal.String("bbb")},
+				program.Constant{Inner: internal.NewNumber(42)},
+				program.Constant{Inner: internal.String("ccc")},
+				program.Constant{Inner: internal.String("test")},
+				program.Constant{Inner: internal.String("ddd")},
+				program.Constant{Inner: internal.Monetary{
 					Asset:  "COIN",
-					Amount: core.NewMonetaryInt(30),
+					Amount: internal.NewMonetaryInt(30),
 				}},
-				program.Constant{Inner: core.String("eee")},
-				program.Constant{Inner: core.Portion{
+				program.Constant{Inner: internal.String("eee")},
+				program.Constant{Inner: internal.Portion{
 					Remaining: false,
 					Specific:  big.NewRat(15, 100),
 				}},
-				program.Constant{Inner: core.String("fff")},
+				program.Constant{Inner: internal.String("fff")},
 			},
 		},
 	})
@@ -239,8 +239,8 @@ func TestSetTxMetaVars(t *testing.T) {
 				program.OP_TX_META,
 			},
 			Resources: []program.Resource{
-				program.Variable{Typ: core.TypePortion, Name: "commission"},
-				program.Constant{Inner: core.String("fee")},
+				program.Variable{Typ: internal.TypePortion, Name: "commission"},
+				program.Constant{Inner: internal.String("fee")},
 			},
 		},
 	})
@@ -259,7 +259,7 @@ func TestComments(t *testing.T) {
 		`,
 		Expected: CaseResult{
 			Instructions: []byte{program.OP_APUSH, 00, 00, program.OP_PRINT},
-			Resources:    []program.Resource{program.Variable{Typ: core.TypeAccount, Name: "a"}},
+			Resources:    []program.Resource{program.Variable{Typ: internal.TypeAccount, Name: "a"}},
 			Error:        "",
 		},
 	})
@@ -367,18 +367,18 @@ func TestDestinationAllotment(t *testing.T) {
 				program.OP_REPAY,            //
 			},
 			Resources: []program.Resource{
-				program.Constant{Inner: core.Monetary{
+				program.Constant{Inner: internal.Monetary{
 					Asset:  "EUR/2",
-					Amount: core.NewMonetaryInt(43),
+					Amount: internal.NewMonetaryInt(43),
 				}},
-				program.Constant{Inner: core.AccountAddress("foo")},
-				program.Constant{Inner: core.NewMonetaryInt(0)},
-				program.Constant{Inner: core.NewMonetaryInt(1)},
-				program.Constant{Inner: core.Portion{Specific: big.NewRat(7, 8)}},
-				program.Constant{Inner: core.Portion{Specific: big.NewRat(1, 8)}},
-				program.Constant{Inner: core.NewMonetaryInt(2)},
-				program.Constant{Inner: core.AccountAddress("bar")},
-				program.Constant{Inner: core.AccountAddress("baz")},
+				program.Constant{Inner: internal.AccountAddress("foo")},
+				program.Constant{Inner: internal.NewMonetaryInt(0)},
+				program.Constant{Inner: internal.NewMonetaryInt(1)},
+				program.Constant{Inner: internal.Portion{Specific: big.NewRat(7, 8)}},
+				program.Constant{Inner: internal.Portion{Specific: big.NewRat(1, 8)}},
+				program.Constant{Inner: internal.NewMonetaryInt(2)},
+				program.Constant{Inner: internal.AccountAddress("bar")},
+				program.Constant{Inner: internal.AccountAddress("baz")},
 			},
 			Error: "",
 		},
@@ -452,21 +452,21 @@ func TestDestinationInOrder(t *testing.T) {
 				program.OP_REPAY,            //
 			},
 			Resources: []program.Resource{
-				program.Constant{Inner: core.Monetary{
+				program.Constant{Inner: internal.Monetary{
 					Asset:  "COIN",
-					Amount: core.NewMonetaryInt(50),
+					Amount: internal.NewMonetaryInt(50),
 				}},
-				program.Constant{Inner: core.AccountAddress("a")},
-				program.Constant{Inner: core.NewMonetaryInt(0)},
-				program.Constant{Inner: core.NewMonetaryInt(1)},
-				program.Constant{Inner: core.Monetary{
+				program.Constant{Inner: internal.AccountAddress("a")},
+				program.Constant{Inner: internal.NewMonetaryInt(0)},
+				program.Constant{Inner: internal.NewMonetaryInt(1)},
+				program.Constant{Inner: internal.Monetary{
 					Asset:  "COIN",
-					Amount: core.NewMonetaryInt(10),
+					Amount: internal.NewMonetaryInt(10),
 				}},
-				program.Constant{Inner: core.NewMonetaryInt(2)},
-				program.Constant{Inner: core.AccountAddress("b")},
-				program.Constant{Inner: core.NewMonetaryInt(3)},
-				program.Constant{Inner: core.AccountAddress("c")},
+				program.Constant{Inner: internal.NewMonetaryInt(2)},
+				program.Constant{Inner: internal.AccountAddress("b")},
+				program.Constant{Inner: internal.NewMonetaryInt(3)},
+				program.Constant{Inner: internal.AccountAddress("c")},
 			},
 			Error: "",
 		},
@@ -486,21 +486,21 @@ func TestAllocationPercentages(t *testing.T) {
 		Expected: CaseResult{
 			Instructions: []byte{},
 			Resources: []program.Resource{
-				program.Constant{Inner: core.Monetary{
+				program.Constant{Inner: internal.Monetary{
 					Asset:  "EUR/2",
-					Amount: core.NewMonetaryInt(43),
+					Amount: internal.NewMonetaryInt(43),
 				}},
-				program.Constant{Inner: core.AccountAddress("foo")},
-				program.Constant{Inner: core.NewMonetaryInt(0)},
-				program.Constant{Inner: core.NewMonetaryInt(1)},
-				program.Constant{Inner: core.Portion{Specific: big.NewRat(1, 2)}},
-				program.Constant{Inner: core.Portion{Specific: big.NewRat(3, 8)}},
-				program.Constant{Inner: core.Portion{Specific: big.NewRat(1, 8)}},
-				program.Constant{Inner: core.NewMonetaryInt(3)},
-				program.Constant{Inner: core.AccountAddress("bar")},
-				program.Constant{Inner: core.NewMonetaryInt(2)},
-				program.Constant{Inner: core.AccountAddress("baz")},
-				program.Constant{Inner: core.AccountAddress("qux")},
+				program.Constant{Inner: internal.AccountAddress("foo")},
+				program.Constant{Inner: internal.NewMonetaryInt(0)},
+				program.Constant{Inner: internal.NewMonetaryInt(1)},
+				program.Constant{Inner: internal.Portion{Specific: big.NewRat(1, 2)}},
+				program.Constant{Inner: internal.Portion{Specific: big.NewRat(3, 8)}},
+				program.Constant{Inner: internal.Portion{Specific: big.NewRat(1, 8)}},
+				program.Constant{Inner: internal.NewMonetaryInt(3)},
+				program.Constant{Inner: internal.AccountAddress("bar")},
+				program.Constant{Inner: internal.NewMonetaryInt(2)},
+				program.Constant{Inner: internal.AccountAddress("baz")},
+				program.Constant{Inner: internal.AccountAddress("qux")},
 			},
 			Error: "",
 		},
@@ -508,8 +508,8 @@ func TestAllocationPercentages(t *testing.T) {
 }
 
 func TestSend(t *testing.T) {
-	alice := core.AccountAddress("alice")
-	bob := core.AccountAddress("bob")
+	alice := internal.AccountAddress("alice")
+	bob := internal.AccountAddress("bob")
 	test(t, TestCase{
 		Case: `send [EUR/2 99] (
 	source = @alice
@@ -534,10 +534,10 @@ func TestSend(t *testing.T) {
 				program.OP_SEND,  // [EUR/2]
 				program.OP_REPAY, //
 			}, Resources: []program.Resource{
-				program.Constant{Inner: core.Monetary{Asset: "EUR/2", Amount: core.NewMonetaryInt(99)}},
+				program.Constant{Inner: internal.Monetary{Asset: "EUR/2", Amount: internal.NewMonetaryInt(99)}},
 				program.Constant{Inner: alice},
-				program.Constant{Inner: core.NewMonetaryInt(0)},
-				program.Constant{Inner: core.NewMonetaryInt(1)},
+				program.Constant{Inner: internal.NewMonetaryInt(0)},
+				program.Constant{Inner: internal.NewMonetaryInt(1)},
 				program.Constant{Inner: bob}},
 			Error: "",
 		},
@@ -563,10 +563,10 @@ func TestSendAll(t *testing.T) {
 				program.OP_SEND,  // [EUR/2]
 				program.OP_REPAY, //
 			}, Resources: []program.Resource{
-				program.Constant{Inner: core.Asset("EUR/2")},
-				program.Constant{Inner: core.AccountAddress("alice")},
-				program.Constant{Inner: core.NewMonetaryInt(0)},
-				program.Constant{Inner: core.AccountAddress("bob")}},
+				program.Constant{Inner: internal.Asset("EUR/2")},
+				program.Constant{Inner: internal.AccountAddress("alice")},
+				program.Constant{Inner: internal.NewMonetaryInt(0)},
+				program.Constant{Inner: internal.AccountAddress("bob")}},
 			Error: "",
 		},
 	})
@@ -589,15 +589,15 @@ func TestMetadata(t *testing.T) {
 		)`,
 		Expected: CaseResult{
 			Instructions: []byte{}, Resources: []program.Resource{
-				program.Variable{Typ: core.TypeAccount, Name: "sale"},
-				program.VariableAccountMetadata{Typ: core.TypeAccount, Account: core.NewAddress(0), Key: "seller"},
-				program.VariableAccountMetadata{Typ: core.TypePortion, Account: core.NewAddress(1), Key: "commission"},
-				program.Constant{Inner: core.Monetary{Asset: "EUR/2", Amount: core.NewMonetaryInt(53)}},
-				program.Constant{Inner: core.NewMonetaryInt(0)},
-				program.Constant{Inner: core.NewMonetaryInt(1)},
-				program.Constant{Inner: core.NewPortionRemaining()},
-				program.Constant{Inner: core.NewMonetaryInt(2)},
-				program.Constant{Inner: core.AccountAddress("platform")},
+				program.Variable{Typ: internal.TypeAccount, Name: "sale"},
+				program.VariableAccountMetadata{Typ: internal.TypeAccount, Account: internal.NewAddress(0), Key: "seller"},
+				program.VariableAccountMetadata{Typ: internal.TypePortion, Account: internal.NewAddress(1), Key: "commission"},
+				program.Constant{Inner: internal.Monetary{Asset: "EUR/2", Amount: internal.NewMonetaryInt(53)}},
+				program.Constant{Inner: internal.NewMonetaryInt(0)},
+				program.Constant{Inner: internal.NewMonetaryInt(1)},
+				program.Constant{Inner: internal.NewPortionRemaining()},
+				program.Constant{Inner: internal.NewMonetaryInt(2)},
+				program.Constant{Inner: internal.AccountAddress("platform")},
 			},
 			Error: "",
 		},
@@ -1027,25 +1027,25 @@ func TestSetAccountMeta(t *testing.T) {
 					program.OP_ACCOUNT_META,
 				},
 				Resources: []program.Resource{
-					program.Constant{Inner: core.AccountAddress("platform")},
-					program.Constant{Inner: core.String("aaa")},
-					program.Constant{Inner: core.AccountAddress("alice")},
-					program.Constant{Inner: core.Asset("GEM")},
-					program.Constant{Inner: core.String("bbb")},
-					program.Constant{Inner: core.NewNumber(42)},
-					program.Constant{Inner: core.String("ccc")},
-					program.Constant{Inner: core.String("test")},
-					program.Constant{Inner: core.String("ddd")},
-					program.Constant{Inner: core.Monetary{
+					program.Constant{Inner: internal.AccountAddress("platform")},
+					program.Constant{Inner: internal.String("aaa")},
+					program.Constant{Inner: internal.AccountAddress("alice")},
+					program.Constant{Inner: internal.Asset("GEM")},
+					program.Constant{Inner: internal.String("bbb")},
+					program.Constant{Inner: internal.NewNumber(42)},
+					program.Constant{Inner: internal.String("ccc")},
+					program.Constant{Inner: internal.String("test")},
+					program.Constant{Inner: internal.String("ddd")},
+					program.Constant{Inner: internal.Monetary{
 						Asset:  "COIN",
-						Amount: core.NewMonetaryInt(30),
+						Amount: internal.NewMonetaryInt(30),
 					}},
-					program.Constant{Inner: core.String("eee")},
-					program.Constant{Inner: core.Portion{
+					program.Constant{Inner: internal.String("eee")},
+					program.Constant{Inner: internal.Portion{
 						Remaining: false,
 						Specific:  big.NewRat(15, 100),
 					}},
-					program.Constant{Inner: core.String("fff")},
+					program.Constant{Inner: internal.String("fff")},
 				},
 			},
 		})
@@ -1093,17 +1093,17 @@ func TestSetAccountMeta(t *testing.T) {
 					program.OP_ACCOUNT_META,
 				},
 				Resources: []program.Resource{
-					program.Variable{Typ: core.TypeAccount, Name: "acc"},
-					program.Constant{Inner: core.Monetary{Asset: "EUR/2", Amount: core.NewMonetaryInt(100)}},
-					program.Constant{Inner: core.AccountAddress("world")},
-					program.Constant{Inner: core.NewMonetaryInt(0)},
-					program.Constant{Inner: core.NewMonetaryInt(1)},
-					program.Constant{Inner: core.NewMonetaryInt(2)},
-					program.Constant{Inner: core.Portion{
+					program.Variable{Typ: internal.TypeAccount, Name: "acc"},
+					program.Constant{Inner: internal.Monetary{Asset: "EUR/2", Amount: internal.NewMonetaryInt(100)}},
+					program.Constant{Inner: internal.AccountAddress("world")},
+					program.Constant{Inner: internal.NewMonetaryInt(0)},
+					program.Constant{Inner: internal.NewMonetaryInt(1)},
+					program.Constant{Inner: internal.NewMonetaryInt(2)},
+					program.Constant{Inner: internal.Portion{
 						Remaining: false,
 						Specific:  big.NewRat(1, 100),
 					}},
-					program.Constant{Inner: core.String("fees")},
+					program.Constant{Inner: internal.String("fees")},
 				},
 			},
 		})
@@ -1179,11 +1179,11 @@ func TestVariableBalance(t *testing.T) {
 					program.OP_REPAY,
 				},
 				Resources: []program.Resource{
-					program.Constant{Inner: core.AccountAddress("alice")},
+					program.Constant{Inner: internal.AccountAddress("alice")},
 					program.VariableAccountBalance{Account: 0, Asset: "COIN"},
-					program.Constant{Inner: core.NewMonetaryInt(0)},
-					program.Constant{Inner: core.NewMonetaryInt(1)},
-					program.Constant{Inner: core.AccountAddress("bob")},
+					program.Constant{Inner: internal.NewMonetaryInt(0)},
+					program.Constant{Inner: internal.NewMonetaryInt(1)},
+					program.Constant{Inner: internal.AccountAddress("bob")},
 				},
 			},
 		})
@@ -1226,13 +1226,13 @@ func TestVariableBalance(t *testing.T) {
 					program.OP_REPAY,
 				},
 				Resources: []program.Resource{
-					program.Variable{Typ: core.TypeAccount, Name: "acc"},
+					program.Variable{Typ: internal.TypeAccount, Name: "acc"},
 					program.VariableAccountBalance{Account: 0, Asset: "COIN"},
-					program.Constant{Inner: core.AccountAddress("world")},
-					program.Constant{Inner: core.NewMonetaryInt(0)},
-					program.Constant{Inner: core.NewMonetaryInt(1)},
-					program.Constant{Inner: core.NewMonetaryInt(2)},
-					program.Constant{Inner: core.AccountAddress("alice")},
+					program.Constant{Inner: internal.AccountAddress("world")},
+					program.Constant{Inner: internal.NewMonetaryInt(0)},
+					program.Constant{Inner: internal.NewMonetaryInt(1)},
+					program.Constant{Inner: internal.NewMonetaryInt(2)},
+					program.Constant{Inner: internal.AccountAddress("alice")},
 				},
 			},
 		})

--- a/components/ledger/pkg/machine/script/compiler/destination.go
+++ b/components/ledger/pkg/machine/script/compiler/destination.go
@@ -3,7 +3,7 @@ package compiler
 import (
 	"errors"
 
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/formancehq/ledger/pkg/machine/script/parser"
 	"github.com/formancehq/ledger/pkg/machine/vm/program"
 )
@@ -26,7 +26,7 @@ func (p *parseVisitor) VisitDestinationRecursive(c parser.IDestinationContext) *
 		if err != nil {
 			return err
 		}
-		if ty != core.TypeAccount {
+		if ty != internal.TypeAccount {
 			return LogicError(c,
 				errors.New("wrong type: expected account as destination"),
 			)
@@ -41,7 +41,7 @@ func (p *parseVisitor) VisitDestinationRecursive(c parser.IDestinationContext) *
 		// initialize the `kept` accumulator
 		p.AppendInstruction(program.OP_FUNDING_SUM)
 		p.AppendInstruction(program.OP_ASSET)
-		err := p.PushInteger(core.NewNumber(0))
+		err := p.PushInteger(internal.NewNumber(0))
 		if err != nil {
 			return LogicError(c, err)
 		}
@@ -57,7 +57,7 @@ func (p *parseVisitor) VisitDestinationRecursive(c parser.IDestinationContext) *
 			if compErr != nil {
 				return compErr
 			}
-			if ty != core.TypeMonetary {
+			if ty != internal.TypeMonetary {
 				return LogicError(c, errors.New("wrong type: expected monetary as max"))
 			}
 			p.AppendInstruction(program.OP_TAKE_MAX)
@@ -84,7 +84,7 @@ func (p *parseVisitor) VisitDestinationRecursive(c parser.IDestinationContext) *
 			if err != nil {
 				return LogicError(c, err)
 			}
-			err = p.PushInteger(core.NewNumber(2))
+			err = p.PushInteger(internal.NewNumber(2))
 			if err != nil {
 				return LogicError(c, err)
 			}
@@ -110,7 +110,7 @@ func (p *parseVisitor) VisitDestinationRecursive(c parser.IDestinationContext) *
 		if err != nil {
 			return LogicError(c, err)
 		}
-		err = p.PushInteger(core.NewNumber(2))
+		err = p.PushInteger(internal.NewNumber(2))
 		if err != nil {
 			return LogicError(c, err)
 		}
@@ -169,7 +169,7 @@ func (p *parseVisitor) VisitAllocDestination(dests []parser.IKeptOrDestinationCo
 		if err != nil {
 			return LogicError(dest, err)
 		}
-		err = p.PushInteger(core.NewNumber(2))
+		err = p.PushInteger(internal.NewNumber(2))
 		if err != nil {
 			return LogicError(dest, err)
 		}

--- a/components/ledger/pkg/machine/script/compiler/program.go
+++ b/components/ledger/pkg/machine/script/compiler/program.go
@@ -1,7 +1,7 @@
 package compiler
 
 import (
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/formancehq/ledger/pkg/machine/vm/program"
 )
 
@@ -9,13 +9,13 @@ func (p *parseVisitor) AppendInstruction(instruction byte) {
 	p.instructions = append(p.instructions, instruction)
 }
 
-func (p *parseVisitor) PushAddress(addr core.Address) {
+func (p *parseVisitor) PushAddress(addr internal.Address) {
 	p.instructions = append(p.instructions, program.OP_APUSH)
 	bytes := addr.ToBytes()
 	p.instructions = append(p.instructions, bytes...)
 }
 
-func (p *parseVisitor) PushInteger(val core.Number) error {
+func (p *parseVisitor) PushInteger(val internal.Number) error {
 	addr, err := p.AllocateResource(program.Constant{Inner: val})
 	if err != nil {
 		return err
@@ -27,7 +27,7 @@ func (p *parseVisitor) PushInteger(val core.Number) error {
 }
 
 func (p *parseVisitor) Bump(n int64) error {
-	err := p.PushInteger(core.NewNumber(n))
+	err := p.PushInteger(internal.NewNumber(n))
 	if err != nil {
 		return err
 	}

--- a/components/ledger/pkg/machine/script/compiler/source.go
+++ b/components/ledger/pkg/machine/script/compiler/source.go
@@ -4,16 +4,16 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/formancehq/ledger/pkg/machine/script/parser"
 	"github.com/formancehq/ledger/pkg/machine/vm/program"
 )
 
-type FallbackAccount core.Address
+type FallbackAccount internal.Address
 
 // VisitValueAwareSource returns the resource addresses of all the accounts
-func (p *parseVisitor) VisitValueAwareSource(c parser.IValueAwareSourceContext, pushAsset func(), monAddr *core.Address) (map[core.Address]struct{}, *CompileError) {
-	neededAccounts := map[core.Address]struct{}{}
+func (p *parseVisitor) VisitValueAwareSource(c parser.IValueAwareSourceContext, pushAsset func(), monAddr *internal.Address) (map[internal.Address]struct{}, *CompileError) {
+	neededAccounts := map[internal.Address]struct{}{}
 	isAll := monAddr == nil
 	switch c := c.(type) {
 	case *parser.SrcContext:
@@ -58,7 +58,7 @@ func (p *parseVisitor) VisitValueAwareSource(c parser.IValueAwareSourceContext, 
 				return nil, LogicError(c, err)
 			}
 		}
-		err := p.PushInteger(core.NewNumber(int64(n)))
+		err := p.PushInteger(internal.NewNumber(int64(n)))
 		if err != nil {
 			return nil, LogicError(c, err)
 		}
@@ -82,13 +82,13 @@ func (p *parseVisitor) TakeFromSource(fallback *FallbackAccount) error {
 			return err
 		}
 		p.AppendInstruction(program.OP_REPAY)
-		p.PushAddress(core.Address(*fallback))
+		p.PushAddress(internal.Address(*fallback))
 		err = p.Bump(2)
 		if err != nil {
 			return err
 		}
 		p.AppendInstruction(program.OP_TAKE_ALWAYS)
-		err = p.PushInteger(core.NewNumber(2))
+		err = p.PushInteger(internal.NewNumber(2))
 		if err != nil {
 			return err
 		}
@@ -100,9 +100,9 @@ func (p *parseVisitor) TakeFromSource(fallback *FallbackAccount) error {
 // VisitSource returns the resource addresses of all the accounts,
 // the addresses of accounts already emptied,
 // and possibly a fallback account if the source has an unbounded overdraft allowance or contains @world
-func (p *parseVisitor) VisitSource(c parser.ISourceContext, pushAsset func(), isAll bool) (map[core.Address]struct{}, map[core.Address]struct{}, *FallbackAccount, *CompileError) {
-	neededAccounts := map[core.Address]struct{}{}
-	emptiedAccounts := map[core.Address]struct{}{}
+func (p *parseVisitor) VisitSource(c parser.ISourceContext, pushAsset func(), isAll bool) (map[internal.Address]struct{}, map[internal.Address]struct{}, *FallbackAccount, *CompileError) {
+	neededAccounts := map[internal.Address]struct{}{}
+	emptiedAccounts := map[internal.Address]struct{}{}
 	var fallback *FallbackAccount
 	switch c := c.(type) {
 	case *parser.SrcAccountContext:
@@ -110,7 +110,7 @@ func (p *parseVisitor) VisitSource(c parser.ISourceContext, pushAsset func(), is
 		if compErr != nil {
 			return nil, nil, nil, compErr
 		}
-		if ty != core.TypeAccount {
+		if ty != internal.TypeAccount {
 			return nil, nil, nil, LogicError(c, errors.New("wrong type: expected account or allocation as destination"))
 		}
 		if p.isWorld(*accAddr) {
@@ -122,7 +122,7 @@ func (p *parseVisitor) VisitSource(c parser.ISourceContext, pushAsset func(), is
 		if overdraft == nil {
 			// no overdraft: use zero monetary
 			pushAsset()
-			err := p.PushInteger(core.NewNumber(0))
+			err := p.PushInteger(internal.NewNumber(0))
 			if err != nil {
 				return nil, nil, nil, LogicError(c, err)
 			}
@@ -138,13 +138,13 @@ func (p *parseVisitor) VisitSource(c parser.ISourceContext, pushAsset func(), is
 				if compErr != nil {
 					return nil, nil, nil, compErr
 				}
-				if ty != core.TypeMonetary {
+				if ty != internal.TypeMonetary {
 					return nil, nil, nil, LogicError(c, errors.New("wrong type: expected monetary"))
 				}
 				p.AppendInstruction(program.OP_TAKE_ALL)
 			case *parser.SrcAccountOverdraftUnboundedContext:
 				pushAsset()
-				err := p.PushInteger(core.NewNumber(0))
+				err := p.PushInteger(internal.NewNumber(0))
 				if err != nil {
 					return nil, nil, nil, LogicError(c, err)
 				}
@@ -170,7 +170,7 @@ func (p *parseVisitor) VisitSource(c parser.ISourceContext, pushAsset func(), is
 		if compErr != nil {
 			return nil, nil, nil, compErr
 		}
-		if ty != core.TypeMonetary {
+		if ty != internal.TypeMonetary {
 			return nil, nil, nil, LogicError(c, errors.New("wrong type: expected monetary as max"))
 		}
 		for k, v := range accounts {
@@ -183,13 +183,13 @@ func (p *parseVisitor) VisitSource(c parser.ISourceContext, pushAsset func(), is
 		}
 		p.AppendInstruction(program.OP_REPAY)
 		if subsourceFallback != nil {
-			p.PushAddress(core.Address(*subsourceFallback))
+			p.PushAddress(internal.Address(*subsourceFallback))
 			err := p.Bump(2)
 			if err != nil {
 				return nil, nil, nil, LogicError(c, err)
 			}
 			p.AppendInstruction(program.OP_TAKE_ALL)
-			err = p.PushInteger(core.NewNumber(2))
+			err = p.PushInteger(internal.NewNumber(2))
 			if err != nil {
 				return nil, nil, nil, LogicError(c, err)
 			}
@@ -223,7 +223,7 @@ func (p *parseVisitor) VisitSource(c parser.ISourceContext, pushAsset func(), is
 				emptiedAccounts[k] = v
 			}
 		}
-		err := p.PushInteger(core.NewNumber(int64(n)))
+		err := p.PushInteger(internal.NewNumber(int64(n)))
 		if err != nil {
 			return nil, nil, nil, LogicError(c, err)
 		}

--- a/components/ledger/pkg/machine/vm/machine.go
+++ b/components/ledger/pkg/machine/vm/machine.go
@@ -16,6 +16,7 @@ import (
 	"math/big"
 
 	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/formancehq/ledger/pkg/machine/vm/program"
 	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
@@ -31,48 +32,48 @@ const (
 type Machine struct {
 	P                   uint
 	Program             program.Program
-	Vars                map[string]core.Value
+	Vars                map[string]internal.Value
 	UnresolvedResources []program.Resource
-	Resources           []core.Value // Constants and Variables
+	Resources           []internal.Value // Constants and Variables
 	resolveCalled       bool
-	Balances            map[core.AccountAddress]map[core.Asset]*core.MonetaryInt // keeps track of balances throughout execution
+	Balances            map[internal.AccountAddress]map[internal.Asset]*internal.MonetaryInt // keeps track of balances throughout execution
 	setBalanceCalled    bool
-	Stack               []core.Value
-	Postings            []Posting                                     // accumulates postings throughout execution
-	TxMeta              map[string]core.Value                         // accumulates transaction meta throughout execution
-	AccountsMeta        map[core.AccountAddress]map[string]core.Value // accumulates accounts meta throughout execution
-	Printer             func(chan core.Value)
-	printChan           chan core.Value
+	Stack               []internal.Value
+	Postings            []Posting                                             // accumulates postings throughout execution
+	TxMeta              map[string]internal.Value                             // accumulates transaction meta throughout execution
+	AccountsMeta        map[internal.AccountAddress]map[string]internal.Value // accumulates accounts meta throughout execution
+	Printer             func(chan internal.Value)
+	printChan           chan internal.Value
 	Debug               bool
 }
 
 type Posting struct {
-	Source      string            `json:"source"`
-	Destination string            `json:"destination"`
-	Amount      *core.MonetaryInt `json:"amount"`
-	Asset       string            `json:"asset"`
+	Source      string                `json:"source"`
+	Destination string                `json:"destination"`
+	Amount      *internal.MonetaryInt `json:"amount"`
+	Asset       string                `json:"asset"`
 }
 
 type Metadata map[string]any
 
 func NewMachine(p program.Program) *Machine {
-	printChan := make(chan core.Value)
+	printChan := make(chan internal.Value)
 
 	m := Machine{
 		Program:             p,
 		UnresolvedResources: p.Resources,
-		Resources:           make([]core.Value, 0),
+		Resources:           make([]internal.Value, 0),
 		printChan:           printChan,
 		Printer:             StdOutPrinter,
 		Postings:            make([]Posting, 0),
-		TxMeta:              map[string]core.Value{},
-		AccountsMeta:        map[core.AccountAddress]map[string]core.Value{},
+		TxMeta:              map[string]internal.Value{},
+		AccountsMeta:        map[internal.AccountAddress]map[string]internal.Value{},
 	}
 
 	return &m
 }
 
-func StdOutPrinter(c chan core.Value) {
+func StdOutPrinter(c chan internal.Value) {
 	for v := range c {
 		fmt.Println("OUT:", v)
 	}
@@ -85,7 +86,7 @@ func (m *Machine) GetTxMetaJSON() Metadata {
 		if err != nil {
 			panic(err)
 		}
-		v, err := json.Marshal(core.ValueJSON{
+		v, err := json.Marshal(internal.ValueJSON{
 			Type:  v.GetType().String(),
 			Value: valJSON,
 		})
@@ -108,7 +109,7 @@ func (m *Machine) GetAccountsMetaJSON() Metadata {
 			if err != nil {
 				panic(err)
 			}
-			v, err := json.Marshal(core.ValueJSON{
+			v, err := json.Marshal(internal.ValueJSON{
 				Type:  v.GetType().String(),
 				Value: valJSON,
 			})
@@ -122,7 +123,7 @@ func (m *Machine) GetAccountsMetaJSON() Metadata {
 	return res
 }
 
-func (m *Machine) getResource(addr core.Address) (*core.Value, bool) {
+func (m *Machine) getResource(addr internal.Address) (*internal.Value, bool) {
 	a := int(addr)
 	if a >= len(m.Resources) {
 		return nil, false
@@ -130,18 +131,18 @@ func (m *Machine) getResource(addr core.Address) (*core.Value, bool) {
 	return &m.Resources[a], true
 }
 
-func (m *Machine) withdrawAll(account core.AccountAddress, asset core.Asset, overdraft *core.MonetaryInt) (*core.Funding, error) {
+func (m *Machine) withdrawAll(account internal.AccountAddress, asset internal.Asset, overdraft *internal.MonetaryInt) (*internal.Funding, error) {
 	if accBalances, ok := m.Balances[account]; ok {
 		if balance, ok := accBalances[asset]; ok {
-			amountTaken := core.NewMonetaryInt(0)
-			if balance.Add(overdraft).Gt(core.NewMonetaryInt(0)) {
+			amountTaken := internal.NewMonetaryInt(0)
+			if balance.Add(overdraft).Gt(internal.NewMonetaryInt(0)) {
 				amountTaken = balance.Add(overdraft)
 				accBalances[asset] = overdraft.Neg()
 			}
 
-			return &core.Funding{
+			return &internal.Funding{
 				Asset: asset,
-				Parts: []core.FundingPart{{
+				Parts: []internal.FundingPart{{
 					Account: account,
 					Amount:  amountTaken,
 				}},
@@ -151,13 +152,13 @@ func (m *Machine) withdrawAll(account core.AccountAddress, asset core.Asset, ove
 	return nil, fmt.Errorf("missing %v balance from %v", asset, account)
 }
 
-func (m *Machine) withdrawAlways(account core.AccountAddress, mon core.Monetary) (*core.Funding, error) {
+func (m *Machine) withdrawAlways(account internal.AccountAddress, mon internal.Monetary) (*internal.Funding, error) {
 	if accBalance, ok := m.Balances[account]; ok {
 		if balance, ok := accBalance[mon.Asset]; ok {
 			accBalance[mon.Asset] = balance.Sub(mon.Amount)
-			return &core.Funding{
+			return &internal.Funding{
 				Asset: mon.Asset,
-				Parts: []core.FundingPart{{
+				Parts: []internal.FundingPart{{
 					Account: account,
 					Amount:  mon.Amount,
 				}},
@@ -167,7 +168,7 @@ func (m *Machine) withdrawAlways(account core.AccountAddress, mon core.Monetary)
 	return nil, fmt.Errorf("missing %v balance from %v", mon.Asset, account)
 }
 
-func (m *Machine) credit(account core.AccountAddress, funding core.Funding) {
+func (m *Machine) credit(account internal.AccountAddress, funding internal.Funding) {
 	if account == "world" {
 		return
 	}
@@ -181,7 +182,7 @@ func (m *Machine) credit(account core.AccountAddress, funding core.Funding) {
 	}
 }
 
-func (m *Machine) repay(funding core.Funding) {
+func (m *Machine) repay(funding internal.Funding) {
 	for _, part := range funding.Parts {
 		if part.Account == "world" {
 			continue
@@ -204,7 +205,7 @@ func (m *Machine) tick() (bool, byte) {
 	switch op {
 	case program.OP_APUSH:
 		bytes := m.Program.Instructions[m.P+1 : m.P+3]
-		v, ok := m.getResource(core.Address(binary.LittleEndian.Uint16(bytes)))
+		v, ok := m.getResource(internal.Address(binary.LittleEndian.Uint16(bytes)))
 		if !ok {
 			return true, EXIT_FAIL
 		}
@@ -212,7 +213,7 @@ func (m *Machine) tick() (bool, byte) {
 		m.P += 2
 
 	case program.OP_BUMP:
-		n := big.Int(*pop[core.Number](m))
+		n := big.Int(*pop[internal.Number](m))
 		idx := len(m.Stack) - int(n.Uint64()) - 1
 		v := m.Stack[idx]
 		m.Stack = append(m.Stack[:idx], m.Stack[idx+1:]...)
@@ -220,18 +221,18 @@ func (m *Machine) tick() (bool, byte) {
 
 	case program.OP_DELETE:
 		n := m.popValue()
-		if n.GetType() == core.TypeFunding {
+		if n.GetType() == internal.TypeFunding {
 			return true, EXIT_FAIL_INVALID
 		}
 
 	case program.OP_IADD:
-		b := pop[core.Number](m)
-		a := pop[core.Number](m)
+		b := pop[internal.Number](m)
+		a := pop[internal.Number](m)
 		m.pushValue(a.Add(b))
 
 	case program.OP_ISUB:
-		b := pop[core.Number](m)
-		a := pop[core.Number](m)
+		b := pop[internal.Number](m)
+		a := pop[internal.Number](m)
 		m.pushValue(a.Sub(b))
 
 	case program.OP_PRINT:
@@ -244,51 +245,51 @@ func (m *Machine) tick() (bool, byte) {
 	case program.OP_ASSET:
 		v := m.popValue()
 		switch v := v.(type) {
-		case core.Asset:
+		case internal.Asset:
 			m.pushValue(v)
-		case core.Monetary:
+		case internal.Monetary:
 			m.pushValue(v.Asset)
-		case core.Funding:
+		case internal.Funding:
 			m.pushValue(v.Asset)
 		default:
 			return true, EXIT_FAIL_INVALID
 		}
 
 	case program.OP_MONETARY_NEW:
-		amount := pop[core.Number](m)
-		asset := pop[core.Asset](m)
-		m.pushValue(core.Monetary{
+		amount := pop[internal.Number](m)
+		asset := pop[internal.Asset](m)
+		m.pushValue(internal.Monetary{
 			Asset:  asset,
 			Amount: amount,
 		})
 
 	case program.OP_MONETARY_ADD:
-		b := pop[core.Monetary](m)
-		a := pop[core.Monetary](m)
+		b := pop[internal.Monetary](m)
+		a := pop[internal.Monetary](m)
 		if a.Asset != b.Asset {
 			return true, EXIT_FAIL_INVALID
 		}
-		m.pushValue(core.Monetary{
+		m.pushValue(internal.Monetary{
 			Asset:  a.Asset,
 			Amount: a.Amount.Add(b.Amount),
 		})
 
 	case program.OP_MAKE_ALLOTMENT:
-		n := pop[core.Number](m)
-		portions := make([]core.Portion, n.Uint64())
+		n := pop[internal.Number](m)
+		portions := make([]internal.Portion, n.Uint64())
 		for i := uint64(0); i < n.Uint64(); i++ {
-			p := pop[core.Portion](m)
+			p := pop[internal.Portion](m)
 			portions[i] = p
 		}
-		allotment, err := core.NewAllotment(portions)
+		allotment, err := internal.NewAllotment(portions)
 		if err != nil {
 			return true, EXIT_FAIL_INVALID
 		}
 		m.pushValue(*allotment)
 
 	case program.OP_TAKE_ALL:
-		overdraft := pop[core.Monetary](m)
-		account := pop[core.AccountAddress](m)
+		overdraft := pop[internal.Monetary](m)
+		account := pop[internal.AccountAddress](m)
 		funding, err := m.withdrawAll(account, overdraft.Asset, overdraft.Amount)
 		if err != nil {
 			return true, EXIT_FAIL_INVALID
@@ -296,8 +297,8 @@ func (m *Machine) tick() (bool, byte) {
 		m.pushValue(*funding)
 
 	case program.OP_TAKE_ALWAYS:
-		mon := pop[core.Monetary](m)
-		account := pop[core.AccountAddress](m)
+		mon := pop[internal.Monetary](m)
+		account := pop[internal.AccountAddress](m)
 		funding, err := m.withdrawAlways(account, mon)
 		if err != nil {
 			return true, EXIT_FAIL_INVALID
@@ -305,8 +306,8 @@ func (m *Machine) tick() (bool, byte) {
 		m.pushValue(*funding)
 
 	case program.OP_TAKE:
-		mon := pop[core.Monetary](m)
-		funding := pop[core.Funding](m)
+		mon := pop[internal.Monetary](m)
+		funding := pop[internal.Funding](m)
 		if funding.Asset != mon.Asset {
 			return true, EXIT_FAIL_INVALID
 		}
@@ -318,18 +319,18 @@ func (m *Machine) tick() (bool, byte) {
 		m.pushValue(result)
 
 	case program.OP_TAKE_MAX:
-		mon := pop[core.Monetary](m)
-		funding := pop[core.Funding](m)
+		mon := pop[internal.Monetary](m)
+		funding := pop[internal.Funding](m)
 		if funding.Asset != mon.Asset {
 			return true, EXIT_FAIL_INVALID
 		}
-		missing := core.NewMonetaryInt(0)
+		missing := internal.NewMonetaryInt(0)
 		total := funding.Total()
 		if mon.Amount.Gt(total) {
 			missing = mon.Amount.Sub(total)
 		}
 		result, remainder := funding.TakeMax(mon.Amount)
-		m.pushValue(core.Monetary{
+		m.pushValue(internal.Monetary{
 			Asset:  mon.Asset,
 			Amount: missing,
 		})
@@ -337,19 +338,19 @@ func (m *Machine) tick() (bool, byte) {
 		m.pushValue(result)
 
 	case program.OP_FUNDING_ASSEMBLE:
-		num := pop[core.Number](m)
+		num := pop[internal.Number](m)
 		n := int(num.Uint64())
 		if n == 0 {
 			return true, EXIT_FAIL_INVALID
 		}
-		first := pop[core.Funding](m)
-		result := core.Funding{
+		first := pop[internal.Funding](m)
+		result := internal.Funding{
 			Asset: first.Asset,
 		}
-		fundings_rev := make([]core.Funding, n)
+		fundings_rev := make([]internal.Funding, n)
 		fundings_rev[0] = first
 		for i := 1; i < n; i++ {
-			f := pop[core.Funding](m)
+			f := pop[internal.Funding](m)
 			if f.Asset != result.Asset {
 				return true, EXIT_FAIL_INVALID
 			}
@@ -365,42 +366,42 @@ func (m *Machine) tick() (bool, byte) {
 		m.pushValue(result)
 
 	case program.OP_FUNDING_SUM:
-		funding := pop[core.Funding](m)
+		funding := pop[internal.Funding](m)
 		sum := funding.Total()
 		m.pushValue(funding)
-		m.pushValue(core.Monetary{
+		m.pushValue(internal.Monetary{
 			Asset:  funding.Asset,
 			Amount: sum,
 		})
 
 	case program.OP_FUNDING_REVERSE:
-		funding := pop[core.Funding](m)
+		funding := pop[internal.Funding](m)
 		result := funding.Reverse()
 		m.pushValue(result)
 
 	case program.OP_ALLOC:
-		allotment := pop[core.Allotment](m)
-		monetary := pop[core.Monetary](m)
+		allotment := pop[internal.Allotment](m)
+		monetary := pop[internal.Monetary](m)
 		total := monetary.Amount
 		parts := allotment.Allocate(total)
 		for i := len(parts) - 1; i >= 0; i-- {
-			m.pushValue(core.Monetary{
+			m.pushValue(internal.Monetary{
 				Asset:  monetary.Asset,
 				Amount: parts[i],
 			})
 		}
 
 	case program.OP_REPAY:
-		m.repay(pop[core.Funding](m))
+		m.repay(pop[internal.Funding](m))
 
 	case program.OP_SEND:
-		dest := pop[core.AccountAddress](m)
-		funding := pop[core.Funding](m)
+		dest := pop[internal.AccountAddress](m)
+		funding := pop[internal.Funding](m)
 		m.credit(dest, funding)
 		for _, part := range funding.Parts {
 			src := part.Account
 			amt := part.Amount
-			if amt.Eq(core.NewMonetaryInt(0)) {
+			if amt.Eq(internal.NewMonetaryInt(0)) {
 				continue
 			}
 			m.Postings = append(m.Postings, Posting{
@@ -412,16 +413,16 @@ func (m *Machine) tick() (bool, byte) {
 		}
 
 	case program.OP_TX_META:
-		k := pop[core.String](m)
+		k := pop[internal.String](m)
 		v := m.popValue()
 		m.TxMeta[string(k)] = v
 
 	case program.OP_ACCOUNT_META:
-		a := pop[core.AccountAddress](m)
-		k := pop[core.String](m)
+		a := pop[internal.AccountAddress](m)
+		k := pop[internal.String](m)
 		v := m.popValue()
 		if m.AccountsMeta[a] == nil {
-			m.AccountsMeta[a] = map[string]core.Value{}
+			m.AccountsMeta[a] = map[string]internal.Value{}
 		}
 		m.AccountsMeta[a][string(k)] = v
 
@@ -463,7 +464,7 @@ func (m *Machine) Execute() (byte, error) {
 type BalanceRequest struct {
 	Account  string
 	Asset    string
-	Response chan *core.MonetaryInt
+	Response chan *internal.MonetaryInt
 	Error    error
 }
 
@@ -475,15 +476,15 @@ func (m *Machine) ResolveBalances(ctx context.Context, store Store) error {
 		return errors.New("tried to call ResolveBalances twice")
 	}
 	m.setBalanceCalled = true
-	m.Balances = make(map[core.AccountAddress]map[core.Asset]*core.MonetaryInt)
+	m.Balances = make(map[internal.AccountAddress]map[internal.Asset]*internal.MonetaryInt)
 	// for every account that we need balances of, check if it's there
 	for addr, neededAssets := range m.Program.NeededBalances {
 		account, ok := m.getResource(addr)
 		if !ok {
 			return errors.New("invalid program (resolve balances: invalid address of account)")
 		}
-		accountAddress := (*account).(core.AccountAddress)
-		m.Balances[accountAddress] = make(map[core.Asset]*core.MonetaryInt)
+		accountAddress := (*account).(internal.AccountAddress)
+		m.Balances[accountAddress] = make(map[internal.Asset]*internal.MonetaryInt)
 		// for every asset, send request
 		for addr := range neededAssets {
 			mon, ok := m.getResource(addr)
@@ -491,9 +492,9 @@ func (m *Machine) ResolveBalances(ctx context.Context, store Store) error {
 				return errors.New("invalid program (resolve balances: invalid address of monetary)")
 			}
 
-			asset := (*mon).(core.HasAsset).GetAsset()
+			asset := (*mon).(internal.HasAsset).GetAsset()
 			if string(accountAddress) == "world" {
-				m.Balances[accountAddress][asset] = core.NewMonetaryInt(0)
+				m.Balances[accountAddress][asset] = internal.NewMonetaryInt(0)
 				continue
 			}
 
@@ -501,9 +502,9 @@ func (m *Machine) ResolveBalances(ctx context.Context, store Store) error {
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("could not get account %q", account))
 			}
-			amt := account.Volumes[string(asset)].Balance().OrZero()
+			amt := account.Volumes[string(asset)].Balance()
 
-			m.Balances[accountAddress][asset] = amt
+			m.Balances[accountAddress][asset] = internal.NewMonetaryIntFromBigInt(amt)
 		}
 	}
 	return nil
@@ -513,7 +514,7 @@ type ResourceRequest struct {
 	Account  string
 	Key      string
 	Asset    string
-	Response chan core.Value
+	Response chan internal.Value
 	Error    error
 }
 
@@ -526,7 +527,7 @@ func (m *Machine) ResolveResources(ctx context.Context, store Store) error {
 	for len(m.Resources) != len(m.UnresolvedResources) {
 		idx := len(m.Resources)
 		res := m.UnresolvedResources[idx]
-		var val core.Value
+		var val internal.Value
 		switch res := res.(type) {
 		case program.Constant:
 			val = res.Inner
@@ -543,13 +544,13 @@ func (m *Machine) ResolveResources(ctx context.Context, store Store) error {
 					"variable '%s': tried to request metadata of an account which has not yet been solved",
 					res.Name)
 			}
-			if (*sourceAccount).GetType() != core.TypeAccount {
+			if (*sourceAccount).GetType() != internal.TypeAccount {
 				return fmt.Errorf(
 					"variable '%s': tried to request metadata on wrong entity: %v instead of account",
 					res.Name, (*sourceAccount).GetType())
 			}
 
-			address := string((*sourceAccount).(core.AccountAddress))
+			address := string((*sourceAccount).(internal.AccountAddress))
 			account, err := store.GetAccountWithVolumes(ctx, address)
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("could not get account %s", address))
@@ -565,7 +566,7 @@ func (m *Machine) ResolveResources(ctx context.Context, store Store) error {
 			if err != nil {
 				return errors.Wrap(err, "marshaling metadata")
 			}
-			val, err = core.NewValueFromTypedJSON(data)
+			val, err = internal.NewValueFromTypedJSON(data)
 			if err != nil {
 				return NewScriptError(ScriptErrorCompilationFailed,
 					errors.Wrap(err, fmt.Sprintf("invalid format for metadata at key %v for account %s",
@@ -578,28 +579,28 @@ func (m *Machine) ResolveResources(ctx context.Context, store Store) error {
 					"variable '%s': tried to request metadata of an account which has not yet been solved",
 					res.Name)
 			}
-			if (*sourceAccount).GetType() != core.TypeAccount {
+			if (*sourceAccount).GetType() != internal.TypeAccount {
 				return fmt.Errorf(
 					"variable '%s': tried to request balance of an account which has not yet been solved",
 					res.Name)
 			}
 
-			address := string((*sourceAccount).(core.AccountAddress))
+			address := string((*sourceAccount).(internal.AccountAddress))
 			account, err := store.GetAccountWithVolumes(ctx, address)
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("could not get account %s", address))
 			}
 
-			amt := account.Volumes[res.Asset].Balance().OrZero()
-			if amt.Ltz() {
+			amt := account.Volumes[res.Asset].Balance()
+			if amt.Cmp(core.Zero) < 0 {
 				return fmt.Errorf(
 					"variable '%s': tried to request the balance of account %s for asset %s: received %s: monetary amounts must be non-negative",
 					res.Name, address, res.Asset, amt)
 			}
 
-			val = core.Monetary{
-				Asset:  core.Asset(res.Asset),
-				Amount: amt,
+			val = internal.Monetary{
+				Asset:  internal.Asset(res.Asset),
+				Amount: internal.NewMonetaryIntFromBigInt(amt),
 			}
 		default:
 			panic(fmt.Errorf("type %T not implemented", res))
@@ -609,7 +610,7 @@ func (m *Machine) ResolveResources(ctx context.Context, store Store) error {
 	return nil
 }
 
-func (m *Machine) SetVars(vars map[string]core.Value) error {
+func (m *Machine) SetVars(vars map[string]internal.Value) error {
 	v, err := m.Program.ParseVariables(vars)
 	if err != nil {
 		return err

--- a/components/ledger/pkg/machine/vm/machine_kept_test.go
+++ b/components/ledger/pkg/machine/vm/machine_kept_test.go
@@ -3,7 +3,7 @@ package vm
 import (
 	"testing"
 
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 )
 
 func TestKeptDestinationAllotment(t *testing.T) {
@@ -21,23 +21,23 @@ func TestKeptDestinationAllotment(t *testing.T) {
 	)`)
 	tc.setBalance("a", "GEM", 1)
 	tc.expected = CaseResult{
-		Printed: []core.Value{},
+		Printed: []internal.Value{},
 		Postings: []Posting{
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(1),
+				Amount:      internal.NewMonetaryInt(1),
 				Source:      "a",
 				Destination: "x",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(24),
+				Amount:      internal.NewMonetaryInt(24),
 				Source:      "world",
 				Destination: "x",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(25),
+				Amount:      internal.NewMonetaryInt(25),
 				Source:      "world",
 				Destination: "y",
 			},
@@ -73,41 +73,41 @@ func TestKeptComplex(t *testing.T) {
 	tc.setBalance("bar", "GEM", 40)
 	tc.setBalance("baz", "GEM", 40)
 	tc.expected = CaseResult{
-		Printed: []core.Value{},
+		Printed: []internal.Value{},
 		Postings: []Posting{
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(2),
+				Amount:      internal.NewMonetaryInt(2),
 				Source:      "foo",
 				Destination: "arst",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(18),
+				Amount:      internal.NewMonetaryInt(18),
 				Source:      "foo",
 				Destination: "thing",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(24),
+				Amount:      internal.NewMonetaryInt(24),
 				Source:      "bar",
 				Destination: "thing",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(16),
+				Amount:      internal.NewMonetaryInt(16),
 				Source:      "bar",
 				Destination: "qux",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(4),
+				Amount:      internal.NewMonetaryInt(4),
 				Source:      "baz",
 				Destination: "qux",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(25),
+				Amount:      internal.NewMonetaryInt(25),
 				Source:      "baz",
 				Destination: "quz",
 			},

--- a/components/ledger/pkg/machine/vm/machine_overdraft_test.go
+++ b/components/ledger/pkg/machine/vm/machine_overdraft_test.go
@@ -3,7 +3,7 @@ package vm
 import (
 	"testing"
 
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 )
 
 func TestOverdraftNotEnough(t *testing.T) {
@@ -14,7 +14,7 @@ func TestOverdraftNotEnough(t *testing.T) {
 	)`)
 	tc.setBalance("foo", "GEM", 89)
 	tc.expected = CaseResult{
-		Printed:  []core.Value{},
+		Printed:  []internal.Value{},
 		Postings: []Posting{},
 		ExitCode: EXIT_FAIL_INSUFFICIENT_FUNDS,
 	}
@@ -29,11 +29,11 @@ func TestOverdraftEnough(t *testing.T) {
 		)`)
 	tc.setBalance("foo", "GEM", 90)
 	tc.expected = CaseResult{
-		Printed: []core.Value{},
+		Printed: []internal.Value{},
 		Postings: []Posting{
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(100),
+				Amount:      internal.NewMonetaryInt(100),
 				Source:      "foo",
 				Destination: "world",
 			},
@@ -51,11 +51,11 @@ func TestOverdraftUnbounded(t *testing.T) {
 		)`)
 	tc.setBalance("foo", "GEM", 90)
 	tc.expected = CaseResult{
-		Printed: []core.Value{},
+		Printed: []internal.Value{},
 		Postings: []Posting{
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(1000),
+				Amount:      internal.NewMonetaryInt(1000),
 				Source:      "foo",
 				Destination: "world",
 			},
@@ -81,23 +81,23 @@ func TestOverdraftSourceAllotmentSuccess(t *testing.T) {
 	tc.setBalance("bar", "GEM", 20)
 	tc.setBalance("baz", "GEM", 0)
 	tc.expected = CaseResult{
-		Printed: []core.Value{},
+		Printed: []internal.Value{},
 		Postings: []Posting{
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(50),
+				Amount:      internal.NewMonetaryInt(50),
 				Source:      "foo",
 				Destination: "world",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(40),
+				Amount:      internal.NewMonetaryInt(40),
 				Source:      "bar",
 				Destination: "world",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(10),
+				Amount:      internal.NewMonetaryInt(10),
 				Source:      "baz",
 				Destination: "world",
 			},
@@ -125,29 +125,29 @@ func TestOverdraftSourceInOrderSuccess(t *testing.T) {
 	tc.setBalance("baz", "GEM", 0)
 	tc.setBalance("qux", "GEM", 0)
 	tc.expected = CaseResult{
-		Printed: []core.Value{},
+		Printed: []internal.Value{},
 		Postings: []Posting{
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(10),
+				Amount:      internal.NewMonetaryInt(10),
 				Source:      "foo",
 				Destination: "world",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(20),
+				Amount:      internal.NewMonetaryInt(20),
 				Source:      "bar",
 				Destination: "world",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(20),
+				Amount:      internal.NewMonetaryInt(20),
 				Source:      "baz",
 				Destination: "world",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(50),
+				Amount:      internal.NewMonetaryInt(50),
 				Source:      "qux",
 				Destination: "world",
 			},
@@ -174,23 +174,23 @@ func TestOverdraftBalanceTracking(t *testing.T) {
 	`)
 	tc.setBalance("foo", "GEM", 0)
 	tc.expected = CaseResult{
-		Printed: []core.Value{},
+		Printed: []internal.Value{},
 		Postings: []Posting{
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(100),
+				Amount:      internal.NewMonetaryInt(100),
 				Source:      "foo",
 				Destination: "world",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(200),
+				Amount:      internal.NewMonetaryInt(200),
 				Source:      "foo",
 				Destination: "world",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(300),
+				Amount:      internal.NewMonetaryInt(300),
 				Source:      "foo",
 				Destination: "world",
 			},
@@ -212,17 +212,17 @@ func TestWorldIsUnbounded(t *testing.T) {
 	)
 	`)
 	tc.expected = CaseResult{
-		Printed: []core.Value{},
+		Printed: []internal.Value{},
 		Postings: []Posting{
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(100),
+				Amount:      internal.NewMonetaryInt(100),
 				Source:      "world",
 				Destination: "foo",
 			},
 			{
 				Asset:       "GEM",
-				Amount:      core.NewMonetaryInt(200),
+				Amount:      internal.NewMonetaryInt(200),
 				Source:      "world",
 				Destination: "foo",
 			},
@@ -248,7 +248,7 @@ func TestOverdraftComplexFailure(t *testing.T) {
 	tc.setBalance("bar", "GEM", 20)
 	tc.setBalance("baz", "GEM", 0)
 	tc.expected = CaseResult{
-		Printed:  []core.Value{},
+		Printed:  []internal.Value{},
 		Postings: []Posting{},
 		ExitCode: EXIT_FAIL_INSUFFICIENT_FUNDS,
 	}
@@ -263,7 +263,7 @@ func TestNegativeBalance(t *testing.T) {
 		)`)
 	tc.setBalance("foo", "GEM", -50)
 	tc.expected = CaseResult{
-		Printed:  []core.Value{},
+		Printed:  []internal.Value{},
 		Postings: []Posting{},
 		ExitCode: EXIT_FAIL_INSUFFICIENT_FUNDS,
 	}

--- a/components/ledger/pkg/machine/vm/program/program.go
+++ b/components/ledger/pkg/machine/vm/program/program.go
@@ -5,15 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/pkg/errors"
 )
 
 type Program struct {
 	Instructions   []byte
 	Resources      []Resource
-	Sources        []core.Address
-	NeededBalances map[core.Address]map[core.Address]struct{}
+	Sources        []internal.Address
+	NeededBalances map[internal.Address]map[internal.Address]struct{}
 }
 
 func (p Program) String() string {
@@ -40,30 +40,30 @@ func (p Program) String() string {
 	return out
 }
 
-func (p *Program) ParseVariables(vars map[string]core.Value) (map[string]core.Value, error) {
-	variables := make(map[string]core.Value)
+func (p *Program) ParseVariables(vars map[string]internal.Value) (map[string]internal.Value, error) {
+	variables := make(map[string]internal.Value)
 	for _, res := range p.Resources {
 		if variable, ok := res.(Variable); ok {
 			if val, ok := vars[variable.Name]; ok && val.GetType() == variable.Typ {
 				variables[variable.Name] = val
 				switch val.GetType() {
-				case core.TypeAccount:
-					if err := core.ParseAccountAddress(val.(core.AccountAddress)); err != nil {
+				case internal.TypeAccount:
+					if err := internal.ParseAccountAddress(val.(internal.AccountAddress)); err != nil {
 						return nil, errors.Wrapf(err, "invalid variable $%s value '%s'",
-							variable.Name, string(val.(core.AccountAddress)))
+							variable.Name, string(val.(internal.AccountAddress)))
 					}
-				case core.TypeMonetary:
-					if err := core.ParseMonetary(val.(core.Monetary)); err != nil {
+				case internal.TypeMonetary:
+					if err := internal.ParseMonetary(val.(internal.Monetary)); err != nil {
 						return nil, errors.Wrapf(err, "invalid variable $%s value '%s'",
-							variable.Name, val.(core.Monetary).String())
+							variable.Name, val.(internal.Monetary).String())
 					}
-				case core.TypePortion:
-					if err := core.ValidatePortionSpecific(val.(core.Portion)); err != nil {
+				case internal.TypePortion:
+					if err := internal.ValidatePortionSpecific(val.(internal.Portion)); err != nil {
 						return nil, errors.Wrapf(err, "invalid variable $%s value '%s'",
-							variable.Name, val.(core.Portion).String())
+							variable.Name, val.(internal.Portion).String())
 					}
-				case core.TypeString:
-				case core.TypeNumber:
+				case internal.TypeString:
+				case internal.TypeNumber:
 				default:
 					return nil, fmt.Errorf("unsupported type for variable $%s: %s",
 						variable.Name, val.GetType())
@@ -83,15 +83,15 @@ func (p *Program) ParseVariables(vars map[string]core.Value) (map[string]core.Va
 	return variables, nil
 }
 
-func (p *Program) ParseVariablesJSON(vars map[string]json.RawMessage) (map[string]core.Value, error) {
-	variables := make(map[string]core.Value)
+func (p *Program) ParseVariablesJSON(vars map[string]json.RawMessage) (map[string]internal.Value, error) {
+	variables := make(map[string]internal.Value)
 	for _, res := range p.Resources {
 		if param, ok := res.(Variable); ok {
 			data, ok := vars[param.Name]
 			if !ok {
 				return nil, fmt.Errorf("missing variable $%s", param.Name)
 			}
-			val, err := core.NewValueFromJSON(param.Typ, data)
+			val, err := internal.NewValueFromJSON(param.Typ, data)
 			if err != nil {
 				return nil, fmt.Errorf(
 					"invalid JSON value for variable $%s of type %v: %w",
@@ -111,19 +111,19 @@ func (p *Program) GetInvolvedAccounts(vars map[string]json.RawMessage) ([]string
 	involvedAccountsMap := map[string]struct{}{}
 	for _, resource := range p.Resources {
 		switch resource.GetType() {
-		case core.TypeAccount:
+		case internal.TypeAccount:
 			switch resource := resource.(type) {
 			case Constant:
 				switch inner := resource.Inner.(type) {
-				case core.AccountAddress:
+				case internal.AccountAddress:
 					involvedAccountsMap[string(inner)] = struct{}{}
 				}
 			case Variable:
-				value, err := core.NewValueFromJSON(core.TypeAccount, vars[resource.Name])
+				value, err := internal.NewValueFromJSON(internal.TypeAccount, vars[resource.Name])
 				if err != nil {
 					return nil, err
 				}
-				involvedAccountsMap[string((value).(core.AccountAddress))] = struct{}{}
+				involvedAccountsMap[string((value).(internal.AccountAddress))] = struct{}{}
 			}
 		}
 	}
@@ -140,19 +140,19 @@ func (p *Program) GetInvolvedSources(vars map[string]json.RawMessage) ([]string,
 		resource := p.Resources[address]
 
 		switch resource.GetType() {
-		case core.TypeAccount:
+		case internal.TypeAccount:
 			switch resource := resource.(type) {
 			case Constant:
 				switch inner := resource.Inner.(type) {
-				case core.AccountAddress:
+				case internal.AccountAddress:
 					involvedSourcesMap[string(inner)] = struct{}{}
 				}
 			case Variable:
-				value, err := core.NewValueFromJSON(core.TypeAccount, vars[resource.Name])
+				value, err := internal.NewValueFromJSON(internal.TypeAccount, vars[resource.Name])
 				if err != nil {
 					return nil, err
 				}
-				involvedSourcesMap[string((value).(core.AccountAddress))] = struct{}{}
+				involvedSourcesMap[string((value).(internal.AccountAddress))] = struct{}{}
 			}
 		}
 	}

--- a/components/ledger/pkg/machine/vm/program/resource.go
+++ b/components/ledger/pkg/machine/vm/program/resource.go
@@ -3,47 +3,47 @@ package program
 import (
 	"fmt"
 
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 )
 
 type Resource interface {
-	GetType() core.Type
+	GetType() internal.Type
 }
 
 type Constant struct {
-	Inner core.Value
+	Inner internal.Value
 }
 
-func (c Constant) GetType() core.Type { return c.Inner.GetType() }
-func (c Constant) String() string     { return fmt.Sprintf("%v", c.Inner) }
+func (c Constant) GetType() internal.Type { return c.Inner.GetType() }
+func (c Constant) String() string         { return fmt.Sprintf("%v", c.Inner) }
 
 type Variable struct {
-	Typ  core.Type
+	Typ  internal.Type
 	Name string
 }
 
-func (p Variable) GetType() core.Type { return p.Typ }
-func (p Variable) String() string     { return fmt.Sprintf("<%v %v>", p.Typ, p.Name) }
+func (p Variable) GetType() internal.Type { return p.Typ }
+func (p Variable) String() string         { return fmt.Sprintf("<%v %v>", p.Typ, p.Name) }
 
 type VariableAccountMetadata struct {
-	Typ     core.Type
+	Typ     internal.Type
 	Name    string
-	Account core.Address
+	Account internal.Address
 	Key     string
 }
 
-func (m VariableAccountMetadata) GetType() core.Type { return m.Typ }
+func (m VariableAccountMetadata) GetType() internal.Type { return m.Typ }
 func (m VariableAccountMetadata) String() string {
 	return fmt.Sprintf("<%v %v meta(%v, %v)>", m.Typ, m.Name, m.Account, m.Key)
 }
 
 type VariableAccountBalance struct {
 	Name    string
-	Account core.Address
+	Account internal.Address
 	Asset   string
 }
 
-func (a VariableAccountBalance) GetType() core.Type { return core.TypeMonetary }
+func (a VariableAccountBalance) GetType() internal.Type { return internal.TypeMonetary }
 func (a VariableAccountBalance) String() string {
-	return fmt.Sprintf("<%v %v balance(%v, %v)>", core.TypeMonetary, a.Name, a.Account, a.Asset)
+	return fmt.Sprintf("<%v %v balance(%v, %v)>", internal.TypeMonetary, a.Name, a.Account, a.Asset)
 }

--- a/components/ledger/pkg/machine/vm/program/resource_test.go
+++ b/components/ledger/pkg/machine/vm/program/resource_test.go
@@ -3,34 +3,34 @@ package program
 import (
 	"testing"
 
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 	"github.com/stretchr/testify/require"
 )
 
 func TestResource(t *testing.T) {
 	c := Constant{
-		Inner: core.NewMonetaryInt(0),
+		Inner: internal.NewMonetaryInt(0),
 	}
 	c.GetType()
 	require.Equal(t, "0", c.String())
 
 	v := Variable{
-		Typ:  core.TypeAccount,
+		Typ:  internal.TypeAccount,
 		Name: "acc",
 	}
 	require.Equal(t, "<account acc>", v.String())
 
 	vab := VariableAccountBalance{
 		Name:    "name",
-		Account: core.Address(0),
+		Account: internal.Address(0),
 		Asset:   "EUR",
 	}
 	require.Equal(t, "<monetary name balance(0, EUR)>", vab.String())
 
 	vam := VariableAccountMetadata{
-		Typ:     core.TypeMonetary,
+		Typ:     internal.TypeMonetary,
 		Name:    "name",
-		Account: core.Address(0),
+		Account: internal.Address(0),
 		Key:     "key",
 	}
 	require.Equal(t, "<monetary name meta(0, key)>", vam.String())

--- a/components/ledger/pkg/machine/vm/stack.go
+++ b/components/ledger/pkg/machine/vm/stack.go
@@ -3,17 +3,17 @@ package vm
 import (
 	"fmt"
 
-	"github.com/formancehq/ledger/pkg/core"
+	"github.com/formancehq/ledger/pkg/machine/internal"
 )
 
-func (m *Machine) popValue() core.Value {
+func (m *Machine) popValue() internal.Value {
 	l := len(m.Stack)
 	x := m.Stack[l-1]
 	m.Stack = m.Stack[:l-1]
 	return x
 }
 
-func pop[T core.Value](m *Machine) T {
+func pop[T internal.Value](m *Machine) T {
 	x := m.popValue()
 	if v, ok := x.(T); ok {
 		return v
@@ -21,6 +21,6 @@ func pop[T core.Value](m *Machine) T {
 	panic(fmt.Errorf("unexpected type '%T' on stack", x))
 }
 
-func (m *Machine) pushValue(v core.Value) {
+func (m *Machine) pushValue(v internal.Value) {
 	m.Stack = append(m.Stack, v)
 }

--- a/components/ledger/pkg/storage/sqlstorage/ledger/accounts_test.go
+++ b/components/ledger/pkg/storage/sqlstorage/ledger/accounts_test.go
@@ -2,6 +2,7 @@ package ledger_test
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/formancehq/ledger/pkg/core"
@@ -89,8 +90,8 @@ func testComputeAccount(t *testing.T, store storage.LedgerStore) {
 	require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 		"world": {
 			"USD/2": {
-				Input:  core.NewMonetaryInt(100),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(100),
+				Output: big.NewInt(0),
 			},
 		},
 	}))
@@ -99,7 +100,7 @@ func testComputeAccount(t *testing.T, store storage.LedgerStore) {
 			Postings: []core.Posting{{
 				Source:      "world",
 				Destination: "bank",
-				Amount:      core.NewMonetaryInt(10),
+				Amount:      big.NewInt(10),
 				Asset:       "USD/2",
 			}},
 		},
@@ -128,8 +129,8 @@ func testComputeAccount(t *testing.T, store storage.LedgerStore) {
 		},
 		Volumes: map[string]core.Volumes{
 			"USD/2": {
-				Input:  core.NewMonetaryInt(10),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(10),
+				Output: big.NewInt(0),
 			},
 		},
 	}, *account)

--- a/components/ledger/pkg/storage/sqlstorage/ledger/balances.go
+++ b/components/ledger/pkg/storage/sqlstorage/ledger/balances.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -52,10 +53,9 @@ func (s *Store) GetBalancesAggregated(ctx context.Context, q storage.BalancesQue
 			return nil, s.error(err)
 		}
 
-		balances, err := core.ParseMonetaryInt(balancesStr)
-
-		if err != nil {
-			return nil, s.error(err)
+		balances, ok := new(big.Int).SetString(balancesStr, 10)
+		if !ok {
+			panic("unable to restore big int")
 		}
 
 		aggregatedBalances[asset] = balances
@@ -126,7 +126,7 @@ func (s *Store) GetBalances(ctx context.Context, q storage.BalancesQuery) (api.C
 			if err != nil {
 				return api.Cursor[core.AccountsBalances]{}, s.error(err)
 			}
-			accountsBalances[currentAccount][asset] = core.NewMonetaryInt(balances)
+			accountsBalances[currentAccount][asset] = big.NewInt(balances)
 		}
 
 		accounts = append(accounts, accountsBalances)

--- a/components/ledger/pkg/storage/sqlstorage/ledger/balances_test.go
+++ b/components/ledger/pkg/storage/sqlstorage/ledger/balances_test.go
@@ -2,6 +2,7 @@ package ledger_test
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/formancehq/ledger/pkg/core"
@@ -13,13 +14,13 @@ import (
 func testGetBalances(t *testing.T, store storage.LedgerStore) {
 	require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 		"world": {
-			"USD": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(200)),
+			"USD": core.NewEmptyVolumes().WithOutput(big.NewInt(200)),
 		},
 		"users:1": {
-			"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(1)),
+			"USD": core.NewEmptyVolumes().WithInput(big.NewInt(1)),
 		},
 		"central_bank": {
-			"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(199)),
+			"USD": core.NewEmptyVolumes().WithInput(big.NewInt(199)),
 		},
 	}))
 
@@ -36,17 +37,17 @@ func testGetBalances(t *testing.T, store storage.LedgerStore) {
 		assert.Equal(t, []core.AccountsBalances{
 			{
 				"world": core.AssetsBalances{
-					"USD": core.NewMonetaryInt(-200),
+					"USD": big.NewInt(-200),
 				},
 			},
 			{
 				"users:1": core.AssetsBalances{
-					"USD": core.NewMonetaryInt(1),
+					"USD": big.NewInt(1),
 				},
 			},
 			{
 				"central_bank": core.AssetsBalances{
-					"USD": core.NewMonetaryInt(199),
+					"USD": big.NewInt(199),
 				},
 			},
 		}, cursor.Data)
@@ -65,7 +66,7 @@ func testGetBalances(t *testing.T, store storage.LedgerStore) {
 		assert.Equal(t, []core.AccountsBalances{
 			{
 				"world": core.AssetsBalances{
-					"USD": core.NewMonetaryInt(-200),
+					"USD": big.NewInt(-200),
 				},
 			},
 		}, cursor.Data)
@@ -85,7 +86,7 @@ func testGetBalances(t *testing.T, store storage.LedgerStore) {
 		assert.Equal(t, []core.AccountsBalances{
 			{
 				"users:1": core.AssetsBalances{
-					"USD": core.NewMonetaryInt(1),
+					"USD": big.NewInt(1),
 				},
 			},
 		}, cursor.Data)
@@ -105,12 +106,12 @@ func testGetBalances(t *testing.T, store storage.LedgerStore) {
 		assert.Equal(t, []core.AccountsBalances{
 			{
 				"users:1": core.AssetsBalances{
-					"USD": core.NewMonetaryInt(1),
+					"USD": big.NewInt(1),
 				},
 			},
 			{
 				"central_bank": core.AssetsBalances{
-					"USD": core.NewMonetaryInt(199),
+					"USD": big.NewInt(199),
 				},
 			},
 		}, cursor.Data)
@@ -131,7 +132,7 @@ func testGetBalances(t *testing.T, store storage.LedgerStore) {
 		assert.Equal(t, []core.AccountsBalances{
 			{
 				"users:1": core.AssetsBalances{
-					"USD": core.NewMonetaryInt(1),
+					"USD": big.NewInt(1),
 				},
 			},
 		}, cursor.Data)
@@ -141,13 +142,13 @@ func testGetBalances(t *testing.T, store storage.LedgerStore) {
 func testGetBalancesAggregated(t *testing.T, store storage.LedgerStore) {
 	require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 		"world": {
-			"USD": core.NewEmptyVolumes().WithOutput(core.NewMonetaryInt(200)),
+			"USD": core.NewEmptyVolumes().WithOutput(big.NewInt(200)),
 		},
 		"users:1": {
-			"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(1)),
+			"USD": core.NewEmptyVolumes().WithInput(big.NewInt(1)),
 		},
 		"central_bank": {
-			"USD": core.NewEmptyVolumes().WithInput(core.NewMonetaryInt(199)),
+			"USD": core.NewEmptyVolumes().WithInput(big.NewInt(199)),
 		},
 	}))
 
@@ -157,6 +158,6 @@ func testGetBalancesAggregated(t *testing.T, store storage.LedgerStore) {
 	cursor, err := store.GetBalancesAggregated(context.Background(), q)
 	assert.NoError(t, err)
 	assert.Equal(t, core.AssetsBalances{
-		"USD": core.NewMonetaryInt(0),
+		"USD": big.NewInt(0),
 	}, cursor)
 }

--- a/components/ledger/pkg/storage/sqlstorage/ledger/migrates/9-add-pre-post-volumes/any.go
+++ b/components/ledger/pkg/storage/sqlstorage/ledger/migrates/9-add-pre-post-volumes/any.go
@@ -108,10 +108,7 @@ func Upgrade(ctx context.Context, schema schema.Schema, sqlTx *schema.Tx) error 
 
 		for account, accountVolumes := range postCommitVolumes {
 			for asset, volumes := range accountVolumes {
-				aggregatedVolumes.SetVolumes(account, asset, core.Volumes{
-					Input:  volumes.Input.OrZero(),
-					Output: volumes.Output.OrZero(),
-				})
+				aggregatedVolumes.SetVolumes(account, asset, volumes.CopyWithZerosIfNeeded())
 			}
 		}
 

--- a/components/ledger/pkg/storage/sqlstorage/ledger/migrates/9-add-pre-post-volumes/any_test.go
+++ b/components/ledger/pkg/storage/sqlstorage/ledger/migrates/9-add-pre-post-volumes/any_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"regexp"
 	"strings"
 	"testing"
@@ -34,35 +35,35 @@ var testCases = []testCase{
 			{
 				Source:      "world",
 				Destination: "bank",
-				Amount:      core.NewMonetaryInt(100),
+				Amount:      big.NewInt(100),
 				Asset:       "USD",
 			},
 		},
 		expectedPreCommitVolumes: core.AccountsAssetsVolumes{
 			"world": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(0),
 				},
 			},
 			"bank": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(0),
 				},
 			},
 		},
 		expectedPostCommitVolumes: core.AccountsAssetsVolumes{
 			"world": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(100),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(100),
 				},
 			},
 			"bank": {
 				"USD": {
-					Input:  core.NewMonetaryInt(100),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(100),
+					Output: big.NewInt(0),
 				},
 			},
 		},
@@ -72,35 +73,35 @@ var testCases = []testCase{
 			{
 				Source:      "world",
 				Destination: "bank2",
-				Amount:      core.NewMonetaryInt(100),
+				Amount:      big.NewInt(100),
 				Asset:       "USD",
 			},
 		},
 		expectedPreCommitVolumes: core.AccountsAssetsVolumes{
 			"world": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(100),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(100),
 				},
 			},
 			"bank2": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(0),
 				},
 			},
 		},
 		expectedPostCommitVolumes: core.AccountsAssetsVolumes{
 			"world": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(200),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(200),
 				},
 			},
 			"bank2": {
 				"USD": {
-					Input:  core.NewMonetaryInt(100),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(100),
+					Output: big.NewInt(0),
 				},
 			},
 		},
@@ -110,53 +111,53 @@ var testCases = []testCase{
 			{
 				Source:      "world",
 				Destination: "bank",
-				Amount:      core.NewMonetaryInt(100),
+				Amount:      big.NewInt(100),
 				Asset:       "USD",
 			},
 			{
 				Source:      "world",
 				Destination: "bank2",
-				Amount:      core.NewMonetaryInt(100),
+				Amount:      big.NewInt(100),
 				Asset:       "USD",
 			},
 		},
 		expectedPreCommitVolumes: core.AccountsAssetsVolumes{
 			"world": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(200),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(200),
 				},
 			},
 			"bank": {
 				"USD": {
-					Input:  core.NewMonetaryInt(100),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(100),
+					Output: big.NewInt(0),
 				},
 			},
 			"bank2": {
 				"USD": {
-					Input:  core.NewMonetaryInt(100),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(100),
+					Output: big.NewInt(0),
 				},
 			},
 		},
 		expectedPostCommitVolumes: core.AccountsAssetsVolumes{
 			"world": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(400),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(400),
 				},
 			},
 			"bank2": {
 				"USD": {
-					Input:  core.NewMonetaryInt(200),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(200),
+					Output: big.NewInt(0),
 				},
 			},
 			"bank": {
 				"USD": {
-					Input:  core.NewMonetaryInt(200),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(200),
+					Output: big.NewInt(0),
 				},
 			},
 		},
@@ -166,53 +167,53 @@ var testCases = []testCase{
 			{
 				Source:      "bank",
 				Destination: "user:1",
-				Amount:      core.NewMonetaryInt(10),
+				Amount:      big.NewInt(10),
 				Asset:       "USD",
 			},
 			{
 				Source:      "bank",
 				Destination: "user:2",
-				Amount:      core.NewMonetaryInt(90),
+				Amount:      big.NewInt(90),
 				Asset:       "USD",
 			},
 		},
 		expectedPreCommitVolumes: core.AccountsAssetsVolumes{
 			"bank": {
 				"USD": {
-					Input:  core.NewMonetaryInt(200),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(200),
+					Output: big.NewInt(0),
 				},
 			},
 			"user:1": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(0),
 				},
 			},
 			"user:2": {
 				"USD": {
-					Input:  core.NewMonetaryInt(0),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(0),
+					Output: big.NewInt(0),
 				},
 			},
 		},
 		expectedPostCommitVolumes: core.AccountsAssetsVolumes{
 			"bank": {
 				"USD": {
-					Input:  core.NewMonetaryInt(200),
-					Output: core.NewMonetaryInt(100),
+					Input:  big.NewInt(200),
+					Output: big.NewInt(100),
 				},
 			},
 			"user:1": {
 				"USD": {
-					Input:  core.NewMonetaryInt(10),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(10),
+					Output: big.NewInt(0),
 				},
 			},
 			"user:2": {
 				"USD": {
-					Input:  core.NewMonetaryInt(90),
-					Output: core.NewMonetaryInt(0),
+					Input:  big.NewInt(90),
+					Output: big.NewInt(0),
 				},
 			},
 		},

--- a/components/ledger/pkg/storage/sqlstorage/ledger/store_test.go
+++ b/components/ledger/pkg/storage/sqlstorage/ledger/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"testing"
 	"time"
 
@@ -87,7 +88,7 @@ var tx1 = core.ExpandedTransaction{
 				{
 					Source:      "world",
 					Destination: "central_bank",
-					Amount:      core.NewMonetaryInt(100),
+					Amount:      big.NewInt(100),
 					Asset:       "USD",
 				},
 			},
@@ -98,28 +99,28 @@ var tx1 = core.ExpandedTransaction{
 	PostCommitVolumes: core.AccountsAssetsVolumes{
 		"world": {
 			"USD": {
-				Input:  core.NewMonetaryInt(0),
-				Output: core.NewMonetaryInt(100),
+				Input:  big.NewInt(0),
+				Output: big.NewInt(100),
 			},
 		},
 		"central_bank": {
 			"USD": {
-				Input:  core.NewMonetaryInt(100),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(100),
+				Output: big.NewInt(0),
 			},
 		},
 	},
 	PreCommitVolumes: core.AccountsAssetsVolumes{
 		"world": {
 			"USD": {
-				Input:  core.NewMonetaryInt(0),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(0),
+				Output: big.NewInt(0),
 			},
 		},
 		"central_bank": {
 			"USD": {
-				Input:  core.NewMonetaryInt(0),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(0),
+				Output: big.NewInt(0),
 			},
 		},
 	},
@@ -132,7 +133,7 @@ var tx2 = core.ExpandedTransaction{
 				{
 					Source:      "world",
 					Destination: "central_bank",
-					Amount:      core.NewMonetaryInt(100),
+					Amount:      big.NewInt(100),
 					Asset:       "USD",
 				},
 			},
@@ -143,28 +144,28 @@ var tx2 = core.ExpandedTransaction{
 	PostCommitVolumes: core.AccountsAssetsVolumes{
 		"world": {
 			"USD": {
-				Input:  core.NewMonetaryInt(0),
-				Output: core.NewMonetaryInt(200),
+				Input:  big.NewInt(0),
+				Output: big.NewInt(200),
 			},
 		},
 		"central_bank": {
 			"USD": {
-				Input:  core.NewMonetaryInt(200),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(200),
+				Output: big.NewInt(0),
 			},
 		},
 	},
 	PreCommitVolumes: core.AccountsAssetsVolumes{
 		"world": {
 			"USD": {
-				Input:  core.NewMonetaryInt(0),
-				Output: core.NewMonetaryInt(100),
+				Input:  big.NewInt(0),
+				Output: big.NewInt(100),
 			},
 		},
 		"central_bank": {
 			"USD": {
-				Input:  core.NewMonetaryInt(100),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(100),
+				Output: big.NewInt(0),
 			},
 		},
 	},
@@ -177,7 +178,7 @@ var tx3 = core.ExpandedTransaction{
 				{
 					Source:      "central_bank",
 					Destination: "users:1",
-					Amount:      core.NewMonetaryInt(1),
+					Amount:      big.NewInt(1),
 					Asset:       "USD",
 				},
 			},
@@ -191,28 +192,28 @@ var tx3 = core.ExpandedTransaction{
 	PreCommitVolumes: core.AccountsAssetsVolumes{
 		"central_bank": {
 			"USD": {
-				Input:  core.NewMonetaryInt(200),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(200),
+				Output: big.NewInt(0),
 			},
 		},
 		"users:1": {
 			"USD": {
-				Input:  core.NewMonetaryInt(0),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(0),
+				Output: big.NewInt(0),
 			},
 		},
 	},
 	PostCommitVolumes: core.AccountsAssetsVolumes{
 		"central_bank": {
 			"USD": {
-				Input:  core.NewMonetaryInt(200),
-				Output: core.NewMonetaryInt(1),
+				Input:  big.NewInt(200),
+				Output: big.NewInt(1),
 			},
 		},
 		"users:1": {
 			"USD": {
-				Input:  core.NewMonetaryInt(1),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(1),
+				Output: big.NewInt(0),
 			},
 		},
 	},
@@ -227,7 +228,7 @@ func testUpdateTransactionMetadata(t *testing.T, store storage.LedgerStore) {
 					{
 						Source:      "world",
 						Destination: "central_bank",
-						Amount:      core.NewMonetaryInt(100),
+						Amount:      big.NewInt(100),
 						Asset:       "USD",
 					},
 				},
@@ -275,8 +276,8 @@ func testGetAssetsVolumes(t *testing.T, store storage.LedgerStore) {
 	require.NoError(t, store.UpdateVolumes(context.Background(), core.AccountsAssetsVolumes{
 		"central_bank": {
 			"USD": {
-				Input:  core.NewMonetaryInt(100),
-				Output: core.NewMonetaryInt(0),
+				Input:  big.NewInt(100),
+				Output: big.NewInt(0),
 			},
 		},
 	}))
@@ -284,8 +285,8 @@ func testGetAssetsVolumes(t *testing.T, store storage.LedgerStore) {
 	volumes, err := store.GetAssetsVolumes(context.Background(), "central_bank")
 	require.NoError(t, err)
 	require.Len(t, volumes, 1)
-	require.EqualValues(t, core.NewMonetaryInt(100), volumes["USD"].Input)
-	require.EqualValues(t, core.NewMonetaryInt(0), volumes["USD"].Output)
+	require.EqualValues(t, big.NewInt(100), volumes["USD"].Input)
+	require.EqualValues(t, big.NewInt(0), volumes["USD"].Output)
 }
 
 func testGetAccounts(t *testing.T, store storage.LedgerStore) {

--- a/components/ledger/pkg/storage/sqlstorage/ledger/volumes.go
+++ b/components/ledger/pkg/storage/sqlstorage/ledger/volumes.go
@@ -2,6 +2,7 @@ package ledger
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/formancehq/ledger/pkg/core"
 	"github.com/uptrace/bun"
@@ -78,14 +79,14 @@ func (s *Store) GetAssetsVolumes(ctx context.Context, accountAddress string) (co
 			return nil, s.error(err)
 		}
 
-		input, err := core.ParseMonetaryInt(inputStr)
-		if err != nil {
-			return nil, s.error(err)
+		input, ok := new(big.Int).SetString(inputStr, 10)
+		if !ok {
+			panic("unable to restore big int")
 		}
 
-		output, err := core.ParseMonetaryInt(outputStr)
-		if err != nil {
-			return nil, s.error(err)
+		output, ok := new(big.Int).SetString(outputStr, 10)
+		if !ok {
+			panic("unable to restore big int")
 		}
 
 		volumes[asset] = core.Volumes{

--- a/tests/integration/Taskfile.yaml
+++ b/tests/integration/Taskfile.yaml
@@ -23,7 +23,7 @@ tasks:
     deps: [run-docker-compose]
     cmds:
       - >
-        ginkgo --race --vet ""
+        ginkgo --vet ""
         {{if eq .VERBOSE "true"}}-v{{end}}
         {{if eq .PARALLEL "true"}}-p{{end}}
         {{if eq .FAILFAST "true"}}--fail-fast{{end}}


### PR DESCRIPTION
Move models used by machine inside pkg/machine/internal.
Also remove usage of *Monetary on the core ledger and use directly *big.Int