### PR TITLE
feat(payments): retry atlar main task on scheduling error

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/task_main.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/task_main.go
@@ -35,7 +35,7 @@ func MainTask(logger logging.Logger) task.Task {
 		})
 		if err != nil {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
@@ -44,7 +44,7 @@ func MainTask(logger logging.Logger) task.Task {
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		return nil

--- a/components/payments/cmd/connectors/internal/task/errors.go
+++ b/components/payments/cmd/connectors/internal/task/errors.go
@@ -3,11 +3,11 @@ package task
 import "github.com/pkg/errors"
 
 var (
-	// ErrRetryableError will be sent by the task if we can retry the task,
+	// ErrRetryable will be sent by the task if we can retry the task,
 	// e.g. if the task failed because of a temporary network issue.
-	ErrRetryableError = errors.New("retryable error")
+	ErrRetryable = errors.New("retryable error")
 
-	// ErrNonRetryableError will be sent by the task if we can't retry the task,
+	// ErrNonRetryable will be sent by the task if we can't retry the task,
 	// e.g. if the task failed because of a validation error.
-	ErrNonRetryableError = errors.New("non-retryable error")
+	ErrNonRetryable = errors.New("non-retryable error")
 )

--- a/components/payments/cmd/connectors/internal/task/scheduler.go
+++ b/components/payments/cmd/connectors/internal/task/scheduler.go
@@ -549,9 +549,9 @@ loop:
 		switch {
 		case err == nil:
 			break loop
-		case errors.Is(err, ErrRetryableError):
+		case errors.Is(err, ErrRetryable):
 			continue
-		case errors.Is(err, ErrNonRetryableError):
+		case errors.Is(err, ErrNonRetryable):
 			fallthrough
 		default:
 			if err == context.Canceled {
@@ -634,10 +634,10 @@ func (s *DefaultTaskScheduler) runTaskPeriodically(
 		switch {
 		case err == nil:
 			// Doing nothing, waiting for the next tick
-		case errors.Is(err, ErrRetryableError):
+		case errors.Is(err, ErrRetryable):
 			ticker.Reset(options.Duration)
 			continue
-		case errors.Is(err, ErrNonRetryableError):
+		case errors.Is(err, ErrNonRetryable):
 			fallthrough
 		default:
 			// All other errors

--- a/components/payments/cmd/connectors/internal/task/scheduler_test.go
+++ b/components/payments/cmd/connectors/internal/task/scheduler_test.go
@@ -291,11 +291,11 @@ func TestTaskScheduler(t *testing.T) {
 				switch string(descriptor) {
 				case string(nonRetryableDescriptor):
 					return func(ctx context.Context, scheduler Scheduler) error {
-						return ErrNonRetryableError
+						return ErrNonRetryable
 					}
 				case string(retryableDescriptor):
 					return func(ctx context.Context, scheduler Scheduler) error {
-						return ErrRetryableError
+						return ErrRetryable
 					}
 				case string(otherErrorDescriptor):
 					return func(ctx context.Context, scheduler Scheduler) error {
@@ -361,11 +361,11 @@ func TestTaskScheduler(t *testing.T) {
 				switch string(descriptor) {
 				case string(nonRetryableDescriptor):
 					return func(ctx context.Context, scheduler Scheduler) error {
-						return ErrNonRetryableError
+						return ErrNonRetryable
 					}
 				case string(retryableDescriptor):
 					return func(ctx context.Context, scheduler Scheduler) error {
-						return ErrRetryableError
+						return ErrRetryable
 					}
 				case string(otherErrorDescriptor):
 					return func(ctx context.Context, scheduler Scheduler) error {


### PR DESCRIPTION
The atlar main task if the one launching all other tasks every polling duration. if we have an error during scheduling we wanna retry, otherwise, all task will never be launched again.