### PR TITLE
feat: payments add restart options

### DIFF
--- a/components/payments/internal/app/connectors/bankingcircle/connector.go
+++ b/components/payments/internal/app/connectors/bankingcircle/connector.go
@@ -45,7 +45,7 @@ func (c *Connector) Install(ctx task.ConnectorContext) error {
 		Duration:       c.cfg.PollingPeriod.Duration,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: false,
+		RestartOption: models.OPTIONS_RESTART_NEVER,
 	})
 }
 

--- a/components/payments/internal/app/connectors/bankingcircle/task_fetch_accounts.go
+++ b/components/payments/internal/app/connectors/bankingcircle/task_fetch_accounts.go
@@ -67,7 +67,7 @@ func taskFetchAccounts(
 
 		err = scheduler.Schedule(ctx, taskPayments, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/bankingcircle/task_main.go
+++ b/components/payments/internal/app/connectors/bankingcircle/task_main.go
@@ -27,7 +27,7 @@ func taskMain(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/currencycloud/connector.go
+++ b/components/payments/internal/app/connectors/currencycloud/connector.go
@@ -69,7 +69,7 @@ func (c *Connector) Install(ctx task.ConnectorContext) error {
 		Duration:       c.cfg.PollingPeriod.Duration,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: false,
+		RestartOption: models.OPTIONS_RESTART_NEVER,
 	})
 }
 

--- a/components/payments/internal/app/connectors/currencycloud/connector.go
+++ b/components/payments/internal/app/connectors/currencycloud/connector.go
@@ -39,12 +39,8 @@ func (c *Connector) InitiatePayment(ctx task.ConnectorContext, transfer *models.
 	}
 
 	err = ctx.Scheduler().Schedule(detachedCtx, taskDescriptor, models.TaskSchedulerOptions{
-		// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-		// and their transactions.
 		ScheduleOption: models.OPTIONS_RUN_NOW_SYNC,
-		// No need to restart this task, since the connector is not existing or
-		// was uninstalled previously, the task does not exists in the database
-		Restart: true,
+		RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 	})
 	if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 		return err

--- a/components/payments/internal/app/connectors/currencycloud/task_fetch_accounts.go
+++ b/components/payments/internal/app/connectors/currencycloud/task_fetch_accounts.go
@@ -68,7 +68,7 @@ func taskFetchAccounts(
 
 		err = scheduler.Schedule(ctx, taskTransactions, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err
@@ -84,7 +84,7 @@ func taskFetchAccounts(
 
 		err = scheduler.Schedule(ctx, taskBalances, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/currencycloud/task_main.go
+++ b/components/payments/internal/app/connectors/currencycloud/task_main.go
@@ -27,7 +27,7 @@ func taskMain(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err
@@ -43,7 +43,7 @@ func taskMain(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskBeneficiaries, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/currencycloud/task_payments.go
+++ b/components/payments/internal/app/connectors/currencycloud/task_payments.go
@@ -169,12 +169,8 @@ func taskInitiatePayment(logger logging.Logger, currencyCloudClient *client.Clie
 
 		ctx, _ = contextutil.DetachedWithTimeout(ctx, 10*time.Second)
 		err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
-			// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-			// and their transactions.
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			// No need to restart this task, since the connector is not existing or
-			// was uninstalled previously, the task does not exists in the database
-			Restart: true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err
@@ -265,7 +261,7 @@ func taskUpdatePaymentStatus(
 			err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_IN_DURATION,
 				Duration:       2 * time.Minute,
-				Restart:        true,
+				RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 			})
 			if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 				return err

--- a/components/payments/internal/app/connectors/dummypay/connector.go
+++ b/components/payments/internal/app/connectors/dummypay/connector.go
@@ -45,7 +45,7 @@ func (c *Connector) Install(ctx task.ConnectorContext) error {
 		ScheduleOption: models.OPTIONS_RUN_NOW,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: false,
+		RestartOption: models.OPTIONS_RESTART_NEVER,
 	}); err != nil {
 		return fmt.Errorf("failed to schedule task to read files: %w", err)
 	}
@@ -57,7 +57,7 @@ func (c *Connector) Install(ctx task.ConnectorContext) error {
 
 	if err = ctx.Scheduler().Schedule(ctx.Context(), generateFilesDescriptor, models.TaskSchedulerOptions{
 		ScheduleOption: models.OPTIONS_RUN_NOW,
-		Restart:        false,
+		RestartOption:  models.OPTIONS_RESTART_NEVER,
 	}); err != nil {
 		return fmt.Errorf("failed to schedule task to generate files: %w", err)
 	}

--- a/components/payments/internal/app/connectors/dummypay/task_read_files.go
+++ b/components/payments/internal/app/connectors/dummypay/task_read_files.go
@@ -48,7 +48,7 @@ func taskReadFiles(config Config, fs fs) task.Task {
 					// schedule a task to ingest the file into the payments system.
 					err = scheduler.Schedule(ctx, descriptor, models.TaskSchedulerOptions{
 						ScheduleOption: models.OPTIONS_RUN_NOW,
-						Restart:        true,
+						RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 					})
 					if err != nil {
 						return fmt.Errorf("failed to schedule task to ingest file '%s': %w", file, err)

--- a/components/payments/internal/app/connectors/mangopay/connector.go
+++ b/components/payments/internal/app/connectors/mangopay/connector.go
@@ -69,7 +69,7 @@ func (c *Connector) Install(ctx task.ConnectorContext) error {
 		Duration:       c.cfg.PollingPeriod.Duration,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: false,
+		RestartOption: models.OPTIONS_RESTART_NEVER,
 	})
 }
 

--- a/components/payments/internal/app/connectors/mangopay/connector.go
+++ b/components/payments/internal/app/connectors/mangopay/connector.go
@@ -39,12 +39,8 @@ func (c *Connector) InitiatePayment(ctx task.ConnectorContext, transfer *models.
 	}
 
 	err = ctx.Scheduler().Schedule(detachedCtx, taskDescriptor, models.TaskSchedulerOptions{
-		// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-		// and their transactions.
 		ScheduleOption: models.OPTIONS_RUN_NOW_SYNC,
-		// No need to restart this task, since the connector is not existing or
-		// was uninstalled previously, the task does not exists in the database
-		Restart: true,
+		RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 	})
 	if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 		return err

--- a/components/payments/internal/app/connectors/mangopay/task_fetch_users.go
+++ b/components/payments/internal/app/connectors/mangopay/task_fetch_users.go
@@ -51,7 +51,7 @@ func taskFetchUsers(logger logging.Logger, client *client.Client) task.Task {
 
 			err = scheduler.Schedule(ctx, walletsTask, models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_NOW,
-				Restart:        true,
+				RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 			})
 			if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 				return err
@@ -68,7 +68,7 @@ func taskFetchUsers(logger logging.Logger, client *client.Client) task.Task {
 
 			err = scheduler.Schedule(ctx, bankAccountsTask, models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_NOW,
-				Restart:        true,
+				RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 			})
 			if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 				return err

--- a/components/payments/internal/app/connectors/mangopay/task_fetch_wallets.go
+++ b/components/payments/internal/app/connectors/mangopay/task_fetch_wallets.go
@@ -123,7 +123,7 @@ func taskFetchWallets(logger logging.Logger, client *client.Client, userID strin
 			for _, transactionTask := range transactionTasks {
 				err = scheduler.Schedule(ctx, transactionTask, models.TaskSchedulerOptions{
 					ScheduleOption: models.OPTIONS_RUN_NOW,
-					Restart:        true,
+					RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 				})
 				if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 					return err

--- a/components/payments/internal/app/connectors/mangopay/task_main.go
+++ b/components/payments/internal/app/connectors/mangopay/task_main.go
@@ -27,7 +27,7 @@ func taskMain(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskUsers, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/mangopay/task_payments.go
+++ b/components/payments/internal/app/connectors/mangopay/task_payments.go
@@ -180,12 +180,8 @@ func taskInitiatePayment(logger logging.Logger, mangopayClient *client.Client, t
 
 		ctx, _ = contextutil.DetachedWithTimeout(ctx, 10*time.Second)
 		err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
-			// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-			// and their transactions.
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			// No need to restart this task, since the connector is not existing or
-			// was uninstalled previously, the task does not exists in the database
-			Restart: true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err
@@ -276,7 +272,7 @@ func taskUpdatePaymentStatus(
 			err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_IN_DURATION,
 				Duration:       2 * time.Minute,
-				Restart:        true,
+				RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 			})
 			if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 				return err

--- a/components/payments/internal/app/connectors/modulr/connector.go
+++ b/components/payments/internal/app/connectors/modulr/connector.go
@@ -40,12 +40,8 @@ func (c *Connector) InitiatePayment(ctx task.ConnectorContext, transfer *models.
 	}
 
 	err = ctx.Scheduler().Schedule(detachedCtx, taskDescriptor, models.TaskSchedulerOptions{
-		// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-		// and their transactions.
 		ScheduleOption: models.OPTIONS_RUN_NOW_SYNC,
-		// No need to restart this task, since the connector is not existing or
-		// was uninstalled previously, the task does not exists in the database
-		Restart: true,
+		RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 	})
 	if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 		return err

--- a/components/payments/internal/app/connectors/modulr/connector.go
+++ b/components/payments/internal/app/connectors/modulr/connector.go
@@ -70,7 +70,7 @@ func (c *Connector) Install(ctx task.ConnectorContext) error {
 		Duration:       c.cfg.PollingPeriod.Duration,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: false,
+		RestartOption: models.OPTIONS_RESTART_NEVER,
 	})
 }
 

--- a/components/payments/internal/app/connectors/modulr/task_fetch_accounts.go
+++ b/components/payments/internal/app/connectors/modulr/task_fetch_accounts.go
@@ -64,7 +64,7 @@ func taskFetchAccounts(logger logging.Logger, client *client.Client) task.Task {
 
 			err = scheduler.Schedule(ctx, transactionsTask, models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_NOW,
-				Restart:        true,
+				RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 			})
 			if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 				return err

--- a/components/payments/internal/app/connectors/modulr/task_main.go
+++ b/components/payments/internal/app/connectors/modulr/task_main.go
@@ -27,7 +27,7 @@ func taskMain(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err
@@ -43,7 +43,7 @@ func taskMain(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskBeneficiaries, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/modulr/task_payments.go
+++ b/components/payments/internal/app/connectors/modulr/task_payments.go
@@ -173,12 +173,8 @@ func taskInitiatePayment(logger logging.Logger, modulrClient *client.Client, tra
 
 		ctx, _ = contextutil.DetachedWithTimeout(ctx, 10*time.Second)
 		err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
-			// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-			// and their transactions.
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			// No need to restart this task, since the connector is not existing or
-			// was uninstalled previously, the task does not exists in the database
-			Restart: true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err
@@ -269,7 +265,7 @@ func taskUpdatePaymentStatus(
 			err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_IN_DURATION,
 				Duration:       2 * time.Minute,
-				Restart:        true,
+				RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 			})
 			if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 				return err

--- a/components/payments/internal/app/connectors/moneycorp/connector.go
+++ b/components/payments/internal/app/connectors/moneycorp/connector.go
@@ -69,7 +69,7 @@ func (c *Connector) Install(ctx task.ConnectorContext) error {
 		Duration:       c.cfg.PollingPeriod.Duration,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: false,
+		RestartOption: models.OPTIONS_RESTART_NEVER,
 	})
 }
 

--- a/components/payments/internal/app/connectors/moneycorp/connector.go
+++ b/components/payments/internal/app/connectors/moneycorp/connector.go
@@ -39,12 +39,8 @@ func (c *Connector) InitiatePayment(ctx task.ConnectorContext, transfer *models.
 	}
 
 	err = ctx.Scheduler().Schedule(detachedCtx, taskDescriptor, models.TaskSchedulerOptions{
-		// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-		// and their transactions.
 		ScheduleOption: models.OPTIONS_RUN_NOW_SYNC,
-		// No need to restart this task, since the connector is not existing or
-		// was uninstalled previously, the task does not exists in the database
-		Restart: true,
+		RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 	})
 	if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 		return err

--- a/components/payments/internal/app/connectors/moneycorp/task_fetch_accounts.go
+++ b/components/payments/internal/app/connectors/moneycorp/task_fetch_accounts.go
@@ -65,7 +65,7 @@ func taskFetchAccounts(logger logging.Logger, client *client.Client) task.Task {
 
 				err = scheduler.Schedule(ctx, transactionsTask, models.TaskSchedulerOptions{
 					ScheduleOption: models.OPTIONS_RUN_NOW,
-					Restart:        true,
+					RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 				})
 				if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 					return err
@@ -82,7 +82,7 @@ func taskFetchAccounts(logger logging.Logger, client *client.Client) task.Task {
 				}
 				err = scheduler.Schedule(ctx, balancesTask, models.TaskSchedulerOptions{
 					ScheduleOption: models.OPTIONS_RUN_NOW,
-					Restart:        true,
+					RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 				})
 				if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 					return err
@@ -99,7 +99,7 @@ func taskFetchAccounts(logger logging.Logger, client *client.Client) task.Task {
 
 				err = scheduler.Schedule(ctx, taskRecipients, models.TaskSchedulerOptions{
 					ScheduleOption: models.OPTIONS_RUN_NOW,
-					Restart:        true,
+					RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 				})
 				if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 					return err

--- a/components/payments/internal/app/connectors/moneycorp/task_main.go
+++ b/components/payments/internal/app/connectors/moneycorp/task_main.go
@@ -27,7 +27,7 @@ func taskMain(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/moneycorp/task_payments.go
+++ b/components/payments/internal/app/connectors/moneycorp/task_payments.go
@@ -167,12 +167,8 @@ func taskInitiatePayment(logger logging.Logger, moneycorpClient *client.Client, 
 
 		ctx, _ = contextutil.DetachedWithTimeout(ctx, 10*time.Second)
 		err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
-			// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-			// and their transactions.
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			// No need to restart this task, since the connector is not existing or
-			// was uninstalled previously, the task does not exists in the database
-			Restart: true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err
@@ -261,7 +257,7 @@ func taskUpdatePaymentStatus(
 			err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_IN_DURATION,
 				Duration:       2 * time.Minute,
-				Restart:        true,
+				RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 			})
 			if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 				return err

--- a/components/payments/internal/app/connectors/stripe/connector.go
+++ b/components/payments/internal/app/connectors/stripe/connector.go
@@ -41,7 +41,7 @@ func (c *Connector) Install(ctx task.ConnectorContext) error {
 		Duration:       c.cfg.PollingPeriod.Duration,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: false,
+		RestartOption: models.OPTIONS_RESTART_NEVER,
 	})
 }
 
@@ -77,7 +77,7 @@ func (c *Connector) InitiatePayment(ctx task.ConnectorContext, transfer *models.
 		ScheduleOption: models.OPTIONS_RUN_NOW_SYNC,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: true,
+		RestartOption: models.OPTIONS_RESTART_ALWAYS,
 	})
 	if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 		return err

--- a/components/payments/internal/app/connectors/stripe/connector.go
+++ b/components/payments/internal/app/connectors/stripe/connector.go
@@ -72,12 +72,8 @@ func (c *Connector) InitiatePayment(ctx task.ConnectorContext, transfer *models.
 	}
 
 	err = ctx.Scheduler().Schedule(detachedCtx, taskDescriptor, models.TaskSchedulerOptions{
-		// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-		// and their transactions.
 		ScheduleOption: models.OPTIONS_RUN_NOW_SYNC,
-		// No need to restart this task, since the connector is not existing or
-		// was uninstalled previously, the task does not exists in the database
-		RestartOption: models.OPTIONS_RESTART_ALWAYS,
+		RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 	})
 	if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 		return err

--- a/components/payments/internal/app/connectors/stripe/task_fetch_accounts.go
+++ b/components/payments/internal/app/connectors/stripe/task_fetch_accounts.go
@@ -61,7 +61,7 @@ func FetchAccountsTask(config Config, client *client.DefaultClient) task.Task {
 
 						err = scheduler.Schedule(ctx, transactionsTask, models.TaskSchedulerOptions{
 							ScheduleOption: models.OPTIONS_RUN_NOW,
-							Restart:        true,
+							RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 						})
 						if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 							return errors.Wrap(err, "scheduling connected account")
@@ -78,7 +78,7 @@ func FetchAccountsTask(config Config, client *client.DefaultClient) task.Task {
 
 						err = scheduler.Schedule(ctx, balancesTask, models.TaskSchedulerOptions{
 							ScheduleOption: models.OPTIONS_RUN_NOW,
-							Restart:        true,
+							RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 						})
 						if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 							return errors.Wrap(err, "scheduling connected account")
@@ -95,7 +95,7 @@ func FetchAccountsTask(config Config, client *client.DefaultClient) task.Task {
 
 						err = scheduler.Schedule(ctx, externalAccountsTask, models.TaskSchedulerOptions{
 							ScheduleOption: models.OPTIONS_RUN_NOW,
-							Restart:        true,
+							RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 						})
 						if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 							return errors.Wrap(err, "scheduling connected account")

--- a/components/payments/internal/app/connectors/stripe/task_main.go
+++ b/components/payments/internal/app/connectors/stripe/task_main.go
@@ -27,7 +27,7 @@ func MainTask(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err
@@ -43,7 +43,7 @@ func MainTask(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskPayments, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/stripe/task_payments.go
+++ b/components/payments/internal/app/connectors/stripe/task_payments.go
@@ -157,12 +157,8 @@ func InitiatePaymentTask(logger logging.Logger, transferID string, stripeClient 
 
 		ctx, _ = contextutil.DetachedWithTimeout(ctx, 10*time.Second)
 		err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
-			// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-			// and their transactions.
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			// No need to restart this task, since the connector is not existing or
-			// was uninstalled previously, the task does not exists in the database
-			Restart: true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/wise/connector.go
+++ b/components/payments/internal/app/connectors/wise/connector.go
@@ -45,7 +45,7 @@ func (c *Connector) InitiatePayment(ctx task.ConnectorContext, transfer *models.
 		ScheduleOption: models.OPTIONS_RUN_NOW_SYNC,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: true,
+		RestartOption: models.OPTIONS_RESTART_ALWAYS,
 	})
 	if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 		return err
@@ -70,7 +70,7 @@ func (c *Connector) Install(ctx task.ConnectorContext) error {
 		Duration:       c.cfg.PollingPeriod.Duration,
 		// No need to restart this task, since the connector is not existing or
 		// was uninstalled previously, the task does not exists in the database
-		Restart: false,
+		RestartOption: models.OPTIONS_RESTART_NEVER,
 	})
 }
 

--- a/components/payments/internal/app/connectors/wise/task_fetch_profiles.go
+++ b/components/payments/internal/app/connectors/wise/task_fetch_profiles.go
@@ -81,7 +81,7 @@ func taskFetchProfiles(logger logging.Logger, client *client.Client) task.Task {
 		for _, descriptor := range descriptors {
 			err = scheduler.Schedule(ctx, descriptor, models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_NOW,
-				Restart:        true,
+				RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 			})
 			if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 				return err

--- a/components/payments/internal/app/connectors/wise/task_main.go
+++ b/components/payments/internal/app/connectors/wise/task_main.go
@@ -27,7 +27,7 @@ func taskMain(logger logging.Logger) task.Task {
 
 		err = scheduler.Schedule(ctx, taskUsers, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err

--- a/components/payments/internal/app/connectors/wise/task_payments.go
+++ b/components/payments/internal/app/connectors/wise/task_payments.go
@@ -170,12 +170,8 @@ func taskInitiatePayment(logger logging.Logger, wiseClient *client.Client, trans
 
 		ctx, _ = contextutil.DetachedWithTimeout(ctx, 10*time.Second)
 		err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
-			// We want to polling every c.cfg.PollingPeriod.Duration seconds the users
-			// and their transactions.
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			// No need to restart this task, since the connector is not existing or
-			// was uninstalled previously, the task does not exists in the database
-			Restart: true,
+			RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			return err
@@ -268,7 +264,7 @@ func taskUpdatePaymentStatus(
 			err = scheduler.Schedule(ctx, taskDescriptor, models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_IN_DURATION,
 				Duration:       2 * time.Minute,
-				Restart:        true,
+				RestartOption:  models.OPTIONS_RESTART_IF_NOT_ACTIVE,
 			})
 			if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 				return err

--- a/components/payments/internal/app/integration/manager_test.go
+++ b/components/payments/internal/app/integration/manager_test.go
@@ -115,7 +115,7 @@ func TestUninstallConnector(t *testing.T) {
 		WithInstall(func(ctx task.ConnectorContext) error {
 			return ctx.Scheduler().Schedule(ctx.Context(), []byte(uuid.New().String()), models.TaskSchedulerOptions{
 				ScheduleOption: models.OPTIONS_RUN_NOW,
-				Restart:        false,
+				RestartOption:  models.OPTIONS_RESTART_NEVER,
 			})
 		}).
 		WithUninstall(func(ctx context.Context) error {

--- a/components/payments/internal/app/models/task.go
+++ b/components/payments/internal/app/models/task.go
@@ -20,6 +20,14 @@ const (
 	OPTIONS_RUN_NOW_SYNC
 )
 
+type RestartOption int
+
+const (
+	OPTIONS_RESTART_NEVER RestartOption = iota
+	OPTIONS_RESTART_ALWAYS
+	OPTIONS_RESTART_IF_NOT_ACTIVE
+)
+
 type Task struct {
 	bun.BaseModel `bun:"tasks.task"`
 
@@ -44,7 +52,12 @@ func (t Task) GetDescriptor() TaskDescriptor {
 type TaskSchedulerOptions struct {
 	ScheduleOption ScheduleOption
 	Duration       time.Duration
-	Restart        bool
+
+	// TODO(polo): Deprecated, will be removed in the next release, use
+	// RestartOption instead.
+	// We have to keep it for now for db compatibility.
+	Restart       bool
+	RestartOption RestartOption
 }
 
 type TaskDescriptor json.RawMessage

--- a/components/payments/internal/app/task/scheduler_test.go
+++ b/components/payments/internal/app/task/scheduler_test.go
@@ -89,7 +89,7 @@ func TestTaskScheduler(t *testing.T) {
 		descriptor := newDescriptor()
 		err := scheduler.Schedule(context.TODO(), descriptor, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        false,
+			RestartOption:  models.OPTIONS_RESTART_NEVER,
 		})
 		require.NoError(t, err)
 
@@ -115,14 +115,14 @@ func TestTaskScheduler(t *testing.T) {
 		descriptor := newDescriptor()
 		err := scheduler.Schedule(context.TODO(), descriptor, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        false,
+			RestartOption:  models.OPTIONS_RESTART_NEVER,
 		})
 		require.NoError(t, err)
 		require.Eventually(t, TaskActive(store, provider, descriptor), time.Second, 100*time.Millisecond)
 
 		err = scheduler.Schedule(context.TODO(), descriptor, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        false,
+			RestartOption:  models.OPTIONS_RESTART_NEVER,
 		})
 		require.Equal(t, ErrAlreadyScheduled, err)
 	})
@@ -142,7 +142,7 @@ func TestTaskScheduler(t *testing.T) {
 		descriptor := newDescriptor()
 		err := scheduler.Schedule(context.TODO(), descriptor, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        false,
+			RestartOption:  models.OPTIONS_RESTART_NEVER,
 		})
 		require.NoError(t, err)
 		require.Eventually(t, TaskFailed(store, provider, descriptor, "test"), time.Second,
@@ -188,11 +188,11 @@ func TestTaskScheduler(t *testing.T) {
 
 		require.NoError(t, scheduler.Schedule(context.TODO(), descriptor1, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        false,
+			RestartOption:  models.OPTIONS_RESTART_NEVER,
 		}))
 		require.NoError(t, scheduler.Schedule(context.TODO(), descriptor2, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        false,
+			RestartOption:  models.OPTIONS_RESTART_NEVER,
 		}))
 		require.Eventually(t, TaskActive(store, provider, descriptor1), time.Second, 100*time.Millisecond)
 		require.Eventually(t, TaskPending(store, provider, descriptor2), time.Second, 100*time.Millisecond)
@@ -219,7 +219,7 @@ func TestTaskScheduler(t *testing.T) {
 						<-ctx.Done()
 						require.NoError(t, scheduler.Schedule(ctx, workerDescriptor, models.TaskSchedulerOptions{
 							ScheduleOption: models.OPTIONS_RUN_NOW,
-							Restart:        false,
+							RestartOption:  models.OPTIONS_RESTART_NEVER,
 						}))
 					}
 				default:
@@ -229,7 +229,7 @@ func TestTaskScheduler(t *testing.T) {
 
 		require.NoError(t, scheduler.Schedule(context.TODO(), mainDescriptor, models.TaskSchedulerOptions{
 			ScheduleOption: models.OPTIONS_RUN_NOW,
-			Restart:        false,
+			RestartOption:  models.OPTIONS_RESTART_NEVER,
 		}))
 		require.Eventually(t, TaskActive(store, provider, mainDescriptor), time.Second, 100*time.Millisecond)
 		require.NoError(t, scheduler.Shutdown(context.TODO()))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,7 @@ services:
       opensearch:
         condition: service_healthy
     volumes:
-      - ./.local/process-compose.yaml:/running/process-compose.yaml
-      - ./config:/etc/formance
+      - ./.local:/etc/formance
       - ./components/search/benthos:/benthos
       - ./components/auth/pkg/web:/app/web
     ports:
@@ -69,7 +68,7 @@ services:
       PGDATA: "/data/postgres"
     volumes:
       - postgres_data:/data/postgres
-      - ./config/postgres:/docker-entrypoint-initdb.d
+      - ./.local/postgres:/docker-entrypoint-initdb.d
 
   opensearch:
     platform: linux/x86_64


### PR DESCRIPTION
Add multiple ways to restart a task:
- NEVER: never restart the task if it was inserted in the db
- ALWAYS: always restart the start
- IF_NOT_ACTIVE: restart if the inserted task status is not active

Fixes NUM-1767