### PR TITLE
fix(payments): banking circle login

### DIFF
--- a/components/payments/internal/app/connectors/bankingcircle/client/auth.go
+++ b/components/payments/internal/app/connectors/bankingcircle/client/auth.go
@@ -76,6 +76,10 @@ func (c *Client) login(ctx context.Context) error {
 }
 
 func (c *Client) ensureAccessTokenIsValid(ctx context.Context) error {
+	if c.accessToken == "" {
+		return c.login(ctx)
+	}
+
 	if c.accessTokenExpiresAt.After(time.Now().Add(5 * time.Second)) {
 		return nil
 	}

--- a/components/payments/internal/app/connectors/bankingcircle/client/client.go
+++ b/components/payments/internal/app/connectors/bankingcircle/client/client.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"crypto/tls"
 	"net/http"
 	"time"
@@ -61,10 +60,6 @@ func NewClient(
 		authorizationEndpoint: authorizationEndpoint,
 
 		logger: logger,
-	}
-
-	if err := c.login(context.TODO()); err != nil {
-		return nil, err
 	}
 
 	return c, nil


### PR DESCRIPTION
login is done at every call if the token is not valid anymore, no need to do it when creating the connector