### PR TITLE
feat: upgrade garden project

### DIFF
--- a/components/operator/Makefile
+++ b/components/operator/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller
+IMG ?= operator
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.1
 
@@ -71,9 +71,19 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+.PHONY: docker-build-local-prod
+docker-build-local-prod: ## Build docker image with the manager.
+	go build -o operator main.go
+	docker build -t ${IMG} -f ./build.Dockerfile ./  --no-cache
+
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build -t ${IMG} -f ./Dockerfile ../../  --no-cache
+
+.PHONY: docker-push-local-prod
+docker-push-local-prod: ## Build docker image with the manager.
+	docker tag ${IMG} k3d-registry.host.k3d.internal:12345/${IMG}:dev-latest
+	docker push k3d-registry.host.k3d.internal:12345/${IMG}:dev-latest
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.

--- a/components/operator/README.md
+++ b/components/operator/README.md
@@ -16,22 +16,38 @@ Also, we use [Garden](https://docs.garden.io/) for management.
 garden create-cluster
 ```
 
-2. Deploy:
+2. Build the operator image yourself or skip and deploy:
+
+> Add an entry for `k3d-registry.host.k3d.internal` inside /etc/hosts file, pointing to 127.0.0.1.
 
 ```sh
-garden  deploy
+    1. BUILD: `make docker-build`
+    2. PUSH: `make docker-push
+    3. BUILD Helm: `make helm-update`
 ```
 
-This will automatically install all the stack.
-When developing, use following command to update the operator code :
+3. Deploy:
+
 ```sh
-go run main.go --disable-webhooks
+garden deploy
 ```
 
-3. Create a stack
+4. Create a stack
 
 ```sh
 kubectl apply -f garden/example-v1beta3.yaml
+```
+
+5. Stop the cluster
+
+```sh
+garden stop
+```
+
+6. Start the cluster
+
+```sh
+garden start
 ```
 
 Add an entry for `host.k3d.internal` inside /etc/hosts file, pointing to 127.0.0.1.
@@ -45,18 +61,30 @@ Run command :
 make test
 ```
 
+
+### Push to local registry
+
+In order to be able to pull and push the image in the internal-registry named `k3d-registry.host.k3d.internal` 
+on fixed port `12345` defined in `garden/k3d.yaml` 
+
+
+Add an entry for `k3d-registry.host.k3d.internal` inside /etc/hosts file, pointing to 127.0.0.1.
+
+Then in order to build and publish your image
+    1. BUILD: `make docker-build`
+    2. PUSH: `make docker-push`
+    3. BUILD Helm: `make helm-update`
+At this step you can use `garden deploy`
+    1. DEPLOY Helm:`make helm-local-install`
+    2. REDEPLOY Helm: `make helm-local-upgrade`
+
+
 ### How it works
 This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
 
 It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/)
 which provides a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster
 
-### Test It Out
-
-You can install a full stack using the command:
-```sh
-kubectl apply -f example.yaml
-```
 
 ## License
 

--- a/components/operator/commands.garden.yaml
+++ b/components/operator/commands.garden.yaml
@@ -12,7 +12,6 @@ exec:
     --config garden/k3d.yaml
     ${variables contains "registries" ? "--registry-config " + variables.registries : ""}
     ${variables contains "network" ? "--network " + variables.network : ""}
-    --registry-create internal-registry
     --k3s-arg "--disable=traefik@server:0" && garden plugins kubernetes cluster-init --env=default --force-refresh
 ---
 kind: Command

--- a/components/operator/commands.garden.yaml
+++ b/components/operator/commands.garden.yaml
@@ -26,6 +26,26 @@ exec:
   - k3d cluster delete ${variables.cluster-name}
 ---
 kind: Command
+name: stop
+description:
+  short: Stop K3D cluster
+exec:
+  command:
+  - sh
+  - -c
+  - k3d cluster stop ${variables.cluster-name}
+---
+kind: Command
+name: start
+description:
+  short: Start K3D cluster
+exec:
+  command:
+  - sh
+  - -c
+  - k3d cluster start ${variables.cluster-name}
+---
+kind: Command
 name: manifests
 description:
   short: Generate manifests

--- a/components/operator/garden.yml
+++ b/components/operator/garden.yml
@@ -1,0 +1,55 @@
+---
+apiVersion: garden.io/v0
+kind: Deploy
+description: operator pre-deploy build
+type: exec
+name: operator-build
+spec:
+  deployCommand:
+    - sh
+    - -c
+    - make docker-build-local-prod 
+---
+apiVersion: garden.io/v0
+kind: Deploy
+description: operator pre-deploy push
+type: exec
+name: operator-push
+spec:
+  deployCommand:
+    - sh
+    - -c
+    - make docker-push-local-prod
+---
+apiVersion: garden.io/v0
+kind: Deploy
+description: operator pre-deploy helm update
+type: exec
+name: operator-helm-build
+spec:
+  deployCommand:
+    - sh
+    - -c
+    - make helm-update
+---
+apiVersion: garden.io/v0
+kind: Deploy
+type: helm
+description: Operator Helm deploy
+name: formance-operator
+dependencies:
+  - deploy.operator-build
+  - deploy.operator-push
+  - deploy.operator-helm-build
+  - deploy.cert-manager
+spec:
+  namespace: formance-system
+  chart:
+    path: ./helm
+  values:
+    image:
+      repository: k3d-registry.host.k3d.internal:12345/operator
+      tag: dev-latest
+      pullPolicy: Always
+
+

--- a/components/operator/garden/cert-manager/garden.yaml
+++ b/components/operator/garden/cert-manager/garden.yaml
@@ -1,13 +1,15 @@
 ---
 apiVersion: garden.io/v0
-kind: Module
+kind: Deploy
 description: cert-manager
 type: helm
 name: cert-manager
-namespace: default
-repo: https://charts.jetstack.io
-chart: cert-manager
 timeout: 3600
-values:
-  fullnameOverride: cert-manager
-  installCRDs: true
+spec:
+  namespace: default
+  chart:
+    repo: https://charts.jetstack.io
+    name: cert-manager
+  values:
+    fullnameOverride: cert-manager
+    installCRDs: true

--- a/components/operator/garden/dex/garden.yaml
+++ b/components/operator/garden/dex/garden.yaml
@@ -1,45 +1,47 @@
 ---
 apiVersion: garden.io/v0
-kind: Module
-description: Cert Manager
+kind: Deploy
+description: Dex
 type: helm
 name: dex
-namespace: default
-repo: https://charts.dexidp.io
-chart: dex
 timeout: 3600
 dependencies:
-- postgres
-values:
-  config:
-    issuer: http://host.k3d.internal/api/dex
-    storage:
-      type: postgres
-      config:
-        host: postgres-postgresql
-        port: 5432
-        database: formance
-        user: formance
-        password: formance
-        ssl:
-          mode: disable
-    enablePasswordDB: true
-    staticPasswords:
-    - email: admin@formance.com
-      # https://github.com/dexidp/dex/blob/576f990d257d9dd63e283cf379960e50506e8bcc/examples/config-dev.yaml#L145
-      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W" # password
-      username: admin
-      userID: 08a8684b-db88-4b73-90a9-3cd1661f5466
-    staticClients:
-    - id: dexclient
-      secret: dexclient
-      name: dexclient
-      redirectURIs:
-      - http://host.k3d.internal/api/auth/authorize/callback
-  ingress:
-    enabled: true
-    hosts:
-    - host: host.k3d.internal
-      paths:
-      - path: /api/dex
-        pathType: Prefix
+- deploy.postgres
+spec:
+  namespace: default
+  chart:
+    repo: https://charts.dexidp.io
+    name: dex
+  values:
+    config:
+      issuer: http://host.k3d.internal/api/dex
+      storage:
+        type: postgres
+        config:
+          host: postgres-postgresql
+          port: 5432
+          database: formance
+          user: formance
+          password: formance
+          ssl:
+            mode: disable
+      enablePasswordDB: true
+      staticPasswords:
+      - email: admin@formance.com
+        # https://github.com/dexidp/dex/blob/576f990d257d9dd63e283cf379960e50506e8bcc/examples/config-dev.yaml#L145
+        hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W" # password
+        username: admin
+        userID: 08a8684b-db88-4b73-90a9-3cd1661f5466
+      staticClients:
+      - id: dexclient
+        secret: dexclient
+        name: dexclient
+        redirectURIs:
+        - http://host.k3d.internal/api/auth/authorize/callback
+    ingress:
+      enabled: true
+      hosts:
+      - host: host.k3d.internal
+        paths:
+        - path: /api/dex
+          pathType: Prefix

--- a/components/operator/garden/elasticsearch/garden.yaml
+++ b/components/operator/garden/elasticsearch/garden.yaml
@@ -1,22 +1,24 @@
 ---
 apiVersion: garden.io/v0
-kind: Module
+kind: Deploy
 description: Zinc
 type: helm
-namespace: default
 name: elasticsearch
-repo: https://helm.elastic.co
-chart: elasticsearch
-version: 7.17.3
 timeout: 3600
-values:
-  replicas: 1
-  esJavaOpts: "-Xmx512m -Xms512m"
-  clusterHealthCheckParams: wait_for_status=yellow&timeout=1s
-  resources:
-    requests:
-      cpu: 100m
-      memory: 512M
-    limits:
-      cpu: 100m
-      memory: 512M
+spec:
+  namespace: default
+  chart:
+    repo: https://helm.elastic.co
+    name: elasticsearch
+    version: 7.17.3
+  values:
+    replicas: 1
+    esJavaOpts: "-Xmx512m -Xms512m"
+    clusterHealthCheckParams: wait_for_status=yellow&timeout=1s
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512M
+      limits:
+        cpu: 200m
+        memory: 1024M

--- a/components/operator/garden/jaeger/garden.yaml
+++ b/components/operator/garden/jaeger/garden.yaml
@@ -1,74 +1,75 @@
 ---
 apiVersion: garden.io/v0
-kind: Module
-name: jaeger
+kind: Deploy
 description: Jaeger
 type: kubernetes
-namespace: default
+name: jaeger
 timeout: 3600
-manifests:
--
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: jaeger
-    labels:
-      app: jaeger
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
+spec:
+  namespace: default
+  manifests:
+  - 
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: jaeger
+      labels:
         app: jaeger
-    template:
-      metadata:
-        labels:
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
           app: jaeger
-      spec:
-        containers:
-        - name: jaeger
-          image: jaegertracing/all-in-one:1.29
-          command:
-          - /go/bin/all-in-one-linux
-          - --query.base-path=/jaeger
-          ports:
-          - containerPort: 16686
-          - containerPort: 14250
-          - containerPort: 14268
--
-  apiVersion: v1
-  kind: Service
-  metadata:
-    name: jaeger
-  spec:
-    selector:
-      app: jaeger
-    ports:
-    - name: http
-      protocol: TCP
-      port: 16686
-      targetPort: 16686
-    - name: collector
-      protocol: TCP
-      port: 14250
-      targetPort: 14250
-    - name: collector-thrift
-      protocol: TCP
-      port: 14268
-      targetPort: 14268
--
-  apiVersion: networking.k8s.io/v1
-  kind: Ingress
-  metadata:
-    name: jaeger
-  spec:
-    rules:
-    - host: host.k3d.internal
-      http:
-        paths:
-        - path: /jaeger
-          pathType: Prefix
-          backend:
-            service:
-              name: jaeger
-              port:
-                number: 16686
+      template:
+        metadata:
+          labels:
+            app: jaeger
+        spec:
+          containers:
+          - name: jaeger
+            image: jaegertracing/all-in-one:1.29
+            command:
+            - /go/bin/all-in-one-linux
+            - --query.base-path=/jaeger
+            ports:
+            - containerPort: 16686
+            - containerPort: 14250
+            - containerPort: 14268
+  -
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: jaeger
+    spec:
+      selector:
+        app: jaeger
+      ports:
+      - name: http
+        protocol: TCP
+        port: 16686
+        targetPort: 16686
+      - name: collector
+        protocol: TCP
+        port: 14250
+        targetPort: 14250
+      - name: collector-thrift
+        protocol: TCP
+        port: 14268
+        targetPort: 14268
+  -
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: jaeger
+    spec:
+      rules:
+      - host: host.k3d.internal
+        http:
+          paths:
+          - path: /jaeger
+            pathType: Prefix
+            backend:
+              service:
+                name: jaeger
+                port:
+                  number: 16686

--- a/components/operator/garden/k3d.yaml
+++ b/components/operator/garden/k3d.yaml
@@ -1,4 +1,4 @@
-apiVersion: k3d.io/v1alpha4
+apiVersion: k3d.io/v1alpha5
 kind: Simple
 metadata:
   name: formance
@@ -14,3 +14,9 @@ ports:
   nodeFilters:
   - loadbalancer
 - port: 30000:30000
+registries:
+  create:
+    name: "k3d-registry.host.k3d.internal"
+    hostPort: "12345"
+    
+    

--- a/components/operator/garden/minio/garden.yaml
+++ b/components/operator/garden/minio/garden.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: garden.io/v0
+kind: Deploy
+description: Minio
+type: helm
+name: minio
+timeout: 3600
+spec:
+  namespace: default
+  chart:
+    repo: https://charts.bitnami.com/bitnami
+    name: minio
+  values:
+    defaultBuckets: backups
+    auth:
+      rootUser: formance
+      rootPassword: formance

--- a/components/operator/garden/nats/garden.yaml
+++ b/components/operator/garden/nats/garden.yaml
@@ -1,16 +1,18 @@
 ---
 apiVersion: garden.io/v0
-kind: Module
+kind: Deploy
 description: Nats
 type: helm
 name: nats
-namespace: default
-repo: https://nats-io.github.io/k8s/helm/charts/
-chart: nats
 timeout: 3600
-values:
-  nats:
-    jetstream:
-      enabled: true
-      fileStorage:
-        enabled: false
+spec:
+  namespace: default
+  chart:
+    repo: https://nats-io.github.io/k8s/helm/charts/
+    name: nats
+  values:
+    config:
+      jetstream:
+        enabled: true
+        fileStore:
+          enabled: false

--- a/components/operator/garden/otel-collector/garden.yaml
+++ b/components/operator/garden/otel-collector/garden.yaml
@@ -1,12 +1,11 @@
 ---
 apiVersion: garden.io/v0
-kind: Module
+kind: Deploy
 description: OTEL collector
 # Use exec as the chart as a values.schema.yaml and garden inject a .garden keyn inside values
 type: exec
 name: otel-collector
-services:
-- name: otel-collector
+spec:
   deployCommand:
     - sh
     - -c

--- a/components/operator/garden/postgres/garden.yaml
+++ b/components/operator/garden/postgres/garden.yaml
@@ -1,25 +1,27 @@
 ---
 apiVersion: garden.io/v0
-kind: Module
+kind: Deploy
 description: Postgres
 type: helm
 name: postgres
-namespace: default
-repo: https://charts.bitnami.com/bitnami
-chart: postgresql
 timeout: 3600
-version: 12.1.2
-values:
-  architecture: standalone
-  primary:
-    service:
-      type: NodePort
-      nodePorts:
-        postgresql: 30000
-  global:
-    postgresql:
-      auth:
-        postgresPassword: formance
-        username: formance
-        password: formance
-        database: formance
+spec:
+  namespace: default
+  chart:
+    repo: https://charts.bitnami.com/bitnami
+    name: postgresql
+    version: 12.1.2
+  values:
+    architecture: standalone
+    primary:
+      service:
+        type: NodePort
+        nodePorts:
+          postgresql: 30000
+    global:
+      postgresql:
+        auth:
+          postgresPassword: formance
+          username: formance
+          password: formance
+          database: formance

--- a/components/operator/garden/reloader/garden.yaml
+++ b/components/operator/garden/reloader/garden.yaml
@@ -1,10 +1,12 @@
 ---
 apiVersion: garden.io/v0
-kind: Module
+kind: Deploy
 description: Reloader
 type: helm
 name: reloader
-namespace: default
-repo: https://stakater.github.io/stakater-charts
-chart: reloader
 timeout: 3600
+spec:
+  namespace: default
+  chart:
+    name: reloader
+    repo: https://stakater.github.io/stakater-charts

--- a/components/operator/garden/traefik/garden.yaml
+++ b/components/operator/garden/traefik/garden.yaml
@@ -1,35 +1,37 @@
 ---
 apiVersion: garden.io/v0
-kind: Module
+kind: Deploy
 description: Traefik
 type: helm
 name: traefik
-namespace: default
-repo: https://helm.traefik.io/traefik
-chart: traefik
 timeout: 3600
-version: "20.4.1"
-values:
-  service:
-    type: NodePort
-  ports:
-    web:
-      nodePort: 30080
-    websecure:
-      nodePort: 30443
-    traefik:
-      nodePort: 30090
-      expose: true
-  ingressClass:
-    enabled: true
-  tracing:
-    jaeger:
-      samplingServerURL: http://jaeger:5778/sampling
-      samplingType: const
-      samplingParam: 1.0
-      localAgentHostPort: 127.0.0.1:6831
-      propagation: b3
-      traceContextHeaderName: uber-trace-id
-      disableAttemptReconnecting: true
-      collector:
-        endpoint: "http://jaeger:14268/api/traces"
+spec:
+  namespace: default
+  chart:
+    repo: https://helm.traefik.io/traefik
+    name: traefik
+    version: "20.4.1"
+  values:
+    service:
+      type: NodePort
+    ports:
+      web:
+        nodePort: 30080
+      websecure:
+        nodePort: 30443
+      traefik:
+        nodePort: 30090
+        expose: true
+    ingressClass:
+      enabled: true
+    tracing:
+      jaeger:
+        samplingServerURL: http://jaeger:5778/sampling
+        samplingType: const
+        samplingParam: 1.0
+        localAgentHostPort: 127.0.0.1:6831
+        propagation: b3
+        traceContextHeaderName: uber-trace-id
+        disableAttemptReconnecting: true
+        collector:
+          endpoint: "http://jaeger:14268/api/traces"

--- a/components/operator/project.garden.yaml
+++ b/components/operator/project.garden.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: garden.io/v0
+apiVersion: garden.io/v1
 kind: Project
 name: operator
 
@@ -11,6 +11,7 @@ environments:
 
 providers:
   - name: kubernetes
+    environments: ["default"]
     setupIngressController: false
     context: k3d-formance
     buildMode: kaniko
@@ -21,8 +22,7 @@ providers:
       - --force
       - --snapshotMode=redo
       - --use-new-run
-    deploymentRegistry:
-      hostname: internal-registry
-      namespace: formancehq
+    deploymentRegistry: # This need to point to the registry created by k3d
+      hostname: k3d-registry.host.k3d.internal
       insecure: true
       port: 5000


### PR DESCRIPTION
- Bump garden project version to garden.io/v1
- It allow us to trigger action https://docs.garden.io/reference/action-types
- `kind: Module` is deprecated
- Convert every `kind: Module` to `kind: Deploy`
- Install default registry as k3d-registry.host.k3d.internal on static port 12345
- Update makefile:
  - docker-push
  - docker-build
  - helm-local-install
  - helm-local-upgrade