### PR TITLE
feat(payments): Remove requirement for non-empty payment description

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/task_payments.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/task_payments.go
@@ -141,9 +141,6 @@ func ValidateTransferInitiation(transfer *models.TransferInitiation) error {
 	if transfer == nil {
 		return errors.New("transfer cannot be nil")
 	}
-	if transfer.Description == "" {
-		return errors.New("description of transfer initiation can not be empty")
-	}
 	if transfer.Type.String() != "PAYOUT" {
 		return errors.New("this connector only supports type PAYOUT")
 	}


### PR DESCRIPTION
# DESCRIPTION

SEPA allows for empty remittance info. We don't need to nor should we reject payments with an empty description.