### PR TITLE
chore(operator): outdated documentation

### DIFF
--- a/components/operator/README.md
+++ b/components/operator/README.md
@@ -198,7 +198,6 @@ Query params :
 | Name           | Type   | Default | Description                                          |
 |----------------|--------|---------|------------------------------------------------------|
 | secret         | string |         | Specify a secret where credentials are defined       |
-| awsRole        | string |         | Specify a service account name mapped to an aws role |
 | disableSSLMode | bool   | false   | Disable SSL on Postgres connection                   |
 
 ### ElasticSearch URI format


### PR DESCRIPTION
Fixes ENG-884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README to reflect the removal of the `awsRole` query parameter in service account mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->