### PR TITLE
feat: check membership version

### DIFF
--- a/components/fctl/cmd/cloud/organizations/users/root.go
+++ b/components/fctl/cmd/cloud/organizations/users/root.go
@@ -1,14 +1,39 @@
 package users
 
 import (
+	"fmt"
+
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 )
 
 func NewCommand() *cobra.Command {
 	return fctl.NewMembershipCommand("users",
 		fctl.WithAliases("u"),
 		fctl.WithShortDescription("Users management"),
+		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
+			cfg, err := fctl.GetConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			apiClient, err := fctl.NewMembershipClient(cmd, cfg)
+			if err != nil {
+				return err
+			}
+
+			version := fctl.MembershipServerInfo(cmd.Context(), apiClient)
+			if !semver.IsValid(version) {
+				return nil
+			}
+
+			if semver.Compare(version, "v0.26.1") >= 0 {
+				return nil
+			}
+
+			return fmt.Errorf("unsupported membership server version: %s", version)
+		}),
 		fctl.WithChildCommands(
 			NewListCommand(),
 			NewShowCommand(),

--- a/components/fctl/cmd/stack/roles/root.go
+++ b/components/fctl/cmd/stack/roles/root.go
@@ -1,14 +1,39 @@
 package roles
 
 import (
+	"fmt"
+
 	fctl "github.com/formancehq/fctl/pkg"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 )
 
 func NewCommand() *cobra.Command {
 	return fctl.NewMembershipCommand("roles",
 		fctl.WithAliases("s"),
 		fctl.WithShortDescription("Stack users management within an organization"),
+		fctl.WithRunE(func(cmd *cobra.Command, args []string) error {
+			cfg, err := fctl.GetConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			apiClient, err := fctl.NewMembershipClient(cmd, cfg)
+			if err != nil {
+				return err
+			}
+
+			version := fctl.MembershipServerInfo(cmd.Context(), apiClient)
+			if !semver.IsValid(version) {
+				return nil
+			}
+
+			if semver.Compare(version, "v0.26.1") >= 0 {
+				return nil
+			}
+
+			return fmt.Errorf("unsupported membership server version: %s", version)
+		}),
 		fctl.WithChildCommands(
 			NewUpsertCommand(),
 			NewListCommand(),

--- a/components/fctl/pkg/clients.go
+++ b/components/fctl/pkg/clients.go
@@ -1,6 +1,7 @@
 package fctl
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/formancehq/fctl/membershipclient"
@@ -32,6 +33,18 @@ func NewMembershipClient(cmd *cobra.Command, cfg *Config) (*membershipclient.API
 	configuration.Servers[0].URL = profile.GetMembershipURI()
 	return membershipclient.NewAPIClient(configuration), nil
 }
+
+func MembershipServerInfo(ctx context.Context, client *membershipclient.APIClient) string {
+	serverInfo, response, err := client.DefaultApi.GetServerInfo(ctx).Execute()
+	if err != nil {
+		return fmt.Sprintf("Error: %s", err)
+	}
+	if response.StatusCode != 200 {
+		return fmt.Sprintf("Error: %s", response.Status)
+	}
+	return serverInfo.Version
+} 
+
 
 func NewStackClient(cmd *cobra.Command, cfg *Config, stack *membershipclient.Stack) (*formance.Formance, error) {
 	profile := GetCurrentProfile(cmd, cfg)


### PR DESCRIPTION
# On command node version >= v0.26.1
- fctl cloud organization users
- fctl stack roles

# Others commands
- fctl cloud organization create/update
- fctl auth create/update
=> Are not impacted and additional parameters are ignored by auth & membership api