### PR TITLE
fix(payments): Correctly determine status of payment in Atlar connector

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/task_fetch_payments.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/task_fetch_payments.go
@@ -169,10 +169,12 @@ func determinePaymentStatus(item *atlar_models.Transaction) models.PaymentStatus
 		// which was not yet reconciled with a payment from the statement
 		return models.PaymentStatusPending
 	}
-	if item.Reconciliation.Status == atlar_models.ReconciliationDetailsStatusRECONCILED {
+	if item.Reconciliation.Status == atlar_models.ReconciliationDetailsStatusBOOKED {
+		// A payment comissioned with the bank, which was not yet reconciled with a
+		// payment from the statement
 		return models.PaymentStatusPending
 	}
-	if item.Reconciliation.Status == atlar_models.ReconciliationDetailsStatusBOOKED {
+	if item.Reconciliation.Status == atlar_models.ReconciliationDetailsStatusRECONCILED {
 		return models.PaymentStatusSucceeded
 	}
 	return models.PaymentStatusOther


### PR DESCRIPTION
# DESCRIPTION

I talked to the guys over at Atlar about what their transaction statuses mean (the documentation is hard to find). After some clarifications, here are some fixes to `determinePaymentStatus()`.