### PR TITLE
fix(operator): fix controller gen version with go 1.22

### DIFF
--- a/components/operator/Earthfile
+++ b/components/operator/Earthfile
@@ -34,7 +34,7 @@ build-image:
 
 controller-gen:
     FROM core+builder-image
-    DO --pass-args core+GO_INSTALL --package=sigs.k8s.io/controller-tools/cmd/controller-gen@v0.13.0
+    DO --pass-args core+GO_INSTALL --package=sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 
 manifests:
     FROM --pass-args +controller-gen

--- a/components/operator/Makefile
+++ b/components/operator/Makefile
@@ -158,7 +158,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.13.0
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.


### PR DESCRIPTION
https://github.com/kubernetes-sigs/controller-tools/issues/880

To merge when https://github.com/elastic/crd-ref-docs/pull/63 is merged and when we bump go to v1.22 in our earthly fork