### PR TITLE
feat(ledger): add some columns on transactions table to speed up read queries

### DIFF
--- a/components/ledger/internal/storage/ledgerstore/migrations/0-init-schema.sql
+++ b/components/ledger/internal/storage/ledgerstore/migrations/0-init-schema.sql
@@ -55,7 +55,11 @@ create table transactions (
     timestamp timestamp without time zone not null,
     reference varchar,
     reverted_at timestamp without time zone,
-    postings varchar not null
+    postings varchar not null,
+    sources jsonb,
+    destinations jsonb,
+    sources_arrays jsonb,
+    destinations_arrays jsonb
 );
 
 create table transactions_metadata (
@@ -127,6 +131,10 @@ create index moves_range_dates on moves (account_address, asset, effective_date)
 create index transactions_date on transactions (timestamp);
 create index transactions_metadata_metadata on transactions_metadata using gin (metadata);
 --create unique index transactions_revisions on transactions_metadata(id desc, revision desc);
+create index transactions_sources on transactions using gin (sources jsonb_path_ops);
+create index transactions_destinations on transactions using gin (destinations jsonb_path_ops);
+create index transactions_sources_arrays on transactions using gin (sources_arrays jsonb_path_ops);
+create index transactions_destinations_arrays on transactions using gin (destinations_arrays jsonb_path_ops);
 
 create index moves_account_address on moves (account_address);
 create index moves_account_address_array on moves using gin (account_address_array jsonb_ops);
@@ -158,6 +166,22 @@ as $$
 
         return _account is not null;
     end;
+$$;
+
+create function explode_address(_address varchar)
+	returns jsonb
+	language sql
+	stable
+as $$
+    select aggregate_objects(jsonb_build_object(data.number - 1, data.value))
+	from (
+	    select row_number() over () as number, v.value
+	    from (
+	        select unnest(string_to_array(_address, ':')) as value
+	        union all
+	        select null
+	    ) v
+    ) data
 $$;
 
 create function get_account(_account_address varchar, _before timestamp default null)
@@ -405,11 +429,28 @@ as $$
     declare
         posting jsonb;
     begin
-        insert into transactions (id, timestamp, reference, postings)
+        insert into transactions (id, timestamp, reference, postings, sources, destinations, sources_arrays, destinations_arrays)
         values ((data->>'id')::numeric,
                 (data->>'timestamp')::timestamp without time zone,
                 data->>'reference',
-                jsonb_pretty(data->'postings'));
+                jsonb_pretty(data->'postings'),
+                (
+	                select to_jsonb(array_agg(v->>'source')) as value
+	                from jsonb_array_elements(data->'postings') v
+                ),
+                (
+	                select to_jsonb(array_agg(v->>'destination')) as value
+	                from jsonb_array_elements(data->'postings') v
+                ),
+                (
+	                select to_jsonb(array_agg(explode_address(v->>'source'))) as value
+	                from jsonb_array_elements(data->'postings') v
+                ),
+                (
+	                select to_jsonb(array_agg(explode_address(v->>'destination'))) as value
+	                from jsonb_array_elements(data->'postings') v
+                )
+        );
 
         for posting in (select jsonb_array_elements(data->'postings')) loop
             -- todo: sometimes the balance is known at commit time (for sources != world), we need to forward the value to populate the pre_commit_aggregated_input and output

--- a/components/ledger/internal/storage/ledgerstore/migrations/0-init-schema.sql
+++ b/components/ledger/internal/storage/ledgerstore/migrations/0-init-schema.sql
@@ -168,10 +168,11 @@ as $$
     end;
 $$;
 
+-- given the input : "a:b:c", the function will produce : '{"0": "a", "1": "b", "2": "c", "3": null}'
 create function explode_address(_address varchar)
 	returns jsonb
 	language sql
