### PR TITLE
fix: refactor query Worker struct and methods

### DIFF
--- a/components/ledger/pkg/ledger/query/worker_test.go
+++ b/components/ledger/pkg/ledger/query/worker_test.go
@@ -35,7 +35,7 @@ func TestWorker(t *testing.T) {
 
 	worker := NewWorker(WorkerConfig{
 		ChanSize: 1024,
-	}, driver, ledgerStore, monitor.NewNoOpMonitor())
+	}, ledgerStore, monitor.NewNoOpMonitor())
 	go func() {
 		require.NoError(t, worker.Run(context.Background()))
 	}()

--- a/components/ledger/pkg/ledger/resolver.go
+++ b/components/ledger/pkg/ledger/resolver.go
@@ -69,7 +69,7 @@ func (r *Resolver) GetLedger(ctx context.Context, name string) (*Ledger, error) 
 
 		queryWorker := query.NewWorker(query.WorkerConfig{
 			ChanSize: 1024,
-		}, r.storageDriver, store, r.monitor)
+		}, store, r.monitor)
 
 		go func() {
 			if err := queryWorker.Run(logging.ContextWithLogger(


### PR DESCRIPTION
- Remove the `driver` field from the `Worker` struct
- Change the `initLedgers` method to `initLedger` and remove the loop