### PR TITLE
feat: fctl-tojson-ledger

### DIFF
--- a/components/fctl/cmd/ledger/accounts/set_metadata.go
+++ b/components/fctl/cmd/ledger/accounts/set_metadata.go
@@ -10,65 +10,98 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type SetMetadataStore struct {
+	Success bool `json:"success"`
+}
+type SetMetadataController struct {
+	store *SetMetadataStore
+}
+
+var _ fctl.Controller[*SetMetadataStore] = (*SetMetadataController)(nil)
+
+func NewDefaultSetMetadataStore() *SetMetadataStore {
+	return &SetMetadataStore{
+		Success: false,
+	}
+}
+
+func NewSetMetadataController() *SetMetadataController {
+	return &SetMetadataController{
+		store: NewDefaultSetMetadataStore(),
+	}
+}
+
 func NewSetMetadataCommand() *cobra.Command {
 	return fctl.NewCommand("set-metadata <address> [<key>=<value>...]",
 		fctl.WithConfirmFlag(),
 		fctl.WithShortDescription("Set metadata on address"),
 		fctl.WithAliases("sm", "set-meta"),
 		fctl.WithArgs(cobra.MinimumNArgs(2)),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-
-			metadata, err := fctl.ParseMetadata(args[1:])
-			if err != nil {
-				return err
-			}
-
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			address := args[0]
-
-			if !fctl.CheckStackApprobation(cmd, stack, "You are about to set a metadata on address '%s'", address) {
-				return fctl.ErrMissingApproval
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			request := operations.AddMetadataToAccountRequest{
-				Ledger:      fctl.GetString(cmd, internal.LedgerFlag),
-				Address:     address,
-				RequestBody: metadata,
-			}
-			response, err := ledgerClient.Ledger.AddMetadataToAccount(cmd.Context(), request)
-			if err != nil {
-				return err
-			}
-
-			if response.ErrorResponse != nil {
-				return fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
-			}
-
-			if response.StatusCode >= 300 {
-				return fmt.Errorf("unexpected status code: %d", response.StatusCode)
-			}
-
-			pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Metadata added!")
-			return nil
-		}),
+		fctl.WithController[*SetMetadataStore](NewSetMetadataController()),
 	)
