### PR TITLE
feat: Numscript: Send monetary with arithmetic

### DIFF
--- a/components/ledger/pkg/core/value.go
+++ b/components/ledger/pkg/core/value.go
@@ -13,7 +13,7 @@ const (
 	TypeNumber                     // 64bit unsigned integer
 	TypeString                     // string
 	TypeMonetary                   // [asset number]
-	TypePortion                    // rational number between 0 and 1 both exclusive
+	TypePortion                    // rational number between 0 and 1 both inclusive
 	TypeAllotment                  // list of portions
 	TypeAmount                     // either ALL or a SPECIFIC number
 	TypeFunding                    // (asset, []{amount, account})

--- a/components/ledger/pkg/machine/script/compiler/source.go
+++ b/components/ledger/pkg/machine/script/compiler/source.go
@@ -11,62 +11,6 @@ import (
 
 type FallbackAccount core.Address
 
-// VisitValueAwareSource returns the resource addresses of all the accounts
-func (p *parseVisitor) VisitValueAwareSource(c parser.IValueAwareSourceContext, pushAsset func(), monAddr *core.Address) (map[core.Address]struct{}, *CompileError) {
-	neededAccounts := map[core.Address]struct{}{}
-	isAll := monAddr == nil
-	switch c := c.(type) {
-	case *parser.SrcContext:
-		accounts, _, unbounded, compErr := p.VisitSource(c.Source(), pushAsset, isAll)
-		if compErr != nil {
-			return nil, compErr
-		}
-		for k, v := range accounts {
-			neededAccounts[k] = v
-		}
-		if !isAll {
-			p.PushAddress(*monAddr)
-			err := p.TakeFromSource(unbounded)
-			if err != nil {
-				return nil, LogicError(c, err)
-			}
-		}
-	case *parser.SrcAllotmentContext:
-		if isAll {
-			return nil, LogicError(c, errors.New("cannot take all balance of an allotment source"))
-		}
-		p.PushAddress(*monAddr)
-		p.VisitAllotment(c.SourceAllotment(), c.SourceAllotment().GetPortions())
-		p.AppendInstruction(program.OP_ALLOC)
-
-		sources := c.SourceAllotment().GetSources()
-		n := len(sources)
-		for i := 0; i < n; i++ {
-			accounts, _, fallback, compErr := p.VisitSource(sources[i], pushAsset, isAll)
-			if compErr != nil {
-				return nil, compErr
-			}
-			for k, v := range accounts {
-				neededAccounts[k] = v
-			}
-			err := p.Bump(int64(i + 1))
-			if err != nil {
-				return nil, LogicError(c, err)
-			}
-			err = p.TakeFromSource(fallback)
-			if err != nil {
-				return nil, LogicError(c, err)
-			}
-		}
-		err := p.PushInteger(core.NewNumber(int64(n)))
-		if err != nil {
-			return nil, LogicError(c, err)
-		}
-		p.AppendInstruction(program.OP_FUNDING_ASSEMBLE)
-	}
-	return neededAccounts, nil
-}
-
 func (p *parseVisitor) TakeFromSource(fallback *FallbackAccount) error {
 	if fallback == nil {
 		p.AppendInstruction(program.OP_TAKE)
@@ -75,25 +19,26 @@ func (p *parseVisitor) TakeFromSource(fallback *FallbackAccount) error {
 			return err
 		}
 		p.AppendInstruction(program.OP_REPAY)
-	} else {
-		p.AppendInstruction(program.OP_TAKE_MAX)
-		err := p.Bump(1)
-		if err != nil {
-			return err
-		}
-		p.AppendInstruction(program.OP_REPAY)
-		p.PushAddress(core.Address(*fallback))
-		err = p.Bump(2)
-		if err != nil {
-			return err
-		}
-		p.AppendInstruction(program.OP_TAKE_ALWAYS)
-		err = p.PushInteger(core.NewNumber(2))
-		if err != nil {
-			return err
-		}
-		p.AppendInstruction(program.OP_FUNDING_ASSEMBLE)
+		return nil
 	}
+
+	p.AppendInstruction(program.OP_TAKE_MAX)
+	err := p.Bump(1)
+	if err != nil {
+		return err
+	}
+	p.AppendInstruction(program.OP_REPAY)
+	p.PushAddress(core.Address(*fallback))
+	err = p.Bump(2)
+	if err != nil {
+		return err
+	}
+	p.AppendInstruction(program.OP_TAKE_ALWAYS)
+	err = p.PushInteger(core.NewNumber(2))
+	if err != nil {
+		return err
+	}
+	p.AppendInstruction(program.OP_FUNDING_ASSEMBLE)
 	return nil
 }
 

--- a/components/ledger/pkg/machine/vm/machine_test.go
+++ b/components/ledger/pkg/machine/vm/machine_test.go
@@ -1844,3 +1844,88 @@ func TestVariableAsset(t *testing.T) {
 	}
 	test(t, tc)
 }
+
+func TestSendWithArithmetic(t *testing.T) {
+	t.Run("nominal", func(t *testing.T) {
+		tc := NewTestCase()
+		script := `
+			vars {
+				asset $ass
+				monetary $mon
+			}
+			send [EUR 1] + $mon + [$ass 3] - [EUR 4] (
+				source = @a
+				destination = @b
+			)`
+		tc.compile(t, script)
+		tc.setBalance("a", "EUR", 10)
+		tc.vars = map[string]core.Value{
+			"ass": core.Asset("EUR"),
+			"mon": core.Monetary{
+				Asset:  "EUR",
+				Amount: core.NewMonetaryInt(2),
+			},
+		}
+		tc.expected = CaseResult{
+			Printed: []core.Value{},
+			Postings: []Posting{
+				{
+					Asset:       "EUR",
+					Amount:      core.NewMonetaryInt(2),
+					Source:      "a",
+					Destination: "b",
+				},
+			},
+			ExitCode: EXIT_OK,
+		}
+		test(t, tc)
+	})
+
+	t.Run("error different assets", func(t *testing.T) {
+		tc := NewTestCase()
+		tc.compile(t, `
+			send [USD 2] + [EUR 1] (
+				source = @world
+				destination = @alice
+			)`)
+		tc.expected = CaseResult{
+			Printed:  []core.Value{},
+			Postings: []Posting{},
+			ExitCode: EXIT_FAIL_INVALID,
+			Error:    "tried to add two monetary with different assets: 'USD' and 'EUR'",
+		}
+		test(t, tc)
+	})
+
+	t.Run("error negative amount", func(t *testing.T) {
+		tc := NewTestCase()
+		tc.compile(t, `
+			send [USD 2] - [USD 3] (
+				source = @world
+				destination = @alice
+			)`)
+		tc.expected = CaseResult{
+			Printed:  []core.Value{},
+			Postings: []Posting{},
+			ExitCode: EXIT_FAIL_INVALID,
+			Error:    "cannot send a monetary with a negative amount: [USD -1]",
+		}
+		test(t, tc)
+	})
+
+	t.Run("error insufficient funds", func(t *testing.T) {
+		tc := NewTestCase()
+		tc.compile(t, `
+			send [USD 3] - [USD 1] (
+				source = @bob
+				destination = @alice
+			)`)
+		tc.setBalance("bob", "USD", 1)
+		tc.expected = CaseResult{
+			Printed:  []core.Value{},
+			Postings: []Posting{},
+			ExitCode: EXIT_FAIL_INSUFFICIENT_FUNDS,
+		}
+		test(t, tc)
+	})
+}

--- a/components/ledger/pkg/machine/vm/program/instructions.go
+++ b/components/ledger/pkg/machine/vm/program/instructions.go
@@ -4,13 +4,14 @@ const (
 	OP_APUSH            = byte(iota + 1)
 	OP_BUMP             // <value_to_bump: any> <any>*N <int N> => <any>*N <value_to_bump>
 	OP_DELETE           // <value: not funding>
-	OP_IADD             // <number> <number> => <number>
-	OP_ISUB             // <number> <number> => <number>
+	OP_IADD             // <number> + <number> => <number>
+	OP_ISUB             // <number> - <number> => <number>
 	OP_PRINT            // <any>
 	OP_FAIL             //
 	OP_ASSET            // <asset | monetary | funding> => <asset>
 	OP_MONETARY_NEW     // <asset> <number> => <monetary>
-	OP_MONETARY_ADD     // <monetary> <monetary> => <monetary>   // panics if not same asset
+	OP_MONETARY_ADD     // <monetary> + <monetary> => <monetary>   // panics if not same asset
+	OP_MONETARY_SUB     // <monetary> - <monetary> => <monetary>   // panics if not same asset
 	OP_MAKE_ALLOTMENT   // <portion>*N <int N> => <allotment(N)>
 	OP_TAKE_ALL         // <source: account> <overdraft: monetary> => <funding>
 	OP_TAKE_ALWAYS      // <source: account> <monetary> => <funding>   // takes amount from account unconditionally
@@ -48,6 +49,8 @@ func OpcodeName(op byte) string {
 		return "OP_MONETARY_NEW"
 	case OP_MONETARY_ADD:
 		return "OP_MONETARY_ADD"
+	case OP_MONETARY_SUB:
+		return "OP_MONETARY_SUB"
 	case OP_MAKE_ALLOTMENT:
 		return "OP_MAKE_ALLOTMENT"
 	case OP_TAKE_ALL:


### PR DESCRIPTION
Be able to send monetary with arithmetic computation such as:
```
vars {
  asset $asset
  monetary $mon1 = balance($account_a, $asset)
  monetary $mon2 = balance($account_b, $asset)
}
send $mon1 + $mon2 - [$asset 1] (
  source = @wallet
  destination = @account_c
)
```