### PR TITLE
feat(payments): add retryable tasks for some connectors

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/bankingcircle/task_main.go
+++ b/components/payments/cmd/connectors/internal/connectors/bankingcircle/task_main.go
@@ -33,7 +33,7 @@ func taskMain() task.Task {
 		})
 		if err != nil {
 			otel.RecordError(span, err)
-			return errors.Wrap(task.ErrRetryableError, err.Error())
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
@@ -42,7 +42,7 @@ func taskMain() task.Task {
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			otel.RecordError(span, err)
-			return errors.Wrap(task.ErrRetryableError, err.Error())
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		return nil

--- a/components/payments/cmd/connectors/internal/connectors/bankingcircle/task_main.go
+++ b/components/payments/cmd/connectors/internal/connectors/bankingcircle/task_main.go
@@ -2,12 +2,12 @@ package bankingcircle
 
 import (
 	"context"
-	"errors"
 
 	"github.com/formancehq/payments/cmd/connectors/internal/connectors"
 	"github.com/formancehq/payments/cmd/connectors/internal/task"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/formancehq/payments/internal/otel"
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -33,7 +33,7 @@ func taskMain() task.Task {
 		})
 		if err != nil {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryableError, err.Error())
 		}
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
@@ -42,7 +42,7 @@ func taskMain() task.Task {
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryableError, err.Error())
 		}
 
 		return nil

