### PR TITLE
docs: add documentation for user invitation process

### DIFF
--- a/docs/docs/getting-started/invite.mdx
+++ b/docs/docs/getting-started/invite.mdx
@@ -1,0 +1,20 @@
+---
+title: Invite users
+description: How to allow users to access your stack
+---
+
+# Invite users to use your stack
+
+The best way to allow users to interact with your Formance stack is to invite them to your organization, using fctl.
+
+```shell
+# if you have multiple organizations, you must specify which one you're using like this :  --organization [OrganizationID]
+fctl cloud organizations invitations send [user@mail.com]
+```
+
+
+
+# Invite users with the web interface
+
+You can also invite users to your organization using the organization management feature in the [web interface](https://console.formance.cloud).
+This feature is available by clicking your username in the top right corner, then clicking on "Organizations", and "Manage Environments".

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -37,6 +37,10 @@ const sidebars = {
         {
           type: 'doc',
           id: 'guides/newSandbox',
+        },
+        {
+          type: 'doc',
+          id: 'getting-started/invite',
         }
       ],
     },


### PR DESCRIPTION
- Add a new file `invite.mdx` in the `docs/docs/getting-started` directory
- Add content for inviting users to use the Formance stack in the `invite.mdx` file
- Provide instructions for inviting users using the `fctl` command line tool
- Provide instructions for inviting users using the web interface
- Update the `sidebars.js` file to include a link to the `invite` documentation page in the sidebar