### PR TITLE
fix(fctl): does not keep polling when no browser

### DIFF
--- a/components/fctl/cmd/login/controller.go
+++ b/components/fctl/cmd/login/controller.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"time"
 
@@ -24,10 +25,11 @@ func LogIn(ctx context.Context, dialog Dialog, relyingParty rp.RelyingParty) (*o
 	query.Set("user_code", deviceCode.UserCode)
 	uri.RawQuery = query.Encode()
 
-	dialog.DisplayURIAndCode(deviceCode.VerificationURI, deviceCode.UserCode)
-
 	if err := fctl.Open(uri.String()); err != nil {
-		return nil, err
+		dialog.DisplayURIAndCode(err, deviceCode.VerificationURI, deviceCode.UserCode)
+		if !errors.Is(err, fctl.ErrOpenningBrowser) {
+			return nil, err
+		}
 	}
 
 	return rp.DeviceAccessToken(ctx, deviceCode.DeviceCode, time.Duration(deviceCode.Interval)*time.Second, relyingParty)

--- a/components/fctl/pkg/utils.go
+++ b/components/fctl/pkg/utils.go
@@ -35,6 +35,10 @@ func ContainValue[V comparable](array []V, value V) bool {
 	return false
 }
 
+var (
+	ErrOpenningBrowser = errors.New("opening browser")
+)
+
 func Open(url string) error {
 	var (
 		cmd  string
@@ -55,5 +59,6 @@ func Open(url string) error {
 		args = append(args, url)
 		return exec.Command(cmd, args...).Start()
 	}
-	return errors.New("error_opening_browser")
+
+	return ErrOpenningBrowser
 }


### PR DESCRIPTION
-A/ Only in case where no browser is detected:
  - before: Print the **rigth** link

- B/ Browser detected:
  - before: open browser with good url 


 After : poll on OAuth endpoint,