--- a/components/payments/cmd/connectors/internal/connectors/currencycloud/task_main.go
+++ b/components/payments/cmd/connectors/internal/connectors/currencycloud/task_main.go
@@ -33,7 +33,7 @@ func taskMain() task.Task {
 		})
 		if err != nil {
 			otel.RecordError(span, err)
-			return errors.Wrap(task.ErrRetryableError, err.Error())
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
@@ -42,7 +42,7 @@ func taskMain() task.Task {
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			otel.RecordError(span, err)
-			return errors.Wrap(task.ErrRetryableError, err.Error())
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		taskBeneficiaries, err := models.EncodeTaskDescriptor(TaskDescriptor{
@@ -51,7 +51,7 @@ func taskMain() task.Task {
 		})
 		if err != nil {
 			otel.RecordError(span, err)
-			return errors.Wrap(task.ErrRetryableError, err.Error())
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		err = scheduler.Schedule(ctx, taskBeneficiaries, models.TaskSchedulerOptions{
@@ -60,7 +60,7 @@ func taskMain() task.Task {
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			otel.RecordError(span, err)
-			return errors.Wrap(task.ErrRetryableError, err.Error())
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		return nil

--- a/components/payments/cmd/connectors/internal/connectors/currencycloud/task_main.go
+++ b/components/payments/cmd/connectors/internal/connectors/currencycloud/task_main.go
@@ -2,12 +2,12 @@ package currencycloud
 
 import (
 	"context"
-	"errors"
 
 	"github.com/formancehq/payments/cmd/connectors/internal/connectors"
 	"github.com/formancehq/payments/cmd/connectors/internal/task"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/formancehq/payments/internal/otel"
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -33,7 +33,7 @@ func taskMain() task.Task {
 		})
 		if err != nil {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryableError, err.Error())
 		}
 
 		err = scheduler.Schedule(ctx, taskAccounts, models.TaskSchedulerOptions{
@@ -42,7 +42,7 @@ func taskMain() task.Task {
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryableError, err.Error())
 		}
 
 		taskBeneficiaries, err := models.EncodeTaskDescriptor(TaskDescriptor{
@@ -51,7 +51,7 @@ func taskMain() task.Task {
 		})
 		if err != nil {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryableError, err.Error())
 		}
 
 		err = scheduler.Schedule(ctx, taskBeneficiaries, models.TaskSchedulerOptions{
@@ -60,7 +60,7 @@ func taskMain() task.Task {
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryableError, err.Error())
 		}
 
 		return nil

--- a/components/payments/cmd/connectors/internal/connectors/mangopay/client/bank_accounts.go
+++ b/components/payments/cmd/connectors/internal/connectors/mangopay/client/bank_accounts.go
@@ -138,7 +138,8 @@ func (c *Client) createBankAccount(ctx context.Context, endpoint string, req any
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, unmarshalError(resp.StatusCode, resp.Body).Error()
+		// Never retry bank account creation
+		return nil, unmarshalErrorWithoutRetry(resp.StatusCode, resp.Body).Error()
 	}
 
 	var bankAccount BankAccount
@@ -185,7 +186,7 @@ func (c *Client) GetBankAccounts(ctx context.Context, userID string, page, pageS
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, unmarshalError(resp.StatusCode, resp.Body).Error()
+		return nil, unmarshalErrorWithRetry(resp.StatusCode, resp.Body).Error()
 	}
 
 	var bankAccounts []*BankAccount

--- a/components/payments/cmd/connectors/internal/connectors/mangopay/client/error.go
+++ b/components/payments/cmd/connectors/internal/connectors/mangopay/client/error.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+
+	"github.com/formancehq/payments/cmd/connectors/internal/task"
+	"github.com/pkg/errors"
 )
 
 type mangopayError struct {
@@ -11,6 +15,7 @@ type mangopayError struct {
 	Message    string            `json:"Message"`
 	Type       string            `json:"Type"`
 	Errors     map[string]string `json:"Errors"`
+	WithRetry  bool              `json:"-"`
 }
 
 func (me *mangopayError) Error() error {
@@ -22,18 +27,53 @@ func (me *mangopayError) Error() error {
 		}
 	}
 
+	var err error
 	if errorMessage == "" {
-		return fmt.Errorf("unexpected status code: %d", me.StatusCode)
+		err = fmt.Errorf("unexpected status code: %d", me.StatusCode)
+	} else {
+		err = fmt.Errorf("%d: %s", me.StatusCode, errorMessage)
 	}
 
-	return fmt.Errorf("%d: %s", me.StatusCode, errorMessage)
+	if me.WithRetry {
+		return checkStatusCodeError(me.StatusCode, err)
+	} else {
+		return errors.Wrap(task.ErrNonRetryable, err.Error())
+	}
 }
 
-func unmarshalError(statusCode int, body io.ReadCloser) *mangopayError {
+func unmarshalErrorWithRetry(statusCode int, body io.ReadCloser) *mangopayError {
 	var ce mangopayError
 	_ = json.NewDecoder(body).Decode(&ce)
 
 	ce.StatusCode = statusCode
+	ce.WithRetry = true
 
 	return &ce
+}
+
+func unmarshalErrorWithoutRetry(statusCode int, body io.ReadCloser) *mangopayError {
+	var ce mangopayError
+	_ = json.NewDecoder(body).Decode(&ce)
+
+	ce.StatusCode = statusCode
+	ce.WithRetry = false
+
+	return &ce
+}
+
+func checkStatusCodeError(statusCode int, err error) error {
+	switch statusCode {
+	case http.StatusTooEarly, http.StatusRequestTimeout:
+		return errors.Wrap(task.ErrRetryable, err.Error())
+	case http.StatusTooManyRequests:
+		// Retry rate limit errors
+		// TODO(polo): add rate limit handling
+		return errors.Wrap(task.ErrRetryable, err.Error())
+	case http.StatusInternalServerError, http.StatusBadGateway,
+		http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		// Retry internal errors
+		return errors.Wrap(task.ErrRetryable, err.Error())
+	default:
+		return errors.Wrap(task.ErrNonRetryable, err.Error())
+	}
 }

--- a/components/payments/cmd/connectors/internal/connectors/mangopay/client/payout.go
+++ b/components/payments/cmd/connectors/internal/connectors/mangopay/client/payout.go
@@ -74,7 +74,8 @@ func (c *Client) InitiatePayout(ctx context.Context, payoutRequest *PayoutReques
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, unmarshalError(resp.StatusCode, resp.Body).Error()
+		// Never retry payout initiation
+		return nil, unmarshalErrorWithoutRetry(resp.StatusCode, resp.Body).Error()
 	}
 
 	var payoutResponse PayoutResponse
@@ -110,7 +111,7 @@ func (c *Client) GetPayout(ctx context.Context, payoutID string) (*PayoutRespons
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, unmarshalError(resp.StatusCode, resp.Body).Error()
+		return nil, unmarshalErrorWithRetry(resp.StatusCode, resp.Body).Error()
 	}
 
 	var payoutResponse PayoutResponse

--- a/components/payments/cmd/connectors/internal/connectors/mangopay/client/transactions.go
+++ b/components/payments/cmd/connectors/internal/connectors/mangopay/client/transactions.go
@@ -72,7 +72,7 @@ func (c *Client) GetTransactions(ctx context.Context, walletsID string, page, pa
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, unmarshalError(resp.StatusCode, resp.Body).Error()
+		return nil, unmarshalErrorWithRetry(resp.StatusCode, resp.Body).Error()
 	}
 
 	var payments []*Payment

--- a/components/payments/cmd/connectors/internal/connectors/mangopay/client/transfer.go
+++ b/components/payments/cmd/connectors/internal/connectors/mangopay/client/transfer.go
@@ -74,7 +74,8 @@ func (c *Client) InitiateWalletTransfer(ctx context.Context, transferRequest *Tr
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, unmarshalError(resp.StatusCode, resp.Body).Error()
+		// Never retry transfer initiation
+		return nil, unmarshalErrorWithoutRetry(resp.StatusCode, resp.Body).Error()
 	}
 
 	var transferResponse TransferResponse
@@ -109,7 +110,7 @@ func (c *Client) GetWalletTransfer(ctx context.Context, transferID string) (*Tra
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, unmarshalError(resp.StatusCode, resp.Body).Error()
+		return nil, unmarshalErrorWithRetry(resp.StatusCode, resp.Body).Error()
 	}
 
 	var transfer TransferResponse

--- a/components/payments/cmd/connectors/internal/connectors/mangopay/client/users.go
+++ b/components/payments/cmd/connectors/internal/connectors/mangopay/client/users.go
@@ -70,7 +70,7 @@ func (c *Client) getUsers(ctx context.Context, page int, pageSize int) ([]*user,
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, unmarshalError(resp.StatusCode, resp.Body).Error()
+		return nil, unmarshalErrorWithRetry(resp.StatusCode, resp.Body).Error()
 	}
 
 	var users []*user

--- a/components/payments/cmd/connectors/internal/connectors/mangopay/client/wallets.go
+++ b/components/payments/cmd/connectors/internal/connectors/mangopay/client/wallets.go
@@ -52,7 +52,7 @@ func (c *Client) GetWallets(ctx context.Context, userID string, page, pageSize i
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, unmarshalError(resp.StatusCode, resp.Body).Error()
+		return nil, unmarshalErrorWithRetry(resp.StatusCode, resp.Body).Error()
 	}
 
 	var wallets []*Wallet

--- a/components/payments/cmd/connectors/internal/connectors/mangopay/task_main.go
+++ b/components/payments/cmd/connectors/internal/connectors/mangopay/task_main.go
@@ -2,12 +2,12 @@ package mangopay
 
 import (
 	"context"
-	"errors"
 
 	"github.com/formancehq/payments/cmd/connectors/internal/connectors"
 	"github.com/formancehq/payments/cmd/connectors/internal/task"
 	"github.com/formancehq/payments/internal/models"
 	"github.com/formancehq/payments/internal/otel"
+	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -33,7 +33,7 @@ func taskMain() task.Task {
 		})
 		if err != nil {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		err = scheduler.Schedule(ctx, taskUsers, models.TaskSchedulerOptions{
@@ -42,7 +42,7 @@ func taskMain() task.Task {
 		})
 		if err != nil && !errors.Is(err, task.ErrAlreadyScheduled) {
 			otel.RecordError(span, err)
-			return err
+			return errors.Wrap(task.ErrRetryable, err.Error())
 		}
 
 		return nil


### PR DESCRIPTION
We do not want periodic tasks that fetch data from psps to end because of a one time error client side or postgres side. It's safe to retry them. What we do not want to retry is transfer/payout creation and bank account creation

Fixes ENG-784
Fixes ENG-785
Fixes ENG-786