### PR TITLE
feat(fctl): remove-cobra-controller-dep

### DIFF
--- a/components/fctl/.goreleaser.yml
+++ b/components/fctl/.goreleaser.yml
@@ -10,9 +10,9 @@ builds:
   - binary: fctl
     id: fctl
     ldflags:
-      - -X github.com/formancehq/fctl/cmd.BuildDate={{ .Date }}
-      - -X github.com/formancehq/fctl/cmd.Version={{ .Version }}
-      - -X github.com/formancehq/fctl/cmd.Commit={{ .ShortCommit }}
+      - -X github.com/formancehq/fctl/pkg.BuildDate={{ .Date }}
+      - -X github.com/formancehq/fctl/pkg.Version={{ .Version }}
+      - -X github.com/formancehq/fctl/pkg.Commit={{ .ShortCommit }}
       - -X github.com/formancehq/fctl/pkg.DefaultSegmentWriteKey={{ .Env.SEGMENT_WRITE_KEY }}
       - -extldflags "-static"
     env:

--- a/components/fctl/Dockerfile
+++ b/components/fctl/Dockerfile
@@ -6,9 +6,9 @@ COPY . .
 WORKDIR /src/components/fctl
 RUN go mod download
 RUN GOOS=linux go build -o fctl \
-    -ldflags="-X $(cat go.mod |head -1|cut -d \  -f2)/cmd.Version=${VERSION} \
-    -X $(cat go.mod |head -1|cut -d \  -f2)/cmd.BuildDate=$(date +%s) \
-    -X $(cat go.mod |head -1|cut -d \  -f2)/cmd.Commit=${APP_SHA}" ./
+    -ldflags="-X $(cat go.mod |head -1|cut -d \  -f2)/pkg.Version=${VERSION} \
+    -X $(cat go.mod |head -1|cut -d \  -f2)/pkg.BuildDate=$(date +%s) \
+    -X $(cat go.mod |head -1|cut -d \  -f2)/pkg.Commit=${APP_SHA}" ./
 
 FROM ubuntu:22.04
 RUN apt update && apt install -y ca-certificates curl && rm -rf /var/lib/apt/lists/*

--- a/components/fctl/cmd/root.go
+++ b/components/fctl/cmd/root.go
@@ -4,24 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"os/signal"
 	"runtime/debug"
 
-	"github.com/formancehq/fctl/cmd/auth"
-	"github.com/formancehq/fctl/cmd/cloud"
-	"github.com/formancehq/fctl/cmd/ledger"
 	"github.com/formancehq/fctl/cmd/login"
-	"github.com/formancehq/fctl/cmd/orchestration"
-	"github.com/formancehq/fctl/cmd/payments"
-	"github.com/formancehq/fctl/cmd/profiles"
-	"github.com/formancehq/fctl/cmd/search"
 	"github.com/formancehq/fctl/cmd/stack"
-	"github.com/formancehq/fctl/cmd/ui"
-	"github.com/formancehq/fctl/cmd/version"
-	"github.com/formancehq/fctl/cmd/wallets"
-	"github.com/formancehq/fctl/cmd/webhooks"
 	"github.com/formancehq/fctl/membershipclient"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/formancehq/formance-sdk-go/pkg/models/shared"
@@ -31,38 +19,28 @@ import (
 )
 
 func NewRootCommand() *cobra.Command {
-	homedir, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
-
 	cmd := fctl.NewCommand("fctl",
 		fctl.WithSilenceError(),
 		fctl.WithShortDescription("Formance Control CLI"),
 		fctl.WithSilenceUsage(),
 		fctl.WithChildCommands(
-			ui.NewCommand(),
-			version.NewCommand(),
+			// ui.NewCommand(),
+			// version.NewCommand(),
 			login.NewCommand(),
-			NewPromptCommand(),
-			ledger.NewCommand(),
-			payments.NewCommand(),
-			profiles.NewCommand(),
+			// NewPromptCommand(),
+			// ledger.NewCommand(),
+			// payments.NewCommand(),
+			// profiles.NewCommand(),
 			stack.NewCommand(),
-			auth.NewCommand(),
-			cloud.NewCommand(),
-			search.NewCommand(),
-			webhooks.NewCommand(),
-			wallets.NewCommand(),
-			orchestration.NewCommand(),
+			// auth.NewCommand(),
+			// cloud.NewCommand(),
+			// search.NewCommand(),
+			// webhooks.NewCommand(),
+			// wallets.NewCommand(),
+			// orchestration.NewCommand(),
 		),
-		fctl.WithPersistentStringPFlag(fctl.ProfileFlag, "p", "", "config profile to use"),
-		fctl.WithPersistentStringPFlag(fctl.FileFlag, "c", fmt.Sprintf("%s/.formance/fctl.config", homedir), "Debug mode"),
-		fctl.WithPersistentBoolPFlag(fctl.DebugFlag, "d", false, "Debug mode"),
-		fctl.WithPersistentStringPFlag(fctl.OutputFlag, "o", "plain", "Output format (plain, json)"),
-		fctl.WithPersistentBoolFlag(fctl.InsecureTlsFlag, false, "Insecure TLS"),
-		fctl.WithPersistentBoolFlag(fctl.TelemetryFlag, false, "Telemetry enabled"),
 	)
+
 	cmd.RegisterFlagCompletionFunc(fctl.ProfileFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		flags := fctl.ConvertPFlagSetToFlagSet(cmd.Flags())
 
@@ -88,7 +66,11 @@ func Execute() {
 	}()
 
 	ctx, _ := signal.NotifyContext(context.TODO(), os.Interrupt)
-	err := NewRootCommand().ExecuteContext(ctx)
+
+	rootCmd := NewRootCommand()
+	rootCmd.Flags().AddGoFlagSet(fctl.WithGlobalFlags(nil))
+
+	err := rootCmd.ExecuteContext(ctx)
 	if err != nil {
 		switch {
 		case errors.Is(err, fctl.ErrMissingApproval):

--- a/components/fctl/cmd/root.go
+++ b/components/fctl/cmd/root.go
@@ -63,9 +63,10 @@ func NewRootCommand() *cobra.Command {
 		fctl.WithPersistentBoolFlag(fctl.InsecureTlsFlag, false, "Insecure TLS"),
 		fctl.WithPersistentBoolFlag(fctl.TelemetryFlag, false, "Telemetry enabled"),
 	)
-	cmd.Version = version.Version
 	cmd.RegisterFlagCompletionFunc(fctl.ProfileFlag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		cfg, err := fctl.GetConfig(cmd)
+		flags := fctl.ConvertPFlagSetToFlagSet(cmd.Flags())
+
+		cfg, err := fctl.GetConfig(flags)
 		if err != nil {
 			return []string{}, cobra.ShellCompDirectiveError
 		}

--- a/components/fctl/cmd/stack/controller.go
+++ b/components/fctl/cmd/stack/controller.go
@@ -1,31 +1,32 @@
 package stack
 
 import (
+	"context"
+	"flag"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/formancehq/fctl/membershipclient"
 	fctl "github.com/formancehq/fctl/pkg"
-	"github.com/spf13/cobra"
 )
 
-func waitStackReady(cmd *cobra.Command, profile *fctl.Profile, stack *membershipclient.Stack) error {
+func waitStackReady(ctx context.Context, flags *flag.FlagSet, profile *fctl.Profile, stack *membershipclient.Stack) error {
 	baseUrlStr := profile.ServicesBaseUrl(stack).String()
 	authServerUrl := fmt.Sprintf("%s/api/auth", baseUrlStr)
 	for {
-		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet,
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet,
 			fmt.Sprintf(authServerUrl+"/.well-known/openid-configuration"), nil)
 		if err != nil {
 			return err
 		}
-		rsp, err := fctl.GetHttpClient(cmd, map[string][]string{}).Do(req)
+		rsp, err := fctl.GetHttpClient(flags, map[string][]string{}).Do(req)
 		if err == nil && rsp.StatusCode == http.StatusOK {
 			break
 		}
 		select {
-		case <-cmd.Context().Done():
-			return cmd.Context().Err()
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-time.After(time.Second):
 		}
 	}

--- a/components/fctl/cmd/stack/delete.go
+++ b/components/fctl/cmd/stack/delete.go
@@ -1,6 +1,12 @@
 package stack
 
 import (
+	"context"
+	"flag"
+	"io"
+	"os"
+
+	"github.com/formancehq/fctl/cmd/stack/internal"
 	"github.com/formancehq/fctl/membershipclient"
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/pkg/errors"
@@ -8,15 +14,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	useDelete         = "delete (<stack-id> | --name=<stack-name>)"
+	descriptionDelete = "Delete a stack"
+)
+
 type DeletedStackStore struct {
 	Stack  *membershipclient.Stack `json:"stack"`
 	Status string                  `json:"status"`
 }
-type StackDeleteController struct {
-	store *DeletedStackStore
-}
-
-var _ fctl.Controller[*DeletedStackStore] = (*StackDeleteController)(nil)
 
 func NewDefaultDeletedStackStore() *DeletedStackStore {
 	return &DeletedStackStore{
@@ -25,69 +31,109 @@ func NewDefaultDeletedStackStore() *DeletedStackStore {
 	}
 }
 
-func NewStackDeleteController() *StackDeleteController {
-	return &StackDeleteController{
-		store: NewDefaultDeletedStackStore(),
+type StackDeleteControllerConfig struct {
+	context     context.Context
+	use         string
+	description string
+	aliases     []string
+	out         io.Writer
+	flags       *flag.FlagSet
+	args        []string
+}
+
+func NewStackDeleteControllerConfig() *StackDeleteControllerConfig {
+	flags := flag.NewFlagSet(useDelete, flag.ExitOnError)
+	flags.String(internal.StackNameFlag, "", "Stack to remove")
+	fctl.WithConfirmFlag(flags)
+	fctl.WithGlobalFlags(flags)
+
+	return &StackDeleteControllerConfig{
+		context:     nil,
+		use:         useDelete,
+		description: descriptionDelete,
+		aliases: []string{
+			"del",
+			"d",
+		},
+		out:   os.Stdout,
+		flags: flags,
+		args:  []string{},
 	}
 }
 
-func NewDeleteCommand() *cobra.Command {
-	const (
-		stackNameFlag = "name"
-	)
-	return fctl.NewMembershipCommand("delete (<stack-id> | --name=<stack-name>)",
-		fctl.WithConfirmFlag(),
-		fctl.WithShortDescription("Delete a stack"),
-		fctl.WithAliases("del", "d"),
-		fctl.WithArgs(cobra.MaximumNArgs(1)),
-		fctl.WithStringFlag(stackNameFlag, "", "Stack to remove"),
-		fctl.WithController[*DeletedStackStore](NewStackDeleteController()),
-	)
+var _ fctl.Controller[*DeletedStackStore] = (*StackDeleteController)(nil)
+
+type StackDeleteController struct {
+	store  *DeletedStackStore
+	config StackDeleteControllerConfig
 }
+
+func NewStackDeleteController(config StackDeleteControllerConfig) *StackDeleteController {
+	return &StackDeleteController{
+		store:  NewDefaultDeletedStackStore(),
+		config: config,
+	}
+}
+func (c *StackDeleteController) GetFlags() *flag.FlagSet {
+	return c.config.flags
+}
+
+func (c *StackDeleteController) GetContext() context.Context {
+	return c.config.context
+}
+
+func (c *StackDeleteController) SetContext(ctx context.Context) {
+	c.config.context = ctx
+}
+
 func (c *StackDeleteController) GetStore() *DeletedStackStore {
 	return c.store
 }
 
-func (c *StackDeleteController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
-	const (
-		stackNameFlag = "name"
-	)
+func (c *StackDeleteController) SetArgs(args []string) {
+	c.config.args = append([]string{}, args...)
 
-	cfg, err := fctl.GetConfig(cmd)
+}
+
+func (c *StackDeleteController) Run() (fctl.Renderable, error) {
+	flags := c.config.flags
+	ctx := c.config.context
+
+	cfg, err := fctl.GetConfig(flags)
 	if err != nil {
 		return nil, err
 	}
-	organization, err := fctl.ResolveOrganizationID(cmd, cfg)
+	organization, err := fctl.ResolveOrganizationID(flags, ctx, cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "searching default organization")
 	}
 
-	apiClient, err := fctl.NewMembershipClient(cmd, cfg)
+	apiClient, err := fctl.NewMembershipClient(flags, ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	var stack *membershipclient.Stack
-	if len(args) == 1 {
-		if fctl.GetString(cmd, stackNameFlag) != "" {
+	if len(c.config.args) == 1 {
+		if fctl.GetString(flags, internal.StackNameFlag) != "" {
 			return nil, errors.New("need either an id of a name specified using --name flag")
 		}
 
-		rsp, _, err := apiClient.DefaultApi.ReadStack(cmd.Context(), organization, args[0]).Execute()
+		rsp, _, err := apiClient.DefaultApi.ReadStack(ctx, organization, c.config.args[0]).Execute()
 		if err != nil {
 			return nil, err
 		}
 		stack = rsp.Data
 	} else {
-		if fctl.GetString(cmd, stackNameFlag) == "" {
+		if fctl.GetString(flags, internal.StackNameFlag) == "" {
 			return nil, errors.New("need either an id of a name specified using --name flag")
 		}
-		stacks, _, err := apiClient.DefaultApi.ListStacks(cmd.Context(), organization).Execute()
+		stacks, _, err := apiClient.DefaultApi.ListStacks(ctx, organization).Execute()
 		if err != nil {
 			return nil, errors.Wrap(err, "listing stacks")
 		}
 		for _, s := range stacks.Data {
-			if s.Name == fctl.GetString(cmd, stackNameFlag) {
+			if s.Name == fctl.GetString(flags, internal.StackNameFlag) {
 				stack = &s
 				break
 			}
@@ -97,11 +143,11 @@ func (c *StackDeleteController) Run(cmd *cobra.Command, args []string) (fctl.Ren
 		return nil, errors.New("Stack not found")
 	}
 
-	if !fctl.CheckStackApprobation(cmd, stack, "You are about to delete stack '%s'", stack.Name) {
+	if !fctl.CheckStackApprobation(flags, stack, "You are about to delete stack '%s'", stack.Name) {
 		return nil, fctl.ErrMissingApproval
 	}
 
-	if _, err := apiClient.DefaultApi.DeleteStack(cmd.Context(), organization, stack.Id).Execute(); err != nil {
+	if _, err := apiClient.DefaultApi.DeleteStack(ctx, organization, stack.Id).Execute(); err != nil {
 		return nil, errors.Wrap(err, "deleting stack")
 	}
 
@@ -111,7 +157,18 @@ func (c *StackDeleteController) Run(cmd *cobra.Command, args []string) (fctl.Ren
 	return c, nil
 }
 
-func (c *StackDeleteController) Render(cmd *cobra.Command, args []string) error {
-	pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln("Stack deleted.")
+func (c *StackDeleteController) Render() error {
+	pterm.Success.WithWriter(c.config.out).Printfln("Stack deleted.")
 	return nil
+}
+
+func NewDeleteCommand() *cobra.Command {
+	config := NewStackDeleteControllerConfig()
+	return fctl.NewMembershipCommand(config.use,
+		fctl.WithShortDescription(config.description),
+		fctl.WithAliases(config.aliases...),
+		fctl.WithArgs(cobra.MaximumNArgs(1)),
+		fctl.WithGoFlagSet(config.flags),
+		fctl.WithController[*DeletedStackStore](NewStackDeleteController(*config)),
+	)
 }

--- a/components/fctl/cmd/stack/internal/global.go
+++ b/components/fctl/cmd/stack/internal/global.go
@@ -1,0 +1,5 @@
+package internal
+
+const (
+	StackNameFlag = "name"
+)

--- a/components/fctl/cmd/stack/root.go
+++ b/components/fctl/cmd/stack/root.go
@@ -10,11 +10,11 @@ func NewCommand() *cobra.Command {
 		fctl.WithShortDescription("Manage your stack"),
 		fctl.WithAliases("stack", "stacks", "st"),
 		fctl.WithChildCommands(
-			NewCreateCommand(),
+			// NewCreateCommand(),
 			NewListCommand(),
-			NewDeleteCommand(),
-			NewShowCommand(),
-			NewRestoreStackCommand(),
+			// NewDeleteCommand(),
+			// NewShowCommand(),
+			// NewRestoreStackCommand(),
 		),
 	)
 }

--- a/components/fctl/cmd/webhooks/secret.go
+++ b/components/fctl/cmd/webhooks/secret.go
@@ -36,7 +36,7 @@ func NewChangeSecretWebhookController() *ChangeSecretWebhookController {
 func (c *ChangeSecretWebhookController) GetStore() *ChangeSecretStore {
 	return c.store
 }
-func (c *ChangeSecretWebhookController) Run(cmd *cobra.Command, args []string) (fctl.Renderable, error) {
+func (c *ChangeSecretWebhookController) Run() (fctl.Renderable, error) {
 	cfg, err := fctl.GetConfig(cmd)
 	if err != nil {
 		return nil, errors.Wrap(err, "fctl.GetConfig")
@@ -91,7 +91,7 @@ func (c *ChangeSecretWebhookController) Run(cmd *cobra.Command, args []string) (
 	return c, nil
 }
 
-func (c *ChangeSecretWebhookController) Render(cmd *cobra.Command, args []string) error {
+func (c *ChangeSecretWebhookController) Render() error {
 	pterm.Success.WithWriter(cmd.OutOrStdout()).Printfln(
 		"Config '%s' updated successfully with new secret", c.store.ID)
 	return nil

--- a/components/fctl/pkg/approval.go
+++ b/components/fctl/pkg/approval.go
@@ -1,13 +1,13 @@
 package fctl
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 
 	"github.com/formancehq/fctl/membershipclient"
 	"github.com/pkg/errors"
 	"github.com/pterm/pterm"
-	"github.com/spf13/cobra"
 )
 
 var ErrMissingApproval = errors.New("Missing approval.")
@@ -30,21 +30,21 @@ func IsProtectedStack(stack *membershipclient.Stack) bool {
 	return stack.Metadata != nil && (stack.Metadata)[ProtectedStackMetadata] == "Yes"
 }
 
-func NeedConfirm(cmd *cobra.Command, stack *membershipclient.Stack) bool {
+func NeedConfirm(flags *flag.FlagSet, stack *membershipclient.Stack) bool {
 	if !IsProtectedStack(stack) {
 		return false
 	}
-	if GetBool(cmd, confirmFlag) {
+	if GetBool(flags, confirmFlag) {
 		return false
 	}
 	return true
 }
 
-func CheckStackApprobation(cmd *cobra.Command, stack *membershipclient.Stack, disclaimer string, args ...any) bool {
+func CheckStackApprobation(flags *flag.FlagSet, stack *membershipclient.Stack, disclaimer string, args ...any) bool {
 	if !IsProtectedStack(stack) {
 		return true
 	}
-	if GetBool(cmd, confirmFlag) {
+	if GetBool(flags, confirmFlag) {
 		return true
 	}
 
@@ -57,8 +57,8 @@ func CheckStackApprobation(cmd *cobra.Command, stack *membershipclient.Stack, di
 	return strings.ToLower(result) == "y"
 }
 
-func CheckOrganizationApprobation(cmd *cobra.Command, disclaimer string, args ...any) bool {
-	if GetBool(cmd, confirmFlag) {
+func CheckOrganizationApprobation(flags *flag.FlagSet, disclaimer string, args ...any) bool {
+	if GetBool(flags, confirmFlag) {
 		return true
 	}
 

--- a/components/fctl/pkg/clients.go
+++ b/components/fctl/pkg/clients.go
@@ -1,43 +1,43 @@
 package fctl
 
 import (
+	"context"
+	"flag"
 	"fmt"
 
 	"github.com/formancehq/fctl/membershipclient"
 	"github.com/formancehq/formance-sdk-go"
-	"github.com/spf13/cobra"
 )
 
-func getVersion(cmd *cobra.Command) string {
-	for cmd != nil {
-		if cmd.Version != "" {
-			return cmd.Version
-		}
-		cmd = cmd.Parent()
-	}
-	return "cmd.Version"
+func getVersion() string {
+	return Version
 }
 
-func NewMembershipClient(cmd *cobra.Command, cfg *Config) (*membershipclient.APIClient, error) {
-	profile := GetCurrentProfile(cmd, cfg)
-	httpClient := GetHttpClient(cmd, map[string][]string{})
+func NewMembershipClient(flags *flag.FlagSet, ctx context.Context, cfg *Config) (*membershipclient.APIClient, error) {
+	profile := GetCurrentProfile(flags, cfg)
+
+	httpClient := GetHttpClient(flags, map[string][]string{})
+
 	configuration := membershipclient.NewConfiguration()
-	token, err := profile.GetToken(cmd.Context(), httpClient)
+
+	token, err := profile.GetToken(ctx, httpClient)
 	if err != nil {
 		return nil, err
 	}
+
 	configuration.AddDefaultHeader("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken))
 	configuration.HTTPClient = httpClient
-	configuration.UserAgent = "fctl/" + getVersion(cmd)
+	configuration.UserAgent = "fctl/" + getVersion()
 	configuration.Servers[0].URL = profile.GetMembershipURI()
+
 	return membershipclient.NewAPIClient(configuration), nil
 }
 
-func NewStackClient(cmd *cobra.Command, cfg *Config, stack *membershipclient.Stack) (*formance.Formance, error) {
-	profile := GetCurrentProfile(cmd, cfg)
-	httpClient := GetHttpClient(cmd, map[string][]string{})
+func NewStackClient(flags *flag.FlagSet, ctx context.Context, cfg *Config, stack *membershipclient.Stack) (*formance.Formance, error) {
+	profile := GetCurrentProfile(flags, cfg)
+	httpClient := GetHttpClient(flags, map[string][]string{})
 
-	token, err := profile.GetStackToken(cmd.Context(), httpClient, stack)
+	token, err := profile.GetStackToken(ctx, httpClient, stack)
 	if err != nil {
 		return nil, err
 	}
@@ -45,9 +45,9 @@ func NewStackClient(cmd *cobra.Command, cfg *Config, stack *membershipclient.Sta
 	return formance.New(
 		formance.WithServerURL(stack.Uri),
 		formance.WithClient(
-			GetHttpClient(cmd, map[string][]string{
+			GetHttpClient(flags, map[string][]string{
 				"Authorization": {fmt.Sprintf("Bearer %s", token)},
-				"User-Agent":    {"fctl/" + getVersion(cmd)},
+				"User-Agent":    {"fctl/" + getVersion()},
 			}),
 		),
 	), nil

--- a/components/fctl/pkg/command.go
+++ b/components/fctl/pkg/command.go
@@ -1,7 +1,9 @@
 package fctl
 
 import (
+	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 
 	"github.com/TylerBrock/colorjson"
@@ -30,18 +32,18 @@ type StackOrganizationConfig struct {
 	Config         *Config
 }
 
-func GetStackOrganizationConfig(cmd *cobra.Command) (*StackOrganizationConfig, error) {
-	cfg, err := GetConfig(cmd)
+func GetStackOrganizationConfig(flags *flag.FlagSet) (*StackOrganizationConfig, error) {
+	cfg, err := GetConfig(flags)
 	if err != nil {
 		return nil, err
 	}
 
-	organizationID, err := ResolveOrganizationID(cmd, cfg)
+	organizationID, err := ResolveOrganizationID(flags, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	stack, err := ResolveStack(cmd, cfg, organizationID)
+	stack, err := ResolveStack(flags, cfg, organizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,45 +55,45 @@ func GetStackOrganizationConfig(cmd *cobra.Command) (*StackOrganizationConfig, e
 	}, nil
 }
 
-func GetStackOrganizationConfigApprobation(cmd *cobra.Command, disclaimer string, args ...any) (*StackOrganizationConfig, error) {
-	soc, err := GetStackOrganizationConfig(cmd)
+func GetStackOrganizationConfigApprobation(flags *flag.FlagSet, disclaimer string, args ...any) (*StackOrganizationConfig, error) {
+	soc, err := GetStackOrganizationConfig(flags)
 	if err != nil {
 		return nil, err
 	}
 
-	if !CheckStackApprobation(cmd, soc.Stack, disclaimer, args...) {
+	if !CheckStackApprobation(flags, soc.Stack, disclaimer, args...) {
 		return nil, ErrMissingApproval
 	}
 
 	return soc, nil
 }
 
-func GetSelectedOrganization(cmd *cobra.Command) string {
-	return GetString(cmd, organizationFlag)
+func GetSelectedOrganization(flags *flag.FlagSet) string {
+	return GetString(flags, organizationFlag)
 }
 
-func RetrieveOrganizationIDFromFlagOrProfile(cmd *cobra.Command, cfg *Config) (string, error) {
-	if id := GetSelectedOrganization(cmd); id != "" {
+func RetrieveOrganizationIDFromFlagOrProfile(flags *flag.FlagSet, cfg *Config) (string, error) {
+	if id := GetSelectedOrganization(flags); id != "" {
 		return id, nil
 	}
 
-	if defaultOrganization := GetCurrentProfile(cmd, cfg).GetDefaultOrganization(); defaultOrganization != "" {
+	if defaultOrganization := GetCurrentProfile(flags, cfg).GetDefaultOrganization(); defaultOrganization != "" {
 		return defaultOrganization, nil
 	}
 	return "", ErrOrganizationNotSpecified
 }
 
-func ResolveOrganizationID(cmd *cobra.Command, cfg *Config) (string, error) {
-	if id, err := RetrieveOrganizationIDFromFlagOrProfile(cmd, cfg); err == nil {
+func ResolveOrganizationID(flags *flag.FlagSet, ctx context.Context, cfg *Config) (string, error) {
+	if id, err := RetrieveOrganizationIDFromFlagOrProfile(flags, cfg); err == nil {
 		return id, nil
 	}
 
-	client, err := NewMembershipClient(cmd, cfg)
+	client, err := NewMembershipClient(flags, ctx, cfg)
 	if err != nil {
 		return "", err
 	}
 
-	organizations, _, err := client.DefaultApi.ListOrganizations(cmd.Context()).Execute()
+	organizations, _, err := client.DefaultApi.ListOrganizations(ctx).Execute()
 	if err != nil {
 		return "", errors.Wrap(err, "listing organizations")
 	}
@@ -107,17 +109,17 @@ func ResolveOrganizationID(cmd *cobra.Command, cfg *Config) (string, error) {
 	return organizations.Data[0].Id, nil
 }
 
-func GetSelectedStackID(cmd *cobra.Command) string {
-	return GetString(cmd, stackFlag)
+func GetSelectedStackID(flags *flag.FlagSet) string {
+	return GetString(flags, stackFlag)
 }
 
-func ResolveStack(cmd *cobra.Command, cfg *Config, organizationID string) (*membershipclient.Stack, error) {
-	client, err := NewMembershipClient(cmd, cfg)
+func ResolveStack(flags *flag.FlagSet, ctx context.Context, cfg *Config, organizationID string) (*membershipclient.Stack, error) {
+	client, err := NewMembershipClient(flags, ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
-	if id := GetSelectedStackID(cmd); id != "" {
-		response, _, err := client.DefaultApi.ReadStack(cmd.Context(), organizationID, id).Execute()
+	if id := GetSelectedStackID(flags); id != "" {
+		response, _, err := client.DefaultApi.ReadStack(ctx, organizationID, id).Execute()
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +127,7 @@ func ResolveStack(cmd *cobra.Command, cfg *Config, organizationID string) (*memb
 		return response.Data, nil
 	}
 
-	stacks, _, err := client.DefaultApi.ListStacks(cmd.Context(), organizationID).Execute()
+	stacks, _, err := client.DefaultApi.ListStacks(ctx, organizationID).Execute()
 	if err != nil {
 		return nil, errors.Wrap(err, "listing stacks")
 	}
@@ -228,7 +230,7 @@ func WithPreRunE(fn func(cmd *cobra.Command, args []string) error) CommandOption
 func WithController[T any](c Controller[T]) CommandOptionFn {
 	return func(cmd *cobra.Command) {
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
-			renderable, err := c.Run(cmd, args)
+			renderable, err := c.Run()
 
 			// If the controller return an argument error, we want to print the usage
 			// of the command instead of the error message.
@@ -241,7 +243,7 @@ func WithController[T any](c Controller[T]) CommandOptionFn {
 				return err
 			}
 
-			err = WithRender(cmd, args, c, renderable)
+			err = WithRender(c.GetFlags(), args, c, renderable)
 
 			if err != nil {
 				return err
@@ -251,10 +253,10 @@ func WithController[T any](c Controller[T]) CommandOptionFn {
 		}
 	}
 }
-func WithRender[T any](cmd *cobra.Command, args []string, c Controller[T], r Renderable) error {
-	flags := GetString(cmd, OutputFlag)
+func WithRender[T any](flags *flag.FlagSet, args []string, c Controller[T], r Renderable) error {
+	flag := GetString(flags, OutputFlag)
 
-	switch flags {
+	switch flag {
 	case "json":
 		// Inject into export struct
 		export := ExportedData{
@@ -275,14 +277,14 @@ func WithRender[T any](cmd *cobra.Command, args []string, c Controller[T], r Ren
 			if err != nil {
 				panic(err)
 			}
-			cmd.OutOrStdout().Write(colorized)
+			fmt.Print(string(colorized))
 			return nil
 		} else {
-			cmd.OutOrStdout().Write(out)
+			fmt.Print(out)
 			return nil
 		}
 	default:
-		return r.Render(cmd, args)
+		return r.Render()
 	}
 }
 
@@ -347,18 +349,20 @@ func NewStackCommand(use string, opts ...CommandOption) *cobra.Command {
 		)...,
 	)
 	cmd.RegisterFlagCompletionFunc("stack", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		cfg, err := GetConfig(cmd)
+		flags := ConvertPFlagSetToFlagSet(cmd.Flags())
+
+		cfg, err := GetConfig(flags)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
-		profile := GetCurrentProfile(cmd, cfg)
+		profile := GetCurrentProfile(flags, cfg)
 
-		claims, err := profile.GetUserInfo(cmd)
+		claims, err := profile.GetUserInfo()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
 
-		selectedOrganization := GetSelectedOrganization(cmd)
+		selectedOrganization := GetSelectedOrganization(flags)
 		if selectedOrganization == "" {
 			selectedOrganization = profile.defaultOrganization
 		}
@@ -385,14 +389,14 @@ func NewMembershipCommand(use string, opts ...CommandOption) *cobra.Command {
 		)...,
 	)
 	cmd.RegisterFlagCompletionFunc("organization", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-
-		cfg, err := GetConfig(cmd)
+		flags := ConvertPFlagSetToFlagSet(cmd.Flags())
+		cfg, err := GetConfig(flags)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
-		profile := GetCurrentProfile(cmd, cfg)
+		profile := GetCurrentProfile(flags, cfg)
 
-		claims, err := profile.GetUserInfo(cmd)
+		claims, err := profile.GetUserInfo()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
@@ -411,8 +415,11 @@ func NewCommand(use string, opts ...CommandOption) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: use,
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			if GetBool(cmd, TelemetryFlag) {
-				cfg, err := GetConfig(cmd)
+
+			flags := ConvertPFlagSetToFlagSet(cmd.Flags())
+
+			if GetBool(flags, TelemetryFlag) {
+				cfg, err := GetConfig(flags)
 				if err != nil {
 					return
 				}

--- a/components/fctl/pkg/config.go
+++ b/components/fctl/pkg/config.go
@@ -2,9 +2,9 @@ package fctl
 
 import (
 	"encoding/json"
+	"flag"
 
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
 type persistedConfig struct {
@@ -107,16 +107,16 @@ func (c *Config) SetCurrentProfileName(s string) {
 	c.currentProfile = s
 }
 
-func GetConfig(cmd *cobra.Command) (*Config, error) {
-	return GetConfigManager(cmd).Load()
+func GetConfig(flagSet *flag.FlagSet) (*Config, error) {
+	return GetConfigManager(flagSet).Load()
 }
 
-func GetConfigManager(cmd *cobra.Command) *ConfigManager {
-	return NewConfigManager(GetString(cmd, FileFlag))
+func GetConfigManager(flagSet *flag.FlagSet) *ConfigManager {
+	return NewConfigManager(GetString(flagSet, FileFlag))
 }
 
-func GetCurrentProfileName(cmd *cobra.Command, config *Config) string {
-	if profile := GetString(cmd, ProfileFlag); profile != "" {
+func GetCurrentProfileName(flags *flag.FlagSet, config *Config) string {
+	if profile := GetString(flags, ProfileFlag); profile != "" {
 		return profile
 	}
 	currentProfileName := config.GetCurrentProfileName()
@@ -126,6 +126,6 @@ func GetCurrentProfileName(cmd *cobra.Command, config *Config) string {
 	return currentProfileName
 }
 
-func GetCurrentProfile(cmd *cobra.Command, cfg *Config) *Profile {
-	return cfg.GetProfileOrDefault(GetCurrentProfileName(cmd, cfg), DefaultMembershipURI)
+func GetCurrentProfile(flags *flag.FlagSet, cfg *Config) *Profile {
+	return cfg.GetProfileOrDefault(GetCurrentProfileName(flags, cfg), DefaultMembershipURI)
 }

--- a/components/fctl/pkg/controller.go
+++ b/components/fctl/pkg/controller.go
@@ -1,15 +1,16 @@
 package fctl
 
 import (
-	"github.com/spf13/cobra"
+	"flag"
 )
 
 type Renderable interface {
-	Render(cmd *cobra.Command, args []string) error
+	Render() error
 }
 type Controller[T any] interface {
 	GetStore() T
-	Run(cmd *cobra.Command, args []string) (Renderable, error)
+	GetFlags() *flag.FlagSet
+	Run() (Renderable, error)
 }
 type ExportedData struct {
 	Data interface{} `json:"data"`

--- a/components/fctl/pkg/controller.go
+++ b/components/fctl/pkg/controller.go
@@ -1,6 +1,7 @@
 package fctl
 
 import (
+	"context"
 	"flag"
 )
 
@@ -10,6 +11,13 @@ type Renderable interface {
 type Controller[T any] interface {
 	GetStore() T
 	GetFlags() *flag.FlagSet
+	SetArgs([]string)
+
+	// Not present from creation of the controller
+	// The context is set by the command
+	GetContext() context.Context
+	SetContext(context.Context)
+
 	Run() (Renderable, error)
 }
 type ExportedData struct {

--- a/components/fctl/pkg/file.go
+++ b/components/fctl/pkg/file.go
@@ -1,21 +1,21 @@
 package fctl
 
 import (
+	"flag"
 	"io"
 	"os"
 
 	"github.com/formancehq/fctl/membershipclient"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
-func ReadFile(cmd *cobra.Command, stack *membershipclient.Stack, where string) (string, error) {
+func ReadFile(flags *flag.FlagSet, stack *membershipclient.Stack, where string) (string, error) {
 	var ret string
 	if where == "-" {
-		if NeedConfirm(cmd, stack) {
+		if NeedConfirm(flags, stack) {
 			return "", errors.New("You need to use --confirm flag to use stdin")
 		}
-		data, err := io.ReadAll(cmd.InOrStdin())
+		data, err := io.ReadAll(os.Stdin)
 		if err != nil && err != io.EOF {
 			return "", errors.Wrapf(err, "reading stdin")
 		}

--- a/components/fctl/pkg/flags.go
+++ b/components/fctl/pkg/flags.go
@@ -11,13 +11,13 @@ import (
 )
 
 const (
-	MembershipURIFlag = "membership-uri"
-	FileFlag          = "config"
-	ProfileFlag       = "profile"
-	OutputFlag        = "output"
-	DebugFlag         = "debug"
-	InsecureTlsFlag   = "insecure-tls"
-	TelemetryFlag     = "telemetry"
+	MembershipURIFlag string = "membership-uri"
+	FileFlag          string = "config"
+	ProfileFlag       string = "profile"
+	OutputFlag        string = "output"
+	DebugFlag         string = "debug"
+	InsecureTlsFlag   string = "insecure-tls"
+	TelemetryFlag     string = "telemetry"
 )
 
 func GetBool(flags *flag.FlagSet, flagName string) bool {
@@ -101,6 +101,10 @@ func GetInt(flagSet *flag.FlagSet, flagName string) int {
 		return 0
 	}
 	return int(v)
+}
+
+func WithConfirmFlag(flagSet *flag.FlagSet) *bool {
+	return flagSet.Bool("confirm", false, "Confirm the action")
 }
 
 func ConvertPFlagSetToFlagSet(pFlagSet *pflag.FlagSet) *flag.FlagSet {

--- a/components/fctl/pkg/global.go
+++ b/components/fctl/pkg/global.go
@@ -1,0 +1,7 @@
+package fctl
+
+var (
+	Version   = "develop"
+	Commit    = "-"
+	BuildDate = "-"
+)

--- a/components/fctl/pkg/http.go
+++ b/components/fctl/pkg/http.go
@@ -4,19 +4,19 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httputil"
 
 	"github.com/TylerBrock/colorjson"
-	"github.com/spf13/cobra"
 )
 
-func GetHttpClient(cmd *cobra.Command, defaultHeaders map[string][]string) *http.Client {
+func GetHttpClient(flags *flag.FlagSet, defaultHeaders map[string][]string) *http.Client {
 	return NewHTTPClient(
-		GetBool(cmd, InsecureTlsFlag),
-		GetBool(cmd, DebugFlag),
+		GetBool(flags, InsecureTlsFlag),
+		GetBool(flags, DebugFlag),
 		defaultHeaders,
 	)
 }

--- a/components/fctl/pkg/manager.go
+++ b/components/fctl/pkg/manager.go
@@ -2,6 +2,7 @@ package fctl
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 )
@@ -43,7 +44,7 @@ func (m *ConfigManager) UpdateConfig(config *Config) error {
 	if err := os.MkdirAll(path.Dir(m.configFilePath), 0700); err != nil {
 		return err
 	}
-
+	fmt.Println("configFilePath", m.configFilePath)
 	f, err := os.OpenFile(m.configFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err

--- a/components/fctl/pkg/profile.go
+++ b/components/fctl/pkg/profile.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	"github.com/formancehq/fctl/membershipclient"
 	"github.com/golang-jwt/jwt"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"github.com/zitadel/oidc/v2/pkg/client"
 	"github.com/zitadel/oidc/v2/pkg/client/rp"
 	"github.com/zitadel/oidc/v2/pkg/oidc"
@@ -170,7 +170,7 @@ func (p *Profile) GetClaims() (jwt.MapClaims, error) {
 	return claims, nil
 }
 
-func (p *Profile) GetUserInfo(cmd *cobra.Command) (*userClaims, error) {
+func (p *Profile) GetUserInfo() (*userClaims, error) {
 	claims := &userClaims{}
 	if p.token != nil && p.token.IDToken != "" {
 		_, err := oidc.ParseToken(p.token.IDToken, claims)
@@ -272,8 +272,8 @@ func (p *Profile) IsConnected() bool {
 
 type CurrentProfile Profile
 
-func ListProfiles(cmd *cobra.Command, toComplete string) ([]string, error) {
-	config, err := GetConfig(cmd)
+func ListProfiles(flags *flag.FlagSet, toComplete string) ([]string, error) {
+	config, err := GetConfig(flags)
 	if err != nil {
 		return []string{}, nil
 	}


### PR DESCRIPTION
# 1 Convert Controller Interface
+ Add GetFlags Command to return a FLagSet
- Remove Cobra args from Run & Render

# 2 Convert Pkg

Convert command that was accepting *cobra.Command only to retrieve cmd.Flags() that is implementing *flag.FlagSet

# 3 Convert Login & Stacks Controllers to accept & crete his config

type StackCreateControllerConfig struct {
	context     context.Context
	use         string
	description string
	aliases     []string
	out         io.Writer
	flags       *flag.FlagSet
	args        []string
}

# 4 : Set Context & command Args  at Cobra PreRun cycle, with Controller (CommandOptionFn)