### PR TITLE
fix(payments): Upgrade Atlar client to v1.2.1

### DIFF
--- a/components/payments/go.mod
+++ b/components/payments/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bombsimon/logrusr/v3 v3.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/formancehq/stack/libs/go-libs v0.0.0-20230221161632-e6dc6a89a85e
-	github.com/get-momo/atlar-v1-go-client v1.2.0
+	github.com/get-momo/atlar-v1-go-client v1.2.1
 	github.com/gibson042/canonicaljson-go v1.0.3
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.8

--- a/components/payments/go.sum
+++ b/components/payments/go.sum
@@ -730,6 +730,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/get-momo/atlar-v1-go-client v1.2.0 h1:M/q8+eg5ntslmde4gzky7S7txkhnPXERuWQerMd81FA=
 github.com/get-momo/atlar-v1-go-client v1.2.0/go.mod h1:qcLoXEhjTCOeBqAzG2tucpvxGJS2LYNwaU7WnJYnO64=
+github.com/get-momo/atlar-v1-go-client v1.2.1 h1:sKWd0maMshxBErGXsYVGhGIB+zFxynrWLNHnegB4lXs=
+github.com/get-momo/atlar-v1-go-client v1.2.1/go.mod h1:qcLoXEhjTCOeBqAzG2tucpvxGJS2LYNwaU7WnJYnO64=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gibson042/canonicaljson-go v1.0.3 h1:EAyF8L74AWabkyUmrvEFHEt/AGFQeD6RfwbAuf0j1bI=
 github.com/gibson042/canonicaljson-go v1.0.3/go.mod h1:DsLpJTThXyGNO+KZlI85C1/KDcImpP67k/RKVjcaEqo=

--- a/tests/integration/go.mod
+++ b/tests/integration/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
-	github.com/get-momo/atlar-v1-go-client v1.2.0 // indirect
+	github.com/get-momo/atlar-v1-go-client v1.2.1 // indirect
 	github.com/gibson042/canonicaljson-go v1.0.3 // indirect
 	github.com/go-chi/chi v4.1.2+incompatible // indirect
 	github.com/go-chi/chi/v5 v5.0.8 // indirect

--- a/tests/integration/go.sum
+++ b/tests/integration/go.sum
@@ -759,8 +759,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
-github.com/get-momo/atlar-v1-go-client v1.2.0 h1:M/q8+eg5ntslmde4gzky7S7txkhnPXERuWQerMd81FA=
-github.com/get-momo/atlar-v1-go-client v1.2.0/go.mod h1:qcLoXEhjTCOeBqAzG2tucpvxGJS2LYNwaU7WnJYnO64=
+github.com/get-momo/atlar-v1-go-client v1.2.1 h1:sKWd0maMshxBErGXsYVGhGIB+zFxynrWLNHnegB4lXs=
+github.com/get-momo/atlar-v1-go-client v1.2.1/go.mod h1:qcLoXEhjTCOeBqAzG2tucpvxGJS2LYNwaU7WnJYnO64=
 github.com/getkin/kin-openapi v0.114.0 h1:ar7QiJpDdlR+zSyPjrLf8mNnpoFP/lI90XcywMCFNe8=
 github.com/getkin/kin-openapi v0.114.0/go.mod h1:l5e9PaFUo9fyLJCPGQeXI2ML8c3P8BHOEV2VaAVf/pc=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
# DESCRIPTION

The updated version of the client provides the error response body when posting a credit transfer initiation.

<img width="1237" alt="Screenshot 2024-01-16 at 19 24 06" src="https://github.com/formancehq/stack/assets/91877506/f3e0a73f-212c-43b5-9097-88888a0a1234">

While Atlar is adding some more documentation on errors at https://cdn.atlar.com/api/swagger.json this update will allow us to better debug payment initiation failures.