### PR TITLE
feat: status can now be handle by membership on create, restore, upgrade

### DIFF
--- a/components/fctl/cmd/stack/controller.go
+++ b/components/fctl/cmd/stack/controller.go
@@ -30,7 +30,11 @@ func waitStackReady(cmd *cobra.Command, client *membershipclient.APIClient, prof
 			pterm.Warning.Println("Waiting for stack to be ready...")
 			return fmt.Errorf("there might a problem with the stack scheduling, retry and if the problem persists please contact the support")
 		}
-		time.Sleep(waitTime)
+		select {
+		case <-time.After(waitTime):
+		case <-cmd.Context().Done():
+			return cmd.Context().Err()
+		}
 		waitTime *= 2
 
 	}

--- a/components/fctl/cmd/stack/controller.go
+++ b/components/fctl/cmd/stack/controller.go
@@ -7,27 +7,31 @@ import (
 
 	"github.com/formancehq/fctl/membershipclient"
 	fctl "github.com/formancehq/fctl/pkg"
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
-func waitStackReady(cmd *cobra.Command, profile *fctl.Profile, stack *membershipclient.Stack) error {
-	baseUrlStr := profile.ServicesBaseUrl(stack).String()
-	authServerUrl := fmt.Sprintf("%s/api/auth", baseUrlStr)
+func waitStackReady(cmd *cobra.Command, client *membershipclient.APIClient, profile *fctl.Profile, stack *membershipclient.Stack) error {
+	waitTime := time.Second
 	for {
-		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet,
-			fmt.Sprintf(authServerUrl+"/.well-known/openid-configuration"), nil)
+		stack, resp, err := client.DefaultApi.GetStack(cmd.Context(), stack.OrganizationId, stack.Id).Execute()
 		if err != nil {
 			return err
 		}
-		rsp, err := fctl.GetHttpClient(cmd, map[string][]string{}).Do(req)
-		if err == nil && rsp.StatusCode == http.StatusOK {
-			break
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("stack %s not found", stack.Data.Id)
 		}
-		select {
-		case <-cmd.Context().Done():
-			return cmd.Context().Err()
-		case <-time.After(time.Second):
+
+		if stack.Data.Status == "READY" {
+			return nil
 		}
+
+		if waitTime > time.Minute {
+			pterm.Warning.Println("Waiting for stack to be ready...")
+			return fmt.Errorf("there might a problem with the stack scheduling, retry and if the problem persists please contact the support")
+		}
+		time.Sleep(waitTime)
+		waitTime *= 2
+
 	}
-	return nil
 }

--- a/components/fctl/cmd/stack/create.go
+++ b/components/fctl/cmd/stack/create.go
@@ -175,7 +175,7 @@ func (c *StackCreateController) Run(cmd *cobra.Command, args []string) (fctl.Ren
 			return nil, err
 		}
 
-		if err := waitStackReady(cmd, profile, stackResponse.Data); err != nil {
+		if err := waitStackReady(cmd, apiClient, profile, stackResponse.Data); err != nil {
 			return nil, err
 		}
 

--- a/components/fctl/cmd/stack/restore.go
+++ b/components/fctl/cmd/stack/restore.go
@@ -92,7 +92,7 @@ func (c *StackRestoreController) Run(cmd *cobra.Command, args []string) (fctl.Re
 
 	profile := fctl.GetCurrentProfile(cmd, cfg)
 
-	if err := waitStackReady(cmd, profile, response.Data); err != nil {
+	if err := waitStackReady(cmd, apiClient, profile, response.Data); err != nil {
 		return nil, err
 	}
 

--- a/components/fctl/cmd/stack/upgrade.go
+++ b/components/fctl/cmd/stack/upgrade.go
@@ -143,7 +143,7 @@ func (c *UpgradeController) Run(cmd *cobra.Command, args []string) (fctl.Rendera
 			return nil, err
 		}
 
-		if err := waitStackReady(cmd, profile, stack.Data); err != nil {
+		if err := waitStackReady(cmd, apiClient, profile, stack.Data); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
Remplacement du polling sur auth (l'openid config) vers un polling du status via membership