### PR TITLE
fix: fctl stack show

### DIFF
--- a/components/fctl/cmd/ledger/internal/show.go
+++ b/components/fctl/cmd/ledger/internal/show.go
@@ -28,7 +28,7 @@ type GetTransactionResponse struct {
 	RawResponse            *http.Response
 }
 
-func GetTransaction(client formance.Formance, ctx context.Context, baseURL string, request operations.GetTransactionRequest) (*GetTransactionResponse, error) {
+func GetTransaction(client *formance.Formance, ctx context.Context, baseURL string, request operations.GetTransactionRequest) (*GetTransactionResponse, error) {
 
 	// Dirty hack to get the http client from the sdk client struct
 	field := reflect.ValueOf(client).Elem().FieldByName("_securityClient")

--- a/components/fctl/cmd/ledger/transactions/show.go
+++ b/components/fctl/cmd/ledger/transactions/show.go
@@ -46,7 +46,7 @@ func NewShowCommand() *cobra.Command {
 			baseUrl := profile.ServicesBaseUrl(stack).String()
 
 			response, err := internal.GetTransaction(
-				*ledgerClient,
+				ledgerClient,
 				cmd.Context(),
 				baseUrl,
 				operations.GetTransactionRequest{


### PR DESCRIPTION
client in 'field := reflect.ValueOf(client).Elem().FieldByName('_securityClient')' seems to want an adress