### PR TITLE
fix(payments): fix docker compose to test it locally

### DIFF
--- a/components/payments/docker-compose.yml
+++ b/components/payments/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./local_env/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   payments-migrate:
-    image: golang:1.19.3-alpine3.16
+    image: golang:1.20.11-alpine3.18
     command: go run ./ migrate up
     depends_on:
       postgres:
@@ -34,7 +34,7 @@ services:
       POSTGRES_URI: postgres://payments:payments@postgres:${POSTGRES_PORT:-5432}/payments?sslmode=disable
 
   payments-api:
-    image: golang:1.19.3-alpine3.16
+    image: golang:1.20.11-alpine3.18
     command: go run ./ api server
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/_healthcheck" ]
@@ -58,10 +58,10 @@ services:
       CONFIG_ENCRYPTION_KEY: mysuperencryptionkey
 
   payments-connectors:
-    image: golang:1.19.3-alpine3.16
+    image: golang:1.20.11-alpine3.18
     command: go run ./ connectors server
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/_healthcheck" ]
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:8081/_healthcheck" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/components/payments/docker-compose.yml
+++ b/components/payments/docker-compose.yml
@@ -11,30 +11,72 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:${POSTGRES_PORT:-5432}"
     environment:
       POSTGRES_USER: "payments"
       POSTGRES_PASSWORD: "payments"
       POSTGRES_DB: "payments"
-      PGDATA: /data/postgres
+    command: -p ${POSTGRES_PORT:-5432}
     volumes:
-      - postgres:/data/postgres
+      - ./local_env/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
 
-  payments:
+  payments-migrate:
     image: golang:1.19.3-alpine3.16
-    command: go run ./ migrate up && go run ./ serve
+    command: go run ./ migrate up
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - .:/app/components/payments
+      - ../../libs:/app/libs
+    working_dir: /app/components/payments
+    environment:
+      POSTGRES_URI: postgres://payments:payments@postgres:${POSTGRES_PORT:-5432}/payments?sslmode=disable
+
+  payments-api:
+    image: golang:1.19.3-alpine3.16
+    command: go run ./ api server
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/_healthcheck" ]
       interval: 10s
       timeout: 5s
       retries: 5
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+      payments-migrate:
+        condition: service_completed_successfully
     ports:
       - "8080:8080"
     volumes:
-      - .:/app
-    working_dir: /app
+      - .:/app/components/payments
+      - ../../libs:/app/libs
+    working_dir: /app/components/payments
     environment:
       DEBUG: ${DEBUG:-"true"}
-      POSTGRES_URI: postgres://payments:payments@postgres/payments?sslmode=disable
+      POSTGRES_URI: postgres://payments:payments@postgres:${POSTGRES_PORT:-5432}/payments?sslmode=disable
+      CONFIG_ENCRYPTION_KEY: mysuperencryptionkey
+
+  payments-connectors:
+    image: golang:1.19.3-alpine3.16
+    command: go run ./ connectors server
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/_healthcheck" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      postgres:
+        condition: service_healthy
+      payments-migrate:
+        condition: service_completed_successfully
+    ports:
+      - "8081:8080"
+    volumes:
+       - .:/app/components/payments
+       - ../../libs:/app/libs
+    working_dir: /app/components/payments
+    environment:
+      DEBUG: ${DEBUG:-"true"}
+      POSTGRES_URI: postgres://payments:payments@postgres:${POSTGRES_PORT:-5432}/payments?sslmode=disable
+      CONFIG_ENCRYPTION_KEY: mysuperencryptionkey

--- a/components/payments/local_env/postgres/init.sql
+++ b/components/payments/local_env/postgres/init.sql
@@ -1,0 +1,1 @@
+ALTER ROLE payments SET search_path = public;


### PR DESCRIPTION
# DESCRIPTION

The docker compose in the components/payments/ was not working anymore after the splitting of payments in two services. This PR fixes that.

It also adds the possibility to use the `POSTGRES_PORT` env var to configure the postgres port.

Fixes ENG-249