### PR TITLE
feat: add deployment strategy on ledger

### DIFF
--- a/components/operator/apis/stack/v1beta3/ledger_types.go
+++ b/components/operator/apis/stack/v1beta3/ledger_types.go
@@ -26,6 +26,13 @@ type LockingStrategy struct {
 	Redis LockingStrategyRedisConfig `json:"redis"`
 }
 
+type DeploymentStrategy string
+
+const (
+	DeploymentStrategySingle                   = "single"
+	DeploymentStrategyMonoWriterMultipleReader = "single-writer"
+)
+
 // +kubebuilder:object:generate=true
 type LedgerSpec struct {
 	Postgres PostgresConfig `json:"postgres"`
@@ -38,6 +45,8 @@ type LedgerSpec struct {
 	// +optional
 	ResourceProperties *ResourceProperties     `json:"resourceProperties,omitempty"`
 	Annotations        AnnotationsServicesSpec `json:"annotations,omitempty"`
+	// +optional
+	DeploymentStrategy DeploymentStrategy `json:"deploymentStrategy,omitempty"`
 }
 
 type ServiceSpec struct {

--- a/components/operator/config/crd/bases/stack.formance.com_configurations.yaml
+++ b/components/operator/config/crd/bases/stack.formance.com_configurations.yaml
@@ -4365,6 +4365,8 @@ spec:
                         type: object
                       debug:
                         type: boolean
+                      deploymentStrategy:
+                        type: string
                       dev:
                         type: boolean
                       locking:

--- a/components/operator/internal/modules/ledger/handler.go
+++ b/components/operator/internal/modules/ledger/handler.go
@@ -1,6 +1,7 @@
 package ledger
 
 import (
+	"github.com/formancehq/stack/libs/go-libs/pointer"
 	"net/http"
 	"strconv"
 
@@ -113,14 +114,16 @@ func (l module) Versions() map[string]modules.Version {
 				if ctx.Configuration.Spec.Services.Ledger.DeploymentStrategy == v1beta3.DeploymentStrategyMonoWriterMultipleReader {
 					cp := main
 					cp.Name = "read"
-					main.ExposeHTTP = &modules.ExposeHTTP{
-						Methods: []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch},
-					}
 					cp.ExposeHTTP = &modules.ExposeHTTP{
 						Methods: []string{http.MethodGet, http.MethodOptions, http.MethodHead},
 					}
 					cp.Container = createContainer(modules.NewEnv().Append(modules.Env("READ_ONLY", "true")))
 					ret = append(ret, &cp)
+
+					main.ExposeHTTP = &modules.ExposeHTTP{
+						Methods: []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch},
+					}
+					main.Replicas = pointer.For(int32(1))
 				}
 
 				return ret

--- a/components/operator/internal/modules/pod.go
+++ b/components/operator/internal/modules/pod.go
@@ -26,6 +26,7 @@ type pod struct {
 	containers           []corev1.Container
 	disableRollingUpdate bool
 	mono                 bool
+	replicas             *int32
 }
 
 type PodDeployer interface {
@@ -59,8 +60,12 @@ func (d *defaultPodDeployer) deploy(ctx context.Context, pod pod) error {
 				stackLabel:   "true",
 				productLabel: pod.moduleName,
 			}
+			replicas := pod.replicas
+			if replicas == nil {
+				replicas = t.Spec.Replicas
+			}
 			t.Spec = appsv1.DeploymentSpec{
-				Replicas: t.Spec.Replicas,
+				Replicas: replicas,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: matchLabels,
 				},

--- a/components/operator/internal/modules/service.go
+++ b/components/operator/internal/modules/service.go
@@ -298,6 +298,7 @@ type Service struct {
 	Container               func(resolveContext ContainerResolutionConfiguration) Container
 	InitContainer           func(resolveContext ContainerResolutionConfiguration) []Container
 	NeedTopic               bool
+	Replicas                *int32
 
 	EnvPrefix string
 }
@@ -438,6 +439,7 @@ func (r *serviceReconciler) createDeployment(ctx context.Context, config Contain
 		initContainers:       r.initContainers(config, r.name),
 		containers:           r.containers(config, container, r.name),
 		disableRollingUpdate: container.DisableRollingUpdate,
+		replicas:             r.service.Replicas,
 	})
 }
 


### PR DESCRIPTION
Add deployment strategy for the ledger on the operator.
The operator now deploy two Deployments for the ledger : 
* A writer : Numbers of replicas to 1
* Readers: Number of replicas initially set to 1 but can be changed

Also, the gateway will route all http requests with GET, OPTIONS or HEAD methods to the readers, others to the writer.