+}
+
+func (c *SetMetadataController) GetStore() *SetMetadataStore {
+	return c.store
+}
+
+func (c *SetMetadataController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+
+	metadata, err := fctl.ParseMetadata(args[1:])
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	address := args[0]
+
+	if !fctl.CheckStackApprobation(cmd, stack, "You are about to set a metadata on address '%s'", address) {
+		return nil, fctl.ErrMissingApproval
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	request := operations.AddMetadataToAccountRequest{
+		Ledger:      fctl.GetString(cmd, internal.LedgerFlag),
+		Address:     address,
+		RequestBody: metadata,
+	}
+	response, err := ledgerClient.Ledger.AddMetadataToAccount(cmd.Context(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.ErrorResponse != nil {
+		return nil, fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
+	}
+
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
+	c.store.Success = response.StatusCode == 204
+
+	return c, nil
+}
+
+func (c *SetMetadataController) Render(cmd *cobra.Command, args []string) error {
+	pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Metadata added!")
+	return nil
 }

--- a/components/fctl/cmd/ledger/accounts/show.go
+++ b/components/fctl/cmd/ledger/accounts/show.go
@@ -3,83 +3,112 @@ package accounts
 import (
 	"fmt"
 
-	"github.com/formancehq/fctl/cmd/ledger/internal"
+	internal "github.com/formancehq/fctl/cmd/ledger/internal"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/formancehq/formance-sdk-go/pkg/models/operations"
+	"github.com/formancehq/formance-sdk-go/pkg/models/shared"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
+
+type ShowStore struct {
+	Account *shared.AccountWithVolumesAndBalances `json:"account"`
+}
+type ShowController struct {
+	store *ShowStore
+}
+
+var _ fctl.Controller[*ShowStore] = (*ShowController)(nil)
+
+func NewDefaultShowStore() *ShowStore {
+	return &ShowStore{}
+}
+
+func NewShowController() *ShowController {
+	return &ShowController{
+		store: NewDefaultShowStore(),
+	}
+}
 
 func NewShowCommand() *cobra.Command {
 	return fctl.NewCommand("show <address>",
 		fctl.WithShortDescription("Show account"),
 		fctl.WithArgs(cobra.ExactArgs(1)),
 		fctl.WithAliases("sh", "s"),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			ledger := fctl.GetString(cmd, internal.LedgerFlag)
-			response, err := ledgerClient.Ledger.GetAccount(cmd.Context(), operations.GetAccountRequest{
-				Address: args[0],
-				Ledger:  ledger,
-			})
-			if err != nil {
-				return err
-			}
-
-			if response.ErrorResponse != nil {
-				return fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
-			}
-
-			if response.StatusCode >= 300 {
-				return fmt.Errorf("unexpected status code: %d", response.StatusCode)
-			}
-
-			fctl.Section.WithWriter(cmd.OutOrStdout()).Println("Information")
-			if response.AccountResponse.Data.Volumes != nil && len(response.AccountResponse.Data.Volumes) > 0 {
-				tableData := pterm.TableData{}
-				tableData = append(tableData, []string{"Asset", "Input", "Output"})
-				for asset, volumes := range response.AccountResponse.Data.Volumes {
-					input := volumes["input"]
-					output := volumes["output"]
-					tableData = append(tableData, []string{pterm.LightCyan(asset), fmt.Sprint(input), fmt.Sprint(output)})
-				}
-				if err := pterm.DefaultTable.
-					WithHasHeader(true).
-					WithWriter(cmd.OutOrStdout()).
-					WithData(tableData).
-					Render(); err != nil {
-					return err
-				}
-			} else {
-				fctl.Println("No balances.")
-			}
-
-			fmt.Fprintln(cmd.OutOrStdout())
-
-			if err := fctl.PrintMetadata(cmd.OutOrStdout(), response.AccountResponse.Data.Metadata); err != nil {
-				return err
-			}
-
-			return nil
-		}),
+		fctl.WithController[*ShowStore](NewShowController()),
 	)
+}
+
+func (c *ShowController) GetStore() *ShowStore {
+	return c.store
+}
+
+func (c *ShowController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	ledger := fctl.GetString(cmd, internal.LedgerFlag)
+	response, err := ledgerClient.Ledger.GetAccount(cmd.Context(), operations.GetAccountRequest{
+		Address: args[0],
+		Ledger:  ledger,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if response.ErrorResponse != nil {
+		return nil, fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
+	}
+
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
+	c.store.Account = &response.AccountResponse.Data
+
+	return c, nil
+}
+
+func (c *ShowController) Render(cmd *cobra.Command, args []string) error {
+	fctl.Section.WithWriter(cmd.OutOrStdout()).Println("Information")
+	if c.store.Account.Volumes != nil && len(c.store.Account.Volumes) > 0 {
+		tableData := pterm.TableData{}
+		tableData = append(tableData, []string{"Asset", "Input", "Output"})
+		for asset, volumes := range c.store.Account.Volumes {
+			input := volumes["input"]
+			output := volumes["output"]
+			tableData = append(tableData, []string{pterm.LightCyan(asset), fmt.Sprint(input), fmt.Sprint(output)})
+		}
+		if err := pterm.DefaultTable.
+			WithHasHeader(true).
+			WithWriter(cmd.OutOrStdout()).
+			WithData(tableData).
+			Render(); err != nil {
+			return err
+		}
+	} else {
+		fctl.Println("No balances.")
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout())
+
+	return fctl.PrintMetadata(cmd.OutOrStdout(), c.store.Account.Metadata)
 }

--- a/components/fctl/cmd/ledger/balances.go
+++ b/components/fctl/cmd/ledger/balances.go
@@ -3,84 +3,111 @@ package ledger
 import (
 	"fmt"
 
-	internal "github.com/formancehq/fctl/cmd/ledger/internal"
+	"github.com/formancehq/fctl/cmd/ledger/internal"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/formancehq/formance-sdk-go/pkg/models/operations"
+	"github.com/formancehq/formance-sdk-go/pkg/models/shared"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
+type BalancesStore struct {
+	Balances shared.BalancesCursorResponseCursor `json:"balances"`
+}
+type BalancesController struct {
+	store       *BalancesStore
+	addressFlag string
+}
+
+var _ fctl.Controller[*BalancesStore] = (*BalancesController)(nil)
+
+func NewDefaultBalancesStore() *BalancesStore {
+	return &BalancesStore{}
+}
+
+func NewBalancesController() *BalancesController {
+	return &BalancesController{
+		store:       NewDefaultBalancesStore(),
+		addressFlag: "address",
+	}
+}
+
 func NewBalancesCommand() *cobra.Command {
-	const (
-		addressFlag = "address"
-	)
+	c := NewBalancesController()
 	return fctl.NewCommand("balances",
 		fctl.WithAliases("balance", "bal", "b"),
-		fctl.WithStringFlag(addressFlag, "", "Filter on specific address"),
+		fctl.WithStringFlag(c.addressFlag, "", "Filter on specific address"),
 		fctl.WithShortDescription("Read balances"),
 		fctl.WithArgs(cobra.ExactArgs(0)),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			client, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			response, err := client.Ledger.GetBalances(
-				cmd.Context(),
-				operations.GetBalancesRequest{
-					Address: fctl.Ptr(fctl.GetString(cmd, addressFlag)),
-					Ledger:  fctl.GetString(cmd, internal.LedgerFlag),
-				},
-			)
-			if err != nil {
-				return err
-			}
-
-			if response.ErrorResponse != nil {
-				return fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
-			}
-
-			if response.StatusCode >= 300 {
-				return fmt.Errorf("unexpected status code: %d", response.StatusCode)
-			}
-
-			balances := response.BalancesCursorResponse
-
-			tableData := pterm.TableData{}
-			tableData = append(tableData, []string{"Account", "Asset", "Balance"})
-			for _, accountBalances := range balances.Cursor.Data {
-				for account, volumes := range accountBalances {
-					for asset, balance := range volumes {
-						tableData = append(tableData, []string{
-							account, asset, fmt.Sprint(balance),
-						})
-					}
-				}
-			}
-			if err := pterm.DefaultTable.
-				WithHasHeader(true).
-				WithWriter(cmd.OutOrStdout()).
-				WithData(tableData).
-				Render(); err != nil {
-				return err
-			}
-
-			return nil
-		}),
+		fctl.WithController[*BalancesStore](c),
 	)
+}
+
+func (c *BalancesController) GetStore() *BalancesStore {
+	return c.store
+}
+
+func (c *BalancesController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := client.Ledger.GetBalances(
+		cmd.Context(),
+		operations.GetBalancesRequest{
+			Address: fctl.Ptr(fctl.GetString(cmd, c.addressFlag)),
+			Ledger:  fctl.GetString(cmd, internal.LedgerFlag),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.ErrorResponse != nil {
+		return nil, fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
+	}
+
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
+	c.store.Balances = response.BalancesCursorResponse.Cursor
+
+	return c, nil
+}
+
+func (c *BalancesController) Render(cmd *cobra.Command, args []string) error {
+	tableData := pterm.TableData{}
+	tableData = append(tableData, []string{"Account", "Asset", "Balance"})
+	for _, accountBalances := range c.store.Balances.Data {
+		for account, volumes := range accountBalances {
+			for asset, balance := range volumes {
+				tableData = append(tableData, []string{
+					account, asset, fmt.Sprint(balance),
+				})
+			}
+		}
+	}
+
+	return pterm.DefaultTable.
+		WithHasHeader(true).
+		WithWriter(cmd.OutOrStdout()).
+		WithData(tableData).
+		Render()
 }

--- a/components/fctl/cmd/ledger/list.go
+++ b/components/fctl/cmd/ledger/list.go
@@ -2,53 +2,88 @@ package ledger
 
 import (
 	fctl "github.com/formancehq/fctl/pkg"
+	"github.com/formancehq/formance-sdk-go/pkg/models/shared"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
+
+type ListStore struct {
+	ConfigInfoResponse *shared.ConfigInfoResponse `json:"config_info_response"`
+}
+type ListController struct {
+	store *ListStore
+}
+
+var _ fctl.Controller[*ListStore] = (*ListController)(nil)
+
+func NewDefaultListStore() *ListStore {
+	return &ListStore{
+		ConfigInfoResponse: &shared.ConfigInfoResponse{},
+	}
+}
+
+func NewListController() *ListController {
+	return &ListController{
+		store: NewDefaultListStore(),
+	}
+}
 
 func NewListCommand() *cobra.Command {
 	return fctl.NewCommand("list",
 		fctl.WithAliases("l", "ls"),
 		fctl.WithShortDescription("List ledgers"),
 		fctl.WithArgs(cobra.ExactArgs(0)),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			response, err := ledgerClient.Ledger.GetInfo(cmd.Context())
-			if err != nil {
-				return err
-			}
-
-			info := response.ConfigInfoResponse
-			tableData := fctl.Map(info.Config.Storage.Ledgers, func(ledger string) []string {
-				return []string{
-					ledger,
-				}
-			})
-			tableData = fctl.Prepend(tableData, []string{"Name"})
-			return pterm.DefaultTable.
-				WithHasHeader().
-				WithWriter(cmd.OutOrStdout()).
-				WithData(tableData).
-				Render()
-		}),
+		fctl.WithController[*ListStore](NewListController()),
 	)
+}
+
+func (c *ListController) GetStore() *ListStore {
+	return c.store
+}
+
+func (c *ListController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := ledgerClient.Ledger.GetInfo(cmd.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	c.store.ConfigInfoResponse = response.ConfigInfoResponse
+
+	return c, nil
+}
+
+// TODO: This need to use the ui.NewListModel
+func (c *ListController) Render(cmd *cobra.Command, args []string) error {
+	tableData := fctl.Map(c.store.ConfigInfoResponse.Config.Storage.Ledgers, func(ledger string) []string {
+		return []string{
+			ledger,
+		}
+	})
+	tableData = fctl.Prepend(tableData, []string{"Name"})
+	return pterm.DefaultTable.
+		WithHasHeader().
+		WithWriter(cmd.OutOrStdout()).
+		WithData(tableData).
+		Render()
 }

--- a/components/fctl/cmd/ledger/send.go
+++ b/components/fctl/cmd/ledger/send.go
@@ -10,87 +10,120 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type SendStore struct {
+	Transaction *shared.Transaction `json:"transaction"`
+}
+type SendController struct {
+	store         *SendStore
+	metadataFlag  string
+	referenceFlag string
+}
+
+var _ fctl.Controller[*SendStore] = (*SendController)(nil)
+
+func NewDefaultSendStore() *SendStore {
+	return &SendStore{}
+}
+
+func NewSendController() *SendController {
+	return &SendController{
+		store:         NewDefaultSendStore(),
+		metadataFlag:  "metadata",
+		referenceFlag: "reference",
+	}
+}
+
 func NewSendCommand() *cobra.Command {
-	const (
-		metadataFlag  = "metadata"
-		referenceFlag = "reference"
-	)
+	c := NewSendController()
 	return fctl.NewCommand("send [<source>] <destination> <amount> <asset>",
 		fctl.WithAliases("s", "se"),
 		fctl.WithShortDescription("Send from one account to another"),
 		fctl.WithConfirmFlag(),
 		fctl.WithArgs(cobra.RangeArgs(3, 4)),
-		fctl.WithStringSliceFlag(metadataFlag, []string{""}, "Metadata to use"),
-		fctl.WithStringFlag(referenceFlag, "", "Reference to add to the generated transaction"),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			if !fctl.CheckStackApprobation(cmd, stack, "You are about to create a new transaction") {
-				return fctl.ErrMissingApproval
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			var source, destination, asset, amountStr string
-			if len(args) == 3 {
-				source = "world"
-				destination = args[0]
-				amountStr = args[1]
-				asset = args[2]
-			} else {
-				source = args[0]
-				destination = args[1]
-				amountStr = args[2]
-				asset = args[3]
-			}
-
-			amount, err := strconv.ParseInt(amountStr, 10, 64)
-			if err != nil {
-				return err
-			}
-
-			metadata, err := fctl.ParseMetadata(fctl.GetStringSlice(cmd, metadataFlag))
-			if err != nil {
-				return err
-			}
-
-			reference := fctl.GetString(cmd, referenceFlag)
-			tx, err := internal.CreateTransaction(ledgerClient, cmd.Context(), fctl.GetString(cmd, internal.LedgerFlag), operations.CreateTransactionRequest{
-				PostTransaction: shared.PostTransaction{
-					Metadata: metadata,
-					Postings: []shared.Posting{
-						{
-							Amount:      amount,
-							Asset:       asset,
-							Destination: destination,
-							Source:      source,
-						},
-					},
-					Reference: &reference,
-				},
-				Ledger: fctl.GetString(cmd, internal.LedgerFlag),
-			})
-			if err != nil {
-				return err
-			}
-
-			return internal.PrintTransaction(cmd.OutOrStdout(), *tx)
-		}),
+		fctl.WithStringSliceFlag(c.metadataFlag, []string{""}, "Metadata to use"),
+		fctl.WithStringFlag(c.referenceFlag, "", "Reference to add to the generated transaction"),
+		fctl.WithController[*SendStore](c),
 	)
+}
+
+func (c *SendController) GetStore() *SendStore {
+	return c.store
+}
+
+func (c *SendController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	if !fctl.CheckStackApprobation(cmd, stack, "You are about to create a new transaction") {
+		return nil, fctl.ErrMissingApproval
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	var source, destination, asset, amountStr string
+	if len(args) == 3 {
+		source = "world"
+		destination = args[0]
+		amountStr = args[1]
+		asset = args[2]
+	} else {
+		source = args[0]
+		destination = args[1]
+		amountStr = args[2]
+		asset = args[3]
+	}
+
+	amount, err := strconv.ParseInt(amountStr, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata, err := fctl.ParseMetadata(fctl.GetStringSlice(cmd, c.metadataFlag))
+	if err != nil {
+		return nil, err
+	}
+
+	reference := fctl.GetString(cmd, c.referenceFlag)
+
+	tx, err := internal.CreateTransaction(ledgerClient, cmd.Context(), fctl.GetString(cmd, internal.LedgerFlag), operations.CreateTransactionRequest{
+		PostTransaction: shared.PostTransaction{
+			Metadata: metadata,
+			Postings: []shared.Posting{
+				{
+					Amount:      amount,
+					Asset:       asset,
+					Destination: destination,
+					Source:      source,
+				},
+			},
+			Reference: &reference,
+		},
+		Ledger: fctl.GetString(cmd, internal.LedgerFlag),
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.store.Transaction = tx
+	return c, nil
+}
+
+// TODO: This need to use the ui.NewListModel
+func (c *SendController) Render(cmd *cobra.Command, args []string) error {
+	return internal.PrintTransaction(cmd.OutOrStdout(), *c.store.Transaction)
 }

--- a/components/fctl/cmd/ledger/serverinfo.go
+++ b/components/fctl/cmd/ledger/serverinfo.go
@@ -4,69 +4,103 @@ import (
 	"fmt"
 
 	fctl "github.com/formancehq/fctl/pkg"
+	"github.com/formancehq/formance-sdk-go/pkg/models/shared"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
+
+type ServerInfoStore struct {
+	ConfigInfoResponse *shared.ConfigInfoResponse `json:"config_info_response"`
+}
+type ServerInfoController struct {
+	store *ServerInfoStore
+}
+
+var _ fctl.Controller[*ServerInfoStore] = (*ServerInfoController)(nil)
+
+func NewDefaultServerInfoStore() *ServerInfoStore {
+	return &ServerInfoStore{
+		ConfigInfoResponse: &shared.ConfigInfoResponse{},
+	}
+}
+
+func NewServerInfoController() *ServerInfoController {
+	return &ServerInfoController{
+		store: NewDefaultServerInfoStore(),
+	}
+}
 
 func NewServerInfoCommand() *cobra.Command {
 	return fctl.NewCommand("server-infos",
 		fctl.WithArgs(cobra.ExactArgs(0)),
 		fctl.WithAliases("si"),
 		fctl.WithShortDescription("Read server info"),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			response, err := ledgerClient.Ledger.GetInfo(cmd.Context())
-			if err != nil {
-				return err
-			}
-
-			infoResponse := response.ConfigInfoResponse
-			tableData := pterm.TableData{}
-			tableData = append(tableData, []string{pterm.LightCyan("Server"), fmt.Sprint(infoResponse.Server)})
-			tableData = append(tableData, []string{pterm.LightCyan("Version"), fmt.Sprint(infoResponse.Version)})
-			tableData = append(tableData, []string{pterm.LightCyan("Storage driver"), fmt.Sprint(infoResponse.Config.Storage.Driver)})
-
-			if err := pterm.DefaultTable.
-				WithWriter(cmd.OutOrStdout()).
-				WithData(tableData).
-				Render(); err != nil {
-				return err
-			}
-
-			fctl.BasicTextCyan.WithWriter(cmd.OutOrStdout()).Printfln("Ledgers :")
-			if err := pterm.DefaultBulletList.
-				WithWriter(cmd.OutOrStdout()).
-				WithItems(fctl.Map(infoResponse.Config.Storage.Ledgers, func(ledger string) pterm.BulletListItem {
-					return pterm.BulletListItem{
-						Text:        ledger,
-						TextStyle:   pterm.NewStyle(pterm.FgDefault),
-						BulletStyle: pterm.NewStyle(pterm.FgLightCyan),
-					}
-				})).
-				Render(); err != nil {
-				return err
-			}
-
-			return nil
-		}),
+		fctl.WithController[*ServerInfoStore](NewServerInfoController()),
 	)
+}
+
+func (c *ServerInfoController) GetStore() *ServerInfoStore {
+	return c.store
+}
+
+func (c *ServerInfoController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := ledgerClient.Ledger.GetInfo(cmd.Context())
+	if err != nil {
+		return nil, err
+	}
+
+	c.store.ConfigInfoResponse = response.ConfigInfoResponse
+
+	return c, nil
+}
+
+func (c *ServerInfoController) Render(cmd *cobra.Command, args []string) error {
+	tableData := pterm.TableData{}
+	tableData = append(tableData, []string{pterm.LightCyan("Server"), fmt.Sprint(c.store.ConfigInfoResponse.Server)})
+	tableData = append(tableData, []string{pterm.LightCyan("Version"), fmt.Sprint(c.store.ConfigInfoResponse.Version)})
+	tableData = append(tableData, []string{pterm.LightCyan("Storage driver"), fmt.Sprint(c.store.ConfigInfoResponse.Config.Storage.Driver)})
+
+	if err := pterm.DefaultTable.
+		WithWriter(cmd.OutOrStdout()).
+		WithData(tableData).
+		Render(); err != nil {
+		return err
+	}
+
+	fctl.BasicTextCyan.WithWriter(cmd.OutOrStdout()).Printfln("Ledgers :")
+	if err := pterm.DefaultBulletList.
+		WithWriter(cmd.OutOrStdout()).
+		WithItems(fctl.Map(c.store.ConfigInfoResponse.Config.Storage.Ledgers, func(ledger string) pterm.BulletListItem {
+			fmt.Println(ledger)
+			return pterm.BulletListItem{
+				Text:        ledger,
+				TextStyle:   pterm.NewStyle(pterm.FgDefault),
+				BulletStyle: pterm.NewStyle(pterm.FgLightCyan),
+			}
+		})).
+		Render(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/components/fctl/cmd/ledger/stats.go
+++ b/components/fctl/cmd/ledger/stats.go
@@ -6,60 +6,94 @@ import (
 	"github.com/formancehq/fctl/cmd/ledger/internal"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/formancehq/formance-sdk-go/pkg/models/operations"
+	"github.com/formancehq/formance-sdk-go/pkg/models/shared"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
+
+type StatsStore struct {
+	Stats shared.Stats `json:"stats`
+}
+type StatsController struct {
+	store *StatsStore
+}
+
+var _ fctl.Controller[*StatsStore] = (*StatsController)(nil)
+
+func NewDefaultStatsStore() *StatsStore {
+	return &StatsStore{}
+}
+
+func NewStatsController() *StatsController {
+	return &StatsController{
+		store: NewDefaultStatsStore(),
+	}
+}
 
 func NewStatsCommand() *cobra.Command {
 	return fctl.NewCommand("stats",
 		fctl.WithArgs(cobra.ExactArgs(0)),
 		fctl.WithAliases("st"),
 		fctl.WithShortDescription("Read ledger stats"),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			request := operations.ReadStatsRequest{
-				Ledger: fctl.GetString(cmd, internal.LedgerFlag),
-			}
-			response, err := ledgerClient.Ledger.ReadStats(cmd.Context(), request)
-			if err != nil {
-				return err
-			}
-
-			if response.ErrorResponse != nil {
-				return fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
-			}
-
-			if response.StatusCode >= 300 {
-				return fmt.Errorf("unexpected status code: %d", response.StatusCode)
-			}
-
-			tableData := pterm.TableData{}
-			tableData = append(tableData, []string{pterm.LightCyan("Transactions"), fmt.Sprint(response.StatsResponse.Data.Transactions)})
-			tableData = append(tableData, []string{pterm.LightCyan("Accounts"), fmt.Sprint(response.StatsResponse.Data.Accounts)})
-
-			return pterm.DefaultTable.
-				WithWriter(cmd.OutOrStdout()).
-				WithData(tableData).
-				Render()
-		}),
+		fctl.WithController[*StatsStore](NewStatsController()),
 	)
+}
+
+func (c *StatsController) GetStore() *StatsStore {
+	return c.store
+}
+
+func (c *StatsController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	request := operations.ReadStatsRequest{
+		Ledger: fctl.GetString(cmd, internal.LedgerFlag),
+	}
+	response, err := ledgerClient.Ledger.ReadStats(cmd.Context(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.ErrorResponse != nil {
+		return nil, fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
+	}
+
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
+	c.store.Stats = response.StatsResponse.Data
+
+	return c, nil
+}
+
+// TODO: This need to use the ui.NewListModel
+func (c *StatsController) Render(cmd *cobra.Command, args []string) error {
+
+	tableData := pterm.TableData{}
+	tableData = append(tableData, []string{pterm.LightCyan("Transactions"), fmt.Sprint(c.store.Stats.Transactions)})
+	tableData = append(tableData, []string{pterm.LightCyan("Accounts"), fmt.Sprint(c.store.Stats.Accounts)})
+
+	return pterm.DefaultTable.
+		WithWriter(cmd.OutOrStdout()).
+		WithData(tableData).
+		Render()
 }

--- a/components/fctl/cmd/ledger/transactions/list.go
+++ b/components/fctl/cmd/ledger/transactions/list.go
@@ -12,127 +12,163 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewListCommand() *cobra.Command {
-	const (
-		pageSizeFlag    = "page-size"
-		metadataFlag    = "metadata"
-		referenceFlag   = "reference"
-		accountFlag     = "account"
-		destinationFlag = "dst"
-		sourceFlag      = "src"
-		endTimeFlag     = "end"
-		startTimeFlag   = "start"
-	)
+type ListStore struct {
+	Transaction shared.TransactionsCursorResponseCursor `json:"transaction_cursor"`
+}
+type ListController struct {
+	store           *ListStore
+	pageSizeFlag    string
+	metadataFlag    string
+	referenceFlag   string
+	accountFlag     string
+	destinationFlag string
+	sourceFlag      string
+	endTimeFlag     string
+	startTimeFlag   string
+}
 
+var _ fctl.Controller[*ListStore] = (*ListController)(nil)
+
+func NewDefaultListStore() *ListStore {
+	return &ListStore{}
+}
+
+func NewListController() *ListController {
+	return &ListController{
+		store:           NewDefaultListStore(),
+		pageSizeFlag:    "page-size",
+		metadataFlag:    "metadata",
+		referenceFlag:   "reference",
+		accountFlag:     "account",
+		destinationFlag: "dst",
+		sourceFlag:      "src",
+		endTimeFlag:     "end",
+		startTimeFlag:   "start",
+	}
+}
+
+func NewListCommand() *cobra.Command {
+	c := NewListController()
 	return fctl.NewCommand("list",
 		fctl.WithAliases("ls", "l"),
 		fctl.WithShortDescription("List transactions"),
-		fctl.WithStringFlag(accountFlag, "", "Filter on account"),
-		fctl.WithStringFlag(destinationFlag, "", "Filter on destination account"),
-		fctl.WithStringFlag(endTimeFlag, "", "Consider transactions before date"),
-		fctl.WithStringFlag(startTimeFlag, "", "Consider transactions after date"),
-		fctl.WithStringFlag(sourceFlag, "", "Filter on source account"),
-		fctl.WithStringFlag(referenceFlag, "", "Filter on reference"),
-		fctl.WithStringSliceFlag(metadataFlag, []string{}, "Filter transactions with metadata"),
-		fctl.WithIntFlag(pageSizeFlag, 5, "Page size"),
-		// SDK not generating correct requests
-		fctl.WithHiddenFlag(metadataFlag),
+		fctl.WithStringFlag(c.accountFlag, "", "Filter on account"),
+		fctl.WithStringFlag(c.destinationFlag, "", "Filter on destination account"),
+		fctl.WithStringFlag(c.endTimeFlag, "", "Consider transactions before date"),
+		fctl.WithStringFlag(c.startTimeFlag, "", "Consider transactions after date"),
+		fctl.WithStringFlag(c.sourceFlag, "", "Filter on source account"),
+		fctl.WithStringFlag(c.referenceFlag, "", "Filter on reference"),
+		fctl.WithStringSliceFlag(c.metadataFlag, []string{}, "Filter transactions with metadata"),
+		fctl.WithIntFlag(c.pageSizeFlag, 5, "Page size"),
+		fctl.WithHiddenFlag(c.metadataFlag),
 		fctl.WithArgs(cobra.ExactArgs(0)),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			metadata, err := fctl.ParseMetadata(fctl.GetStringSlice(cmd, metadataFlag))
-			if err != nil {
-				return err
-			}
-
-			var (
-				endTime   time.Time
-				startTime time.Time
-			)
-			if startTimeStr := fctl.GetString(cmd, startTimeFlag); startTimeStr != "" {
-				startTime, err = time.Parse(time.RFC3339Nano, startTimeStr)
-				if err != nil {
-					return err
-				}
-			}
-			if endTimeStr := fctl.GetString(cmd, endTimeFlag); endTimeStr != "" {
-				endTime, err = time.Parse(time.RFC3339Nano, endTimeStr)
-				if err != nil {
-					return err
-				}
-			}
-
-			ledger := fctl.GetString(cmd, internal.LedgerFlag)
-			response, err := ledgerClient.Ledger.ListTransactions(
-				cmd.Context(),
-				operations.ListTransactionsRequest{
-					Account:     fctl.Ptr(fctl.GetString(cmd, accountFlag)),
-					Destination: fctl.Ptr(fctl.GetString(cmd, destinationFlag)),
-					EndTime:     &endTime,
-					Ledger:      ledger,
-					Metadata:    metadata,
-					PageSize:    fctl.Ptr(int64(fctl.GetInt(cmd, pageSizeFlag))),
-					Reference:   fctl.Ptr(fctl.GetString(cmd, referenceFlag)),
-					Source:      fctl.Ptr(fctl.GetString(cmd, sourceFlag)),
-					StartTime:   &startTime,
-				},
-			)
-			if err != nil {
-				return err
-			}
-
-			if response.ErrorResponse != nil {
-				return fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
-			}
-
-			if response.StatusCode >= 300 {
-				return fmt.Errorf("unexpected status code: %d", response.StatusCode)
-			}
-
-			transactionResponse := response.TransactionsCursorResponse
-			if len(transactionResponse.Cursor.Data) == 0 {
-				fctl.Println("No transactions found.")
-				return nil
-			}
-
-			tableData := fctl.Map(transactionResponse.Cursor.Data, func(tx shared.ExpandedTransaction) []string {
-				return []string{
-					fmt.Sprintf("%d", tx.Txid),
-					func() string {
-						if tx.Reference == nil {
-							return ""
-						}
-						return *tx.Reference
-					}(),
-					tx.Timestamp.Format(time.RFC3339),
-					fctl.MetadataAsShortString(tx.Metadata),
-				}
-			})
-			tableData = fctl.Prepend(tableData, []string{"ID", "Reference", "Date", "Metadata"})
-			return pterm.DefaultTable.
-				WithHasHeader().
-				WithWriter(cmd.OutOrStdout()).
-				WithData(tableData).
-				Render()
-		}),
+		fctl.WithController[*ListStore](c),
 	)
+}
+
+func (c *ListController) GetStore() *ListStore {
+	return c.store
+}
+
+func (c *ListController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	metadata, err := fctl.ParseMetadata(fctl.GetStringSlice(cmd, c.metadataFlag))
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		endTime   time.Time
+		startTime time.Time
+	)
+	if startTimeStr := fctl.GetString(cmd, c.startTimeFlag); startTimeStr != "" {
+		startTime, err = time.Parse(time.RFC3339Nano, startTimeStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if endTimeStr := fctl.GetString(cmd, c.endTimeFlag); endTimeStr != "" {
+		endTime, err = time.Parse(time.RFC3339Nano, endTimeStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ledger := fctl.GetString(cmd, internal.LedgerFlag)
+	response, err := ledgerClient.Ledger.ListTransactions(
+		cmd.Context(),
+		operations.ListTransactionsRequest{
+			Account:     fctl.Ptr(fctl.GetString(cmd, c.accountFlag)),
+			Destination: fctl.Ptr(fctl.GetString(cmd, c.destinationFlag)),
+			EndTime:     &endTime,
+			Ledger:      ledger,
+			Metadata:    metadata,
+			PageSize:    fctl.Ptr(int64(fctl.GetInt(cmd, c.pageSizeFlag))),
+			Reference:   fctl.Ptr(fctl.GetString(cmd, c.referenceFlag)),
+			Source:      fctl.Ptr(fctl.GetString(cmd, c.sourceFlag)),
+			StartTime:   &startTime,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.ErrorResponse != nil {
+		return nil, fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
+	}
+
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
+	c.store.Transaction = response.TransactionsCursorResponse.Cursor
+
+	return c, nil
+}
+
+func (c *ListController) Render(cmd *cobra.Command, args []string) error {
+	if len(c.store.Transaction.Data) == 0 {
+		fctl.Println("No transactions found.")
+		return nil
+	}
+
+	tableData := fctl.Map(c.store.Transaction.Data, func(tx shared.ExpandedTransaction) []string {
+		return []string{
+			fmt.Sprintf("%d", tx.Txid),
+			func() string {
+				if tx.Reference == nil {
+					return ""
+				}
+				return *tx.Reference
+			}(),
+			tx.Timestamp.Format(time.RFC3339),
+			fctl.MetadataAsShortString(tx.Metadata),
+		}
+	})
+	tableData = fctl.Prepend(tableData, []string{"ID", "Reference", "Date", "Metadata"})
+
+	return pterm.DefaultTable.
+		WithHasHeader().
+		WithWriter(cmd.OutOrStdout()).
+		WithData(tableData).
+		Render()
 }

--- a/components/fctl/cmd/ledger/transactions/num.go
+++ b/components/fctl/cmd/ledger/transactions/num.go
@@ -6,142 +6,181 @@ import (
 	"strings"
 	"time"
 
-	"github.com/formancehq/fctl/cmd/ledger/internal"
+	internal "github.com/formancehq/fctl/cmd/ledger/internal"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/formancehq/formance-sdk-go/pkg/models/operations"
 	"github.com/formancehq/formance-sdk-go/pkg/models/shared"
 	"github.com/spf13/cobra"
 )
 
-func NewCommand() *cobra.Command {
-	const (
-		amountVarFlag  = "amount-var"
-		portionVarFlag = "portion-var"
-		accountVarFlag = "account-var"
-		metadataFlag   = "metadata"
-		referenceFlag  = "reference"
-		timestampFlag  = "timestamp"
-	)
+type NumStore struct {
+	Transaction *shared.Transaction `json:"transaction"`
+}
+type NumController struct {
+	store          *NumStore
+	amountVarFlag  string
+	portionVarFlag string
+	accountVarFlag string
+	metadataFlag   string
+	referenceFlag  string
+	timestampFlag  string
+}
+
+var _ fctl.Controller[*NumStore] = (*NumController)(nil)
+
+func NewDefaultNumStore() *NumStore {
+	return &NumStore{}
+}
+
+func NewNumController() *NumController {
+	return &NumController{
+		store:          NewDefaultNumStore(),
+		amountVarFlag:  "amount-var",
+		portionVarFlag: "portion-var",
+		accountVarFlag: "account-var",
+		metadataFlag:   "metadata",
+		referenceFlag:  "reference",
+		timestampFlag:  "timestamp",
+	}
+}
+
+func NewNumCommand() *cobra.Command {
+	c := NewNumController()
+
 	return fctl.NewCommand("num -|<filename>",
 		fctl.WithShortDescription("Execute a numscript script on a ledger"),
 		fctl.WithDescription(`More help on variables can be found here: https://docs.formance.com/oss/ledger/reference/numscript/variables`),
 		fctl.WithArgs(cobra.ExactArgs(1)),
 		fctl.WithConfirmFlag(),
-		fctl.WithStringSliceFlag(amountVarFlag, []string{""}, "Pass a variable of type 'amount'"),
-		fctl.WithStringSliceFlag(portionVarFlag, []string{""}, "Pass a variable of type 'portion'"),
-		fctl.WithStringSliceFlag(accountVarFlag, []string{""}, "Pass a variable of type 'account'"),
-		fctl.WithStringSliceFlag(metadataFlag, []string{""}, "Metadata to use"),
-		fctl.WithStringFlag(timestampFlag, "", "Timestamp to use (format RFC3339)"),
-		fctl.WithStringFlag(referenceFlag, "", "Reference to add to the generated transaction"),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			script, err := fctl.ReadFile(cmd, stack, args[0])
-			if err != nil {
-				return err
-			}
-
-			if !fctl.CheckStackApprobation(cmd, stack, "You are about to apply a numscript") {
-				return fctl.ErrMissingApproval
-			}
-
-			client, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			vars := map[string]interface{}{}
-			for _, v := range fctl.GetStringSlice(cmd, accountVarFlag) {
-				parts := strings.SplitN(v, "=", 2)
-				if len(parts) == 1 {
-					return fmt.Errorf("malformed var: %s", v)
-				}
-				vars[parts[0]] = parts[1]
-			}
-			for _, v := range fctl.GetStringSlice(cmd, portionVarFlag) {
-				parts := strings.SplitN(v, "=", 2)
-				if len(parts) == 1 {
-					return fmt.Errorf("malformed var: %s", v)
-				}
-				vars[parts[0]] = parts[1]
-			}
-			for _, v := range fctl.GetStringSlice(cmd, amountVarFlag) {
-				parts := strings.SplitN(v, "=", 2)
-				if len(parts) == 1 {
-					return fmt.Errorf("malformed var: %s", v)
-				}
-
-				amountParts := strings.SplitN(parts[1], "/", 2)
-				if len(amountParts) != 2 {
-					return fmt.Errorf("malformed var: %s", v)
-				}
-
-				amount, err := strconv.ParseInt(amountParts[0], 10, 64)
-				if err != nil {
-					return fmt.Errorf("malformed var: %s", v)
-				}
-
-				vars[parts[0]] = map[string]any{
-					"amount": amount,
-					"asset":  amountParts[1],
-				}
-			}
-
-			timestampStr := fctl.GetString(cmd, timestampFlag)
-			var (
-				timestamp time.Time
-			)
-			if timestampStr != "" {
-				timestamp, err = time.Parse(time.RFC3339Nano, timestampStr)
-				if err != nil {
-					return err
-				}
-			}
-
-			reference := fctl.GetString(cmd, referenceFlag)
-
-			metadata, err := fctl.ParseMetadata(fctl.GetStringSlice(cmd, metadataFlag))
-			if err != nil {
-				return err
-			}
-
-			ledger := fctl.GetString(cmd, internal.LedgerFlag)
-
-			tx, err := internal.CreateTransaction(client, cmd.Context(), ledger, operations.CreateTransactionRequest{
-				PostTransaction: shared.PostTransaction{
-					Metadata:  metadata,
-					Reference: &reference,
-					Script: &shared.PostTransactionScript{
-						Plain: script,
-						Vars:  vars,
-					},
-					Timestamp: func() *time.Time {
-						if timestamp.IsZero() {
-							return nil
-						}
-						return &timestamp
-					}(),
-				},
-				Ledger: ledger,
-			})
-			if err != nil {
-				return err
-			}
-
-			return internal.PrintTransaction(cmd.OutOrStdout(), *tx)
-		}),
+		fctl.WithStringSliceFlag(c.amountVarFlag, []string{""}, "Pass a variable of type 'amount'"),
+		fctl.WithStringSliceFlag(c.portionVarFlag, []string{""}, "Pass a variable of type 'portion'"),
+		fctl.WithStringSliceFlag(c.accountVarFlag, []string{""}, "Pass a variable of type 'account'"),
+		fctl.WithStringSliceFlag(c.metadataFlag, []string{""}, "Metadata to use"),
+		fctl.WithStringFlag(c.timestampFlag, "", "Timestamp to use (format RFC3339)"),
+		fctl.WithStringFlag(c.referenceFlag, "", "Reference to add to the generated transaction"),
+		fctl.WithController[*NumStore](c),
 	)
+}
+
+func (c *NumController) GetStore() *NumStore {
+	return c.store
+}
+
+func (c *NumController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	script, err := fctl.ReadFile(cmd, stack, args[0])
+	if err != nil {
+		return nil, err
+	}
+
+	if !fctl.CheckStackApprobation(cmd, stack, "You are about to apply a numscript") {
+		return nil, fctl.ErrMissingApproval
+	}
+
+	client, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	vars := map[string]interface{}{}
+	for _, v := range fctl.GetStringSlice(cmd, c.accountVarFlag) {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) == 1 {
+			return nil, fmt.Errorf("malformed var: %s", v)
+		}
+		vars[parts[0]] = parts[1]
+	}
+	for _, v := range fctl.GetStringSlice(cmd, c.portionVarFlag) {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) == 1 {
+			return nil, fmt.Errorf("malformed var: %s", v)
+		}
+		vars[parts[0]] = parts[1]
+	}
+	for _, v := range fctl.GetStringSlice(cmd, c.amountVarFlag) {
+		parts := strings.SplitN(v, "=", 2)
+		if len(parts) == 1 {
+			return nil, fmt.Errorf("malformed var: %s", v)
+		}
+
+		amountParts := strings.SplitN(parts[1], "/", 2)
+		if len(amountParts) != 2 {
+			return nil, fmt.Errorf("malformed var: %s", v)
+		}
+
+		amount, err := strconv.ParseInt(amountParts[0], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("malformed var: %s", v)
+		}
+
+		vars[parts[0]] = map[string]any{
+			"amount": amount,
+			"asset":  amountParts[1],
+		}
+	}
+
+	timestampStr := fctl.GetString(cmd, c.timestampFlag)
+	var (
+		timestamp time.Time
+	)
+	if timestampStr != "" {
+		timestamp, err = time.Parse(time.RFC3339Nano, timestampStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	reference := fctl.GetString(cmd, c.referenceFlag)
+
+	metadata, err := fctl.ParseMetadata(fctl.GetStringSlice(cmd, c.metadataFlag))
+	if err != nil {
+		return nil, err
+	}
+
+	ledger := fctl.GetString(cmd, internal.LedgerFlag)
+
+	tx, err := internal.CreateTransaction(client, cmd.Context(), ledger, operations.CreateTransactionRequest{
+		PostTransaction: shared.PostTransaction{
+			Metadata:  metadata,
+			Reference: &reference,
+			Script: &shared.PostTransactionScript{
+				Plain: script,
+				Vars:  vars,
+			},
+			Timestamp: func() *time.Time {
+				if timestamp.IsZero() {
+					return nil
+				}
+				return &timestamp
+			}(),
+		},
+		Ledger: ledger,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	c.store.Transaction = tx
+
+	return c, nil
+}
+
+func (c *NumController) Render(cmd *cobra.Command, args []string) error {
+
+	return internal.PrintTransaction(cmd.OutOrStdout(), *c.store.Transaction)
 }

--- a/components/fctl/cmd/ledger/transactions/revert.go
+++ b/components/fctl/cmd/ledger/transactions/revert.go
@@ -6,8 +6,28 @@ import (
 	"github.com/formancehq/fctl/cmd/ledger/internal"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/formancehq/formance-sdk-go/pkg/models/operations"
+	"github.com/formancehq/formance-sdk-go/pkg/models/shared"
 	"github.com/spf13/cobra"
 )
+
+type RevertStore struct {
+	Transaction *shared.Transaction `json:"transaction"`
+}
+type RevertController struct {
+	store *RevertStore
+}
+
+var _ fctl.Controller[*RevertStore] = (*RevertController)(nil)
+
+func NewDefaultRevertStore() *RevertStore {
+	return &RevertStore{}
+}
+
+func NewRevertController() *RevertController {
+	return &RevertController{
+		store: NewDefaultRevertStore(),
+	}
+}
 
 func NewRevertCommand() *cobra.Command {
 	return fctl.NewCommand("revert <transaction-id>",
@@ -15,56 +35,68 @@ func NewRevertCommand() *cobra.Command {
 		fctl.WithShortDescription("Revert a transaction"),
 		fctl.WithArgs(cobra.ExactArgs(1)),
 		fctl.WithValidArgs("last"),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			if !fctl.CheckStackApprobation(cmd, stack, "You are about to revert transaction %s", args[0]) {
-				return fctl.ErrMissingApproval
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			ledger := fctl.GetString(cmd, internal.LedgerFlag)
-			txId, err := internal.TransactionIDOrLastN(cmd.Context(), ledgerClient, ledger, args[0])
-			if err != nil {
-				return err
-			}
-
-			request := operations.RevertTransactionRequest{
-				Ledger: ledger,
-				Txid:   txId,
-			}
-
-			response, err := ledgerClient.Ledger.RevertTransaction(cmd.Context(), request)
-			if err != nil {
-				return err
-			}
-
-			if response.ErrorResponse != nil {
-				return fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
-			}
-
-			if response.StatusCode >= 300 {
-				return fmt.Errorf("unexpected status code: %d", response.StatusCode)
-			}
-
-			return internal.PrintTransaction(cmd.OutOrStdout(), response.RevertTransactionResponse.Data)
-		}),
+		fctl.WithController[*RevertStore](NewRevertController()),
 	)
+}
+
+func (c *RevertController) GetStore() *RevertStore {
+	return c.store
+}
+
+func (c *RevertController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	if !fctl.CheckStackApprobation(cmd, stack, "You are about to revert transaction %s", args[0]) {
+		return nil, fctl.ErrMissingApproval
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	ledger := fctl.GetString(cmd, internal.LedgerFlag)
+	txId, err := internal.TransactionIDOrLastN(cmd.Context(), ledgerClient, ledger, args[0])
+	if err != nil {
+		return nil, err
+	}
+
+	request := operations.RevertTransactionRequest{
+		Ledger: ledger,
+		Txid:   txId,
+	}
+
+	response, err := ledgerClient.Ledger.RevertTransaction(cmd.Context(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.ErrorResponse != nil {
+		return nil, fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
+	}
+
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
+	c.store.Transaction = &response.RevertTransactionResponse.Data
+
+	return c, nil
+}
+
+func (c *RevertController) Render(cmd *cobra.Command, args []string) error {
+	return internal.PrintTransaction(cmd.OutOrStdout(), *c.store.Transaction)
 }

--- a/components/fctl/cmd/ledger/transactions/root.go
+++ b/components/fctl/cmd/ledger/transactions/root.go
@@ -11,7 +11,7 @@ func NewLedgerTransactionsCommand() *cobra.Command {
 		fctl.WithShortDescription("Transactions management"),
 		fctl.WithChildCommands(
 			NewListCommand(),
-			NewCommand(),
+			NewNumCommand(),
 			NewRevertCommand(),
 			NewShowCommand(),
 			NewSetMetadataCommand(),

--- a/components/fctl/cmd/ledger/transactions/set_metadata.go
+++ b/components/fctl/cmd/ledger/transactions/set_metadata.go
@@ -10,6 +10,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type SetMetadataStore struct {
+	Success bool `json:"success"`
+}
+type SetMetadataController struct {
+	store *SetMetadataStore
+}
+
+var _ fctl.Controller[*SetMetadataStore] = (*SetMetadataController)(nil)
+
+func NewDefaultSetMetadataStore() *SetMetadataStore {
+	return &SetMetadataStore{}
+}
+
+func NewSetMetadataController() *SetMetadataController {
+	return &SetMetadataController{
+		store: NewDefaultSetMetadataStore(),
+	}
+}
+
 func NewSetMetadataCommand() *cobra.Command {
 	return fctl.NewCommand("set-metadata <transaction-id> [<key>=<value>...]",
 		fctl.WithShortDescription("Set metadata on transaction"),
@@ -17,63 +36,75 @@ func NewSetMetadataCommand() *cobra.Command {
 		fctl.WithConfirmFlag(),
 		fctl.WithValidArgs("last"),
 		fctl.WithArgs(cobra.MinimumNArgs(2)),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-
-			metadata, err := fctl.ParseMetadata(args[1:])
-			if err != nil {
-				return err
-			}
-
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			transactionID, err := internal.TransactionIDOrLastN(cmd.Context(), ledgerClient,
-				fctl.GetString(cmd, internal.LedgerFlag), args[0])
-			if err != nil {
-				return err
-			}
-
-			if !fctl.CheckStackApprobation(cmd, stack, "You are about to set a metadata on transaction %d", transactionID) {
-				return fctl.ErrMissingApproval
-			}
-
-			request := operations.AddMetadataOnTransactionRequest{
-				Ledger:      fctl.GetString(cmd, internal.LedgerFlag),
-				Txid:        transactionID,
-				RequestBody: metadata,
-			}
-			response, err := ledgerClient.Ledger.AddMetadataOnTransaction(cmd.Context(), request)
-			if err != nil {
-				return err
-			}
-
-			if response.ErrorResponse != nil {
-				return fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
-			}
-
-			if response.StatusCode >= 300 {
-				return fmt.Errorf("unexpected status code: %d", response.StatusCode)
-			}
-
-			pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Metadata added!")
-			return nil
-		}),
+		fctl.WithController[*SetMetadataStore](NewSetMetadataController()),
 	)
+}
+
+func (c *SetMetadataController) GetStore() *SetMetadataStore {
+	return c.store
+}
+
+func (c *SetMetadataController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+
+	metadata, err := fctl.ParseMetadata(args[1:])
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	transactionID, err := internal.TransactionIDOrLastN(cmd.Context(), ledgerClient,
+		fctl.GetString(cmd, internal.LedgerFlag), args[0])
+	if err != nil {
+		return nil, err
+	}
+
+	if !fctl.CheckStackApprobation(cmd, stack, "You are about to set a metadata on transaction %d", transactionID) {
+		return nil, fctl.ErrMissingApproval
+	}
+
+	request := operations.AddMetadataOnTransactionRequest{
+		Ledger:      fctl.GetString(cmd, internal.LedgerFlag),
+		Txid:        transactionID,
+		RequestBody: metadata,
+	}
+	response, err := ledgerClient.Ledger.AddMetadataOnTransaction(cmd.Context(), request)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.ErrorResponse != nil {
+		return nil, fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
+	}
+
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
+	c.store.Success = response.StatusCode == 204
+	return c, nil
+}
+
+// TODO: This need to use the ui.NewListModel
+func (c *SetMetadataController) Render(cmd *cobra.Command, args []string) error {
+	pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Metadata added!")
+	return nil
 }

--- a/components/fctl/cmd/ledger/transactions/show.go
+++ b/components/fctl/cmd/ledger/transactions/show.go
@@ -6,8 +6,28 @@ import (
 	"github.com/formancehq/fctl/cmd/ledger/internal"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/formancehq/formance-sdk-go/pkg/models/operations"
+	"github.com/formancehq/formance-sdk-go/pkg/models/shared"
 	"github.com/spf13/cobra"
 )
+
+type ShowStore struct {
+	Transaction shared.ExpandedTransaction `json:"transaction"`
+}
+type ShowController struct {
+	store *ShowStore
+}
+
+var _ fctl.Controller[*ShowStore] = (*ShowController)(nil)
+
+func NewDefaultShowStore() *ShowStore {
+	return &ShowStore{}
+}
+
+func NewShowController() *ShowController {
+	return &ShowController{
+		store: NewDefaultShowStore(),
+	}
+}
 
 func NewShowCommand() *cobra.Command {
 	return fctl.NewCommand("show <transaction-id>",
@@ -15,53 +35,65 @@ func NewShowCommand() *cobra.Command {
 		fctl.WithArgs(cobra.ExactArgs(1)),
 		fctl.WithAliases("sh"),
 		fctl.WithValidArgs("last"),
-		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
-			cfg, err := fctl.GetConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
-			if err != nil {
-				return err
-			}
-
-			stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
-			if err != nil {
-				return err
-			}
-
-			ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
-			if err != nil {
-				return err
-			}
-
-			ledger := fctl.GetString(cmd, internal.LedgerFlag)
-			txId, err := internal.TransactionIDOrLastN(cmd.Context(), ledgerClient, ledger, args[0])
-			if err != nil {
-				return err
-			}
-
-			response, err := ledgerClient.Ledger.GetTransaction(
-				cmd.Context(),
-				operations.GetTransactionRequest{
-					Ledger: ledger,
-					Txid:   txId,
-				},
-			)
-			if err != nil {
-				return err
-			}
-
-			if response.ErrorResponse != nil {
-				return fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
-			}
-
-			if response.StatusCode >= 300 {
-				return fmt.Errorf("unexpected status code: %d", response.StatusCode)
-			}
-
-			return internal.PrintExpandedTransaction(cmd.OutOrStdout(), response.GetTransactionResponse.Data)
-		}),
+		fctl.WithController[*ShowStore](NewShowController()),
 	)
+}
+
+func (c *ShowController) GetStore() *ShowStore {
+	return c.store
+}
+
+func (c *ShowController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+	cfg, err := fctl.GetConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationID, err := fctl.ResolveOrganizationID(cmd, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	stack, err := fctl.ResolveStack(cmd, cfg, organizationID)
+	if err != nil {
+		return nil, err
+	}
+
+	ledgerClient, err := fctl.NewStackClient(cmd, cfg, stack)
+	if err != nil {
+		return nil, err
+	}
+
+	ledger := fctl.GetString(cmd, internal.LedgerFlag)
+	txId, err := internal.TransactionIDOrLastN(cmd.Context(), ledgerClient, ledger, args[0])
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := ledgerClient.Ledger.GetTransaction(
+		cmd.Context(),
+		operations.GetTransactionRequest{
+			Ledger: ledger,
+			Txid:   txId,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.ErrorResponse != nil {
+		return nil, fmt.Errorf("%s: %s", response.ErrorResponse.ErrorCode, response.ErrorResponse.ErrorMessage)
+	}
+
+	if response.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
+	c.store.Transaction = response.GetTransactionResponse.Data
+
+	return c, nil
+}
+
+func (c *ShowController) Render(cmd *cobra.Command, args []string) error {
+	return internal.PrintExpandedTransaction(cmd.OutOrStdout(), c.store.Transaction)
 }


### PR DESCRIPTION
Response has `Data` object intermediary but sdk doesn't :
- fctl ledger send
- fctl ledger list
- fctl ledger server-infos

Metadata map[string][string] and response from sdk is map[string][[]string{}]:
- fctl ledger transaction revert

