### PR TITLE
fix: expect 200 response for revert transaction response

### DIFF
--- a/components/ledger/openapi.yaml
+++ b/components/ledger/openapi.yaml
@@ -655,7 +655,7 @@ paths:
             minimum: 0
             example: 1234
       responses:
-        "201":
+        "200":
           description: OK
           content:
             application/json:

--- a/openapi/build/generate.json
+++ b/openapi/build/generate.json
@@ -12,7 +12,7 @@
       "url": "https://avatars.githubusercontent.com/u/84325077?s=200&v=4",
       "altText": "Formance"
     },
-    "version": "v1.0.20230822"
+    "version": "v1.0.20230831"
   },
   "servers": [
     {
@@ -1569,7 +1569,7 @@
           }
         ],
         "responses": {
-          "201": {
+          "200": {
             "description": "OK",
             "content": {
               "application/json": {

--- a/sdks/go/ledger.go
+++ b/sdks/go/ledger.go
@@ -993,7 +993,7 @@ func (s *ledger) RevertTransaction(ctx context.Context, request operations.Rever
 		RawResponse: httpRes,
 	}
 	switch {
-	case httpRes.StatusCode == 201:
+	case httpRes.StatusCode == 200:
 		switch {
 		case utils.MatchContentType(contentType, `application/json`):
 			var out *shared.RevertTransactionResponse

--- a/sdks/java/lib/src/main/java/com/formance/formance_sdk/Ledger.java
+++ b/sdks/java/lib/src/main/java/com/formance/formance_sdk/Ledger.java
@@ -847,7 +847,7 @@ public class Ledger {
         }};
         res.rawResponse = httpRes;
         
-        if (httpRes.statusCode() == 201) {
+        if (httpRes.statusCode() == 200) {
             if (com.formance.formance_sdk.utils.Utils.matchContentType(contentType, "application/json")) {
                 ObjectMapper mapper = JSON.getMapper();
                 com.formance.formance_sdk.models.shared.RevertTransactionResponse out = mapper.readValue(new String(httpRes.body(), StandardCharsets.UTF_8), com.formance.formance_sdk.models.shared.RevertTransactionResponse.class);

--- a/sdks/php/src/Ledger.php
+++ b/sdks/php/src/Ledger.php
@@ -722,7 +722,7 @@ class Ledger
         $response->contentType = $contentType;
         $response->rawResponse = $httpResponse;
         
-        if ($httpResponse->getStatusCode() === 201) {
+        if ($httpResponse->getStatusCode() === 200) {
             if (Utils\Utils::matchContentType($contentType, 'application/json')) {
                 $serializer = Utils\JSON::createSerializer();
                 $response->revertTransactionResponse = $serializer->deserialize((string)$httpResponse->getBody(), 'formance\stack\Models\Shared\RevertTransactionResponse', 'json');

--- a/sdks/python/src/sdk/ledger.py
+++ b/sdks/python/src/sdk/ledger.py
@@ -483,7 +483,7 @@ class Ledger:
 
         res = operations.RevertTransactionResponse(status_code=http_res.status_code, content_type=content_type, raw_response=http_res)
         
-        if http_res.status_code == 201:
+        if http_res.status_code == 200:
             if utils.match_content_type(content_type, 'application/json'):
                 out = utils.unmarshal_json(http_res.text, Optional[shared.RevertTransactionResponse])
                 res.revert_transaction_response = out

--- a/sdks/typescript/src/sdk/ledger.ts
+++ b/sdks/typescript/src/sdk/ledger.ts
@@ -1148,7 +1148,7 @@ export class Ledger {
         rawResponse: httpRes,
       });
     switch (true) {
-      case httpRes?.status == 201:
+      case httpRes?.status == 200:
         if (utils.matchContentType(contentType, `application/json`)) {
           res.revertTransactionResponse = utils.objectToClass(
             httpRes?.data,


### PR DESCRIPTION
https://docs.formance.com/api/stack/v1.0#tag/Transactions/operation/revertTransaction

Revert transaction returns 200 upon success, however, the SDK expects status 201. As a result, the error response is unmarshalled on success, which ultimately fails.