### PR TITLE
docs: Add a reference page about postings

### DIFF
--- a/docs/docs/ledger/reference/numscript/postings.mdx
+++ b/docs/docs/ledger/reference/numscript/postings.mdx
@@ -1,0 +1,31 @@
+---
+title: Postings
+---
+import { NumscriptBlock } from 'react-numscript-codeblock';
+
+In Numscript, a [posting](/ledger/reference/transactions#postings) models the movement of an amount of an asset from one account to another. Postings are wrapped in a [transaction](/ledger/reference/transactions#transactions-1) to ensure that they are applied atomically.
+
+## Defining a posting
+
+A posting is defined as followed:
+
+<NumscriptBlock script={`send [COIN 100] (
+  source = @world
+  destination = @users:001
+)`}></NumscriptBlock>
+
+Square brackets describe the asset being moved using the Formance's [Unambiguous Monetary Notation (UMN)](/stack/unambiguous-monetary-notation). It is composed of the asset type optionally followed by a scaling value, and the amount. In this case, the asset type is `COIN` with no scaling value, and the amount is `100`.
+
+## Postings with no amount
+
+You can omit the amount of an asset in a posting and replace it with a `*`. This is used when you want to move all of the asset from one account to another.
+
+<NumscriptBlock script={`send [USD/2 *] (
+  source = @order:1234
+  destination = {
+    10% to @platform:fees
+    remaining to @merchant:5678
+  }
+)`}></NumscriptBlock>
+
+Here, we are moving all of the `USD/2` asset from the `@order:1234` account. 10% of the `@order:1234` balance is moved to the `@platform:fees` account, and the remaining 90% is moved to the `@merchant:5678` account.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -219,6 +219,7 @@ const sidebars = {
                   collapsed: true,
                   items: [
                     'ledger/reference/numscript/machine',
+                    'ledger/reference/numscript/postings',
                     'ledger/reference/numscript/sources',
                     'ledger/reference/numscript/destinations',
                     'ledger/reference/numscript/variables',


### PR DESCRIPTION
In addition to explaining the basic posting syntax, this page explains the `send [ASSET *] ( [...] )` syntax.