### PR TITLE
fix(payments): Make IBAN easier to get() in account metadata (ATLAR)

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/account_utils.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/account_utils.go
@@ -64,6 +64,12 @@ func IdentifiersToMetadata(identifiers []*atlar_models.AccountIdentifier) metada
 			fmt.Sprintf("identifier/%s/%s", *i.Market, *i.Type),
 			*i.Number,
 		))
+		if *i.Type == "IBAN" {
+			result = result.Merge(ComputeAccountMetadata(
+				fmt.Sprintf("identifier/%s", *i.Type),
+				*i.Number,
+			))
+		}
 	}
 	return result
 }


### PR DESCRIPTION
# DESCRIPTION

As metadata is currently saved, we took a lot of care to save the information as lossless as possible.

However, when one does not know the market an account operates in, it's currently hard to get the IBAN. We'll need the IBAN in flows, so this PR offers a quick fix to the issue. Once we have some room to breathe, we might have to look back into how to solve this in a clean manner.