### PR TITLE
fix(ci): cache invalidation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,17 +57,10 @@ jobs:
           --no-output
           --allow-privileged
           --secret SPEAKEASY_API_KEY=$SPEAKEASY_API_KEY
-          --secret SEGMENT_WRITE_KEY=$SEGMENT_WRITE_KEY
-          --secret GITHUB_TOKEN=$GITHUB_TOKEN
-          --secret FURY_TOKEN=$FURY_TOKEN
-          --secret GORELEASER_KEY=$GORELEASER_KEY
           ${{ contains(github.event.pull_request.labels.*.name, 'no-cache') && '--no-cache' || '' }}
           +tests
         env:
-          GITHUB_TOKEN: ${{ secrets.NUMARY_GITHUB_TOKEN }}
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
-          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
   Extract:
     name: Extract


### PR DESCRIPTION
When secrets change (as for GITHUB_TOKEN), the WITH DOCKER instructions are not cached.
I think it is related to https://github.com/earthly/earthly/issues/3298.
Since we don't need these vars, just drop it from the pipeline.

