### PR TITLE
fix(payments): fix error when missing scheme

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/stripe/translate.go
+++ b/components/payments/cmd/connectors/internal/connectors/stripe/translate.go
@@ -251,8 +251,8 @@ func createBatchElement(
 			Amount:        big.NewInt(balanceTransaction.Source.Refund.Charge.Amount - balanceTransaction.Source.Refund.Charge.AmountRefunded),
 			InitialAmount: big.NewInt(balanceTransaction.Source.Refund.Charge.Amount),
 			Asset:         currency.FormatAsset(supportedCurrenciesWithDecimal, transactionCurrency),
+			Scheme:        models.PaymentSchemeOther,
 			RawData:       rawData,
-			Scheme:        models.PaymentScheme(balanceTransaction.Source.Refund.Charge.PaymentMethodDetails.Card.Brand),
 			CreatedAt:     time.Unix(balanceTransaction.Source.Refund.Charge.Created, 0),
 		}
 
@@ -306,8 +306,8 @@ func createBatchElement(
 			Amount:        big.NewInt(balanceTransaction.Source.Refund.Charge.Amount - balanceTransaction.Source.Refund.Charge.AmountRefunded),
 			InitialAmount: big.NewInt(balanceTransaction.Source.Refund.Charge.Amount),
 			Asset:         currency.FormatAsset(supportedCurrenciesWithDecimal, transactionCurrency),
+			Scheme:        models.PaymentSchemeOther,
 			RawData:       rawData,
-			Scheme:        models.PaymentScheme(balanceTransaction.Source.Refund.Charge.PaymentMethodDetails.Card.Brand),
 			CreatedAt:     time.Unix(balanceTransaction.Source.Refund.Charge.Created, 0),
 		}
 


### PR DESCRIPTION
For payments transactions t ype, we don't need to
fill the scheme as it will always be other.