### PR TITLE
fix(payments): fix atlar external ID when creating a payment

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/task_payments.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/task_payments.go
@@ -87,7 +87,7 @@ func InitiatePaymentTask(config Config, client *client.Client, transferID string
 			DestinationExternalAccountID: &transfer.DestinationAccount.Reference,
 			Amount:                       &amount,
 			Date:                         &dateString,
-			ExternalID:                   serializeAtlarPaymentExternalID(transfer.ID.Reference, len(transfer.RelatedAdjustments)),
+			ExternalID:                   serializeAtlarPaymentExternalID(transfer.ID.Reference, transfer.CountRetries()),
 			PaymentSchemeType:            &paymentSchemeType,
 			RemittanceInformation: &atlar_models.RemittanceInformation{
 				Type:  &remittanceInformationType,
@@ -174,7 +174,7 @@ func UpdatePaymentStatusTask(
 		defer cancel()
 		getCreditTransferResponse, err := client.GetV1CreditTransfersGetByExternalIDExternalID(
 			requestCtx,
-			serializeAtlarPaymentExternalID(transfer.ID.Reference, len(transfer.RelatedAdjustments)),
+			serializeAtlarPaymentExternalID(transfer.ID.Reference, transfer.CountRetries()),
 		)
 		if err != nil {
 			return err

--- a/components/payments/internal/models/transfer_initiation.go
+++ b/components/payments/internal/models/transfer_initiation.go
@@ -196,6 +196,17 @@ func (t *TransferInitiation) SortRelatedAdjustments() {
 	})
 }
 
+func (t *TransferInitiation) CountRetries() int {
+	res := 0
+	for _, adjustment := range t.RelatedAdjustments {
+		if adjustment.Status == TransferInitiationStatusRetried {
+			res++
+		}
+	}
+
+	return res
+}
+
 type TransferInitiationPayments struct {
 	bun.BaseModel `bun:"transfers.transfer_initiation_payments"`
 


### PR DESCRIPTION
## Description

When creating an Atlar payment, we want to serialize the external ID with the number of retries of the transfer, and not the length of the adjustements which changes if the payments is created on Atlar side, hence the error that the payment was not found when searching to update the status.