### PR TITLE
fix: crash with resources loaded twice

### DIFF
--- a/components/ledger/libs/logging/logrus.go
+++ b/components/ledger/libs/logging/logrus.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"context"
+	"flag"
 	"io"
 	"os"
 	"testing"
@@ -63,6 +64,7 @@ func NewLogrus(logger *logrus.Logger) *logrusLogger {
 func Testing() *logrusLogger {
 	logger := logrus.New()
 	logger.SetOutput(io.Discard)
+	flag.Parse()
 	if testing.Verbose() {
 		logger.SetOutput(os.Stdout)
 		logger.SetLevel(logrus.DebugLevel)

--- a/components/ledger/libs/otlp/cli.go
+++ b/components/ledger/libs/otlp/cli.go
@@ -1,13 +1,19 @@
 package otlp
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 
 	flag "github.com/spf13/pflag"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.uber.org/fx"
 )
 
 var (
-	once sync.Once
+	onceInitOTLPFlags sync.Once
+	onceLoadResources sync.Once
 )
 
 const (
@@ -16,8 +22,33 @@ const (
 )
 
 func InitOTLPFlags(flags *flag.FlagSet) {
-	once.Do(func() {
+	onceInitOTLPFlags.Do(func() {
 		flags.String(OtelServiceName, "", "OpenTelemetry service name")
 		flags.StringSlice(OtelResourceAttributes, []string{}, "Additional OTLP resource attributes")
 	})
+}
+
+func LoadResource(serviceName string, resourceAttributes []string) fx.Option {
+	options := make([]fx.Option, 0)
+	onceLoadResources.Do(func() {
+		options = append(options,
+			fx.Provide(func() (*resource.Resource, error) {
+				defaultResource := resource.Default()
+				attributes := make([]attribute.KeyValue, 0)
+				if serviceName != "" {
+					attributes = append(attributes, attribute.String("service.name", serviceName))
+				}
+				for _, ra := range resourceAttributes {
+					parts := strings.SplitN(ra, "=", 2)
+					if len(parts) < 2 {
+						return nil, fmt.Errorf("malformed otlp attribute: %s", ra)
+					}
+					attributes = append(attributes, attribute.String(parts[0], parts[1]))
+				}
+				return resource.Merge(defaultResource, resource.NewSchemaless(attributes...))
+			}),
+		)
+	})
+
+	return fx.Options(options...)
 }

--- a/components/stargate/cmd/root.go
+++ b/components/stargate/cmd/root.go
@@ -77,9 +77,8 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	root.PersistentFlags().Bool(service.DebugFlag, false, "Debug mode")
-
-	otlptraces.InitOTLPTracesFlags(root.Flags())
-	otlpmetrics.InitOTLPMetricsFlags(root.Flags())
+	otlptraces.InitOTLPTracesFlags(root.PersistentFlags())
+	otlpmetrics.InitOTLPMetricsFlags(root.PersistentFlags())
 
 	if err := viper.BindPFlags(root.PersistentFlags()); err != nil {
 		panic(err)

--- a/libs/go-libs/otlp/cli.go
+++ b/libs/go-libs/otlp/cli.go
@@ -1,13 +1,19 @@
 package otlp
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 
 	flag "github.com/spf13/pflag"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.uber.org/fx"
 )
 
 var (
-	once sync.Once
+	onceInitOTLPFlags sync.Once
+	onceLoadResources sync.Once
 )
 
 const (
@@ -16,8 +22,33 @@ const (
 )
 
 func InitOTLPFlags(flags *flag.FlagSet) {
-	once.Do(func() {
+	onceInitOTLPFlags.Do(func() {
 		flags.String(OtelServiceName, "", "OpenTelemetry service name")
 		flags.StringSlice(OtelResourceAttributes, []string{}, "Additional OTLP resource attributes")
 	})
+}
+
+func LoadResource(serviceName string, resourceAttributes []string) fx.Option {
+	options := make([]fx.Option, 0)
+	onceLoadResources.Do(func() {
+		options = append(options,
+			fx.Provide(func() (*resource.Resource, error) {
+				defaultResource := resource.Default()
+				attributes := make([]attribute.KeyValue, 0)
+				if serviceName != "" {
+					attributes = append(attributes, attribute.String("service.name", serviceName))
+				}
+				for _, ra := range resourceAttributes {
+					parts := strings.SplitN(ra, "=", 2)
+					if len(parts) < 2 {
+						return nil, fmt.Errorf("malformed otlp attribute: %s", ra)
+					}
+					attributes = append(attributes, attribute.String(parts[0], parts[1]))
+				}
+				return resource.Merge(defaultResource, resource.NewSchemaless(attributes...))
+			}),
+		)
+	})
+
+	return fx.Options(options...)
 }


### PR DESCRIPTION
When setting the metrics and traces flags at true
resources were created twice within fx, hence the
crash. This PR fixes it