### PR TITLE
fix(operator): fix pre-run migrations

### DIFF
--- a/components/operator/internal/modules/module.go
+++ b/components/operator/internal/modules/module.go
@@ -351,7 +351,7 @@ func (r *moduleReconciler) runDatabaseMigration(ctx context.Context, version str
 					return errors.Wrap(err, "stopping pod")
 				} else if !scaledDown {
 					logger.Info("Stop reconciliation as pod needs to be scaled down", "pod", r.module.Name())
-					return nil
+					return fmt.Errorf("pod needs to be scaled down")
 				}
 			}
 			return nil


### PR DESCRIPTION
When scaling down a migration, if pod is not yet scaled down, the migration is still run because we're returning nil. This PR ensures that the reconciliation fails and start again until the pod is effectivement scaled down

Fixes ENG-231