### PR TITLE
fix: Fix time parsing in Atlar connector

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/time.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/time.go
@@ -3,9 +3,9 @@ package atlar
 import "time"
 
 func ParseAtlarTimestamp(value string) (time.Time, error) {
-	return time.Parse("2006-01-02T15:04:05.999999999Z", value)
+	return time.Parse(time.RFC3339Nano, value)
 }
 
 func ParseAtlarDate(value string) (time.Time, error) {
-	return time.Parse("2006-01-02", value)
+	return time.Parse(time.DateOnly, value)
 }


### PR DESCRIPTION
## DESCRIPTION

Parsing the `Account.Timestamp` has uncovered a bug in timestamp parsing, as this is the only timestamp not bing in UTC time. It has a timezone attached to it. I discovered, that go offers the handy `time.RFC3339Nano` as a ready made format string for parsing these dates and times.  I used that instead, that fixes the task crashing.