### PR TITLE
fix(operator): benthos deployment

### DIFF
--- a/components/operator/api/formance.com/v1beta1/shared.go
+++ b/components/operator/api/formance.com/v1beta1/shared.go
@@ -246,7 +246,8 @@ func (u *URI) UnmarshalJSON(data []byte) error {
 
 func (in *URI) WithoutQuery() *URI {
 	cp := *in.URL
-	in.URL.RawQuery = ""
+	cp.ForceQuery = false
+	cp.RawQuery = ""
 	return &URI{
 		URL: &cp,
 	}

--- a/components/operator/helm/templates/gen/apiextensions.k8s.io_v1_customresourcedefinition_stacks.formance.com.yaml
+++ b/components/operator/helm/templates/gen/apiextensions.k8s.io_v1_customresourcedefinition_stacks.formance.com.yaml
@@ -30,6 +30,10 @@ spec:
       jsonPath: .status.ready
       name: Ready
       type: boolean
+    - description: Info
+      jsonPath: .status.info
+      name: Info
+      type: string
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Benthos es output does not build requests properly when the url terminates with a '?'. 
'http://elasticsearch:9200?' will fail for example, whereas 'http://elasticsearch:9200?foo=bar' will be ok.
