### PR TITLE
feat: monetary ops

### DIFF
--- a/components/ledger/pkg/machine/examples/basic.go
+++ b/components/ledger/pkg/machine/examples/basic.go
@@ -8,13 +8,21 @@ import (
 	"github.com/numary/ledger/pkg/machine/vm"
 )
 
+/*
+15% from {
+	@alice
+	@bob
+}
+remaining from @bob
+*/
+
 func main() {
 	program, err := compiler.Compile(`
 		// This is a comment
 		vars {
 			account $dest
 		}
-		send [COIN 99] (
+		send [COIN 38] - [COIN 12] (
 			source = {
 				15% from {
 					@alice

--- a/components/ledger/pkg/machine/script/compiler/destination.go
+++ b/components/ledger/pkg/machine/script/compiler/destination.go
@@ -22,11 +22,11 @@ func (p *parseVisitor) VisitDestinationRecursive(c parser.IDestinationContext) *
 	case *parser.DestAccountContext:
 		p.AppendInstruction(program.OP_FUNDING_SUM)
 		p.AppendInstruction(program.OP_TAKE)
-		ty, _, err := p.VisitExpr(c.Expression(), true)
+		account_info, err := p.VisitExpr(c.Expression(), true)
 		if err != nil {
 			return err
 		}
-		if ty != core.TypeAccount {
+		if account_info.ty != core.TypeAccount {
 			return LogicError(c,
 				errors.New("wrong type: expected account as destination"),
 			)
@@ -53,11 +53,11 @@ func (p *parseVisitor) VisitDestinationRecursive(c parser.IDestinationContext) *
 		}
 
 		for i := 0; i < n; i++ {
-			ty, _, compErr := p.VisitExpr(amounts[i], true)
+			amount_info, compErr := p.VisitExpr(amounts[i], true)
 			if compErr != nil {
 				return compErr
 			}
-			if ty != core.TypeMonetary {
+			if amount_info.ty != core.TypeMonetary {
 				return LogicError(c, errors.New("wrong type: expected monetary as max"))
 			}
 			p.AppendInstruction(program.OP_TAKE_MAX)

--- a/components/ledger/pkg/machine/vm/machine.go
+++ b/components/ledger/pkg/machine/vm/machine.go
@@ -272,6 +272,17 @@ func (m *Machine) tick() (bool, byte) {
 			Amount: a.Amount.Add(b.Amount),
 		})
 
+	case program.OP_MONETARY_SUB:
+		b := pop[core.Monetary](m)
+		a := pop[core.Monetary](m)
+		if a.Asset != b.Asset {
+			return true, EXIT_FAIL_INVALID
+		}
+		m.pushValue(core.Monetary{
+			Asset:  a.Asset,
+			Amount: a.Amount.Sub(b.Amount),
+		})
+
 	case program.OP_MAKE_ALLOTMENT:
 		n := pop[core.Number](m)
 		portions := make([]core.Portion, n.Uint64())

--- a/components/ledger/pkg/machine/vm/program/instructions.go
+++ b/components/ledger/pkg/machine/vm/program/instructions.go
@@ -10,7 +10,8 @@ const (
 	OP_FAIL             //
 	OP_ASSET            // <asset | monetary | funding> => <asset>
 	OP_MONETARY_NEW     // <asset> <number> => <monetary>
-	OP_MONETARY_ADD     // <monetary> <monetary> => <monetary>   // panics if not same asset
+	OP_MONETARY_ADD     // <monetary> <monetary> => <monetary>   // fails if not same asset
+	OP_MONETARY_SUB     // <monetary> <monetary> => <monetary>   // fails if not same asset
 	OP_MAKE_ALLOTMENT   // <portion>*N <int N> => <allotment(N)>
 	OP_TAKE_ALL         // <source: account> <overdraft: monetary> => <funding>
 	OP_TAKE_ALWAYS      // <source: account> <monetary> => <funding>   // takes amount from account unconditionally
@@ -48,6 +49,8 @@ func OpcodeName(op byte) string {
 		return "OP_MONETARY_NEW"
 	case OP_MONETARY_ADD:
 		return "OP_MONETARY_ADD"
+	case OP_MONETARY_SUB:
+		return "OP_MONETARY_SUB"
 	case OP_MAKE_ALLOTMENT:
 		return "OP_MAKE_ALLOTMENT"
 	case OP_TAKE_ALL:


### PR DESCRIPTION
For supporting add/sub on monetaries in send statement

Adds new instruction: OP_MONETARY_SUB

VisitExpr now returns additional data (now structured as a struct called ExprInfo)
- asset_source, which is any resource that let us extract an asset from it
    - in case the expr is an arithmetic op, it'll just be the left operand's asset_source
    - I think this scheme only works as long as we don't allow creating assets dynamically (but I don't think that's planned at the moment), otherwise there would not be an address that lets us read that monetary.

Since there is no longer a resource address associated with a monetary, we just pass a function to VisitValueAwareSource to push the monetary instead of an address