### PR TITLE
fix: fix memory leak with store logs worker not closed

### DIFF
--- a/components/ledger/pkg/storage/sqlstorage/driver.go
+++ b/components/ledger/pkg/storage/sqlstorage/driver.go
@@ -122,7 +122,7 @@ func (d *Driver) GetLedgerStore(ctx context.Context, name string, create bool) (
 			return schema.Close(context.Background())
 		}, func(ctx context.Context) error {
 			return d.GetSystemStore().DeleteLedger(ctx, name)
-		}, d.storeConfig)
+		}, d.storeConfig, true)
 		if err != nil {
 			return nil, false, errors.Wrap(err, "creating ledger store")
 		}

--- a/components/ledger/pkg/storage/sqlstorage/ledger/logs.go
+++ b/components/ledger/pkg/storage/sqlstorage/ledger/logs.go
@@ -136,7 +136,7 @@ func (s *Store) batchLogs(ctx context.Context, logs []*core.Log) error {
 }
 
 func (s *Store) AppendLog(ctx context.Context, log *core.Log) error {
-	if !s.isInitialized {
+	if !s.isInitialized || s.logsBatchWorker == nil {
 		return storageerrors.StorageError(storage.ErrStoreNotInitialized)
 	}
 	recordMetrics := s.instrumentalized(ctx, "append_log")


### PR DESCRIPTION
When calling the RunInTransaction store function, a sub store is created everytime. When creating a new store, a logs worker is created also using context.Background, and the stop function was never called. This commit fixes that by simply adding the logs worker closing inside the ledger close and calling the close when we finish the transaction