-	stable
+	immutable
 as $$
     select aggregate_objects(jsonb_build_object(data.number - 1, data.value))
 	from (

--- a/components/ledger/internal/storage/ledgerstore/transactions_test.go
+++ b/components/ledger/internal/storage/ledgerstore/transactions_test.go
@@ -1020,6 +1020,7 @@ func TestGetTransactions(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			tc.query.Options.ExpandVolumes = true
 			tc.query.Options.ExpandEffectiveVolumes = false
 			cursor, err := store.GetTransactions(ctx, NewGetTransactionsQuery(tc.query))
@@ -1027,6 +1028,7 @@ func TestGetTransactions(t *testing.T) {
 				require.True(t, errors.Is(err, tc.expectError))
 			} else {
 				require.NoError(t, err)
+				require.Len(t, cursor.Data, len(tc.expected.Data))
 				internaltesting.RequireEqual(t, *tc.expected, *cursor)
 
 				count, err := store.CountTransactions(ctx, NewGetTransactionsQuery(tc.query))


### PR DESCRIPTION
Benchmarks results (run 2 times) : 
`

1.
          +benchstat | LogsInsertion-8                                                             3.820m ± 5%   3.577m ± 3%   -6.37% (p=0.000 n=10)
          +benchstat | LogsInsertionReusingAccount-8                                               3.369m ± 7%   3.585m ± 5%   +6.42% (p=0.011 n=10)
          +benchstat | List/listing_transactions_with_no_query-8                                   980.7µ ± 1%   555.1µ ± 1%  -43.40% (p=0.000 n=10)
          +benchstat | List/listing_transactions_using_an_exact_address-8                          902.0µ ± 1%   782.5µ ± 1%  -13.24% (p=0.000 n=10)
          +benchstat | List/listing_transactions_using_an_address_segment-8                       1030.6µ ± 1%   964.7µ ± 1%   -6.39% (p=0.000 n=10)
          +benchstat | 
          +benchstat | List/listing_transactions_using_a_metadata_metadata-8                      1021.8µ ± 1%   756.8µ ± 1%  -25.94% (p=0.000 n=10)
          +benchstat | List/listing_transactions_using_non_existent_account_by_exact_address-8     606.5µ ± 0%   472.5µ ± 0%  -22.11% (p=0.000 n=10)
          +benchstat | List/listing_transactions_using_non_existent_metadata-8                     15.62m ± 2%   15.64m ± 1%        ~ (p=0.353 n=10)
          +benchstat | List/listing_transactions_with_expand_volumes-8                             2.944m ± 1%   2.676m ± 1%   -9.12% (p=0.000 n=10)
          +benchstat | List/listing_transactions_with_expand_effective_volumes-8                   2.932m ± 0%   2.690m ± 1%   -8.26% (p=0.000 n=10)
          +benchstat | 
          +benchstat | List/listing_accounts_with_no_query-8                                       1.067m ± 3%   1.019m ± 1%   -4.51% (p=0.001 n=10)
          +benchstat | 
          +benchstat | List/listing_accounts_filtering_on_address_segment-8                        722.8µ ± 2%   727.2µ ± 2%        ~ (p=0.631 n=10)
          +benchstat | List/listing_accounts_filtering_on_metadata-8                               497.0µ ± 1%   495.1µ ± 1%        ~ (p=0.218 n=10)
          +benchstat | List/listing_accounts_with_expand_volumes-8                                 320.3m ± 0%   329.8m ± 0%   +2.96% (p=0.000 n=10)
          +benchstat | List/listing_accounts_with_expand_effective_volumes-8                       320.3m ± 0%   330.4m ± 0%   +3.17% (p=0.000 n=10)
          +benchstat | 
          +benchstat | List/aggregating_balance_with_no_query-8                                    45.40m ± 1%   45.37m ± 1%        ~ (p=0.912 n=10)
          +benchstat | List/aggregating_balance_filtering_on_exact_account_address-8               457.6µ ± 1%   440.9µ ± 2%   -3.67% (p=0.000 n=10)
          +benchstat | List/aggregating_balance_filtering_on_account_address_segment-8             672.6µ ± 1%   628.2µ ± 1%   -6.60% (p=0.000 n=10)
          +benchstat | List/aggregating_balance_filtering_on_metadata-8                            10.56m ± 2%   10.57m ± 1%        ~ (p=0.684 n=10)
          +benchstat | geomean                                                                     3.262m        2.998m        -8.07%

2.
          +benchstat | LogsInsertion-8                                                            3.152m ± 10%   2.901m ± 6%   -7.95% (p=0.007 n=10)
          +benchstat | LogsInsertionReusingAccount-8                                              3.178m ±  8%   2.916m ± 4%   -8.25% (p=0.000 n=10)
          +benchstat | List/listing_transactions_with_no_query-8                                  991.3µ ±  6%   554.1µ ± 1%  -44.11% (p=0.000 n=10)
          +benchstat | List/listing_transactions_using_an_exact_address-8                         912.1µ ±  1%   778.5µ ± 1%  -14.65% (p=0.000 n=10)
          +benchstat | List/listing_transactions_using_an_address_segment-8                      1032.0µ ±  2%   970.4µ ± 1%   -5.97% (p=0.000 n=10)
          +benchstat | List/listing_transactions_using_a_metadata_metadata-8                     1027.1µ ±  1%   757.2µ ± 2%  -26.28% (p=0.000 n=10)
          +benchstat | List/listing_transactions_using_non_existent_account_by_exact_address-8    610.8µ ±  0%   462.7µ ± 2%  -24.25% (p=0.000 n=10)
          +benchstat | 
          +benchstat | List/listing_transactions_using_non_existent_metadata-8                    16.02m ±  2%   15.60m ± 2%   -2.65% (p=0.000 n=10)
          +benchstat | List/listing_transactions_with_expand_volumes-8                            2.971m ±  1%   2.431m ± 1%  -18.19% (p=0.000 n=10)
          +benchstat | List/listing_transactions_with_expand_effective_volumes-8                  2.974m ±  1%   2.443m ± 1%  -17.86% (p=0.000 n=10)
          +benchstat | List/listing_accounts_with_no_query-8                                      1.030m ±  2%   1.029m ± 3%        ~ (p=0.739 n=10)
          +benchstat | List/listing_accounts_filtering_on_address_segment-8                       724.4µ ±  3%   721.7µ ± 2%        ~ (p=0.436 n=10)
          +benchstat | List/listing_accounts_filtering_on_metadata-8                              501.0µ ±  1%   494.8µ ± 2%        ~ (p=0.143 n=10)
          +benchstat | List/listing_accounts_with_expand_volumes-8                                321.0m ±  0%   320.1m ± 0%   -0.28% (p=0.000 n=10)
          +benchstat | List/listing_accounts_with_expand_effective_volumes-8                      321.8m ±  0%   319.7m ± 0%   -0.63% (p=0.000 n=10)
          +benchstat | List/aggregating_balance_with_no_query-8                                   45.25m ±  1%   45.57m ± 1%   +0.71% (p=0.043 n=10)
          +benchstat | List/aggregating_balance_filtering_on_exact_account_address-8              456.8µ ±  2%   441.3µ ± 1%   -3.40% (p=0.000 n=10)
          +benchstat | List/aggregating_balance_filtering_on_account_address_segment-8            673.0µ ±  2%   631.6µ ± 1%   -6.15% (p=0.000 n=10)
          +benchstat | List/aggregating_balance_filtering_on_metadata-8                           10.58m ±  2%   10.47m ± 1%   -1.06% (p=0.003 n=10)
          +benchstat | geomean                                                                    3.230m         2.891m       -10.49%
`