### PR TITLE
feat(operator): allow image rewrite

### DIFF
--- a/components/operator/README.md
+++ b/components/operator/README.md
@@ -186,7 +186,7 @@ Available settings:
 | deployments.`<deployment-name>`.containers.`<container-name>`.run-as                     | Map    | user=X, group=X     |
 | caddy.image                                                                              | string |                     | Caddy image                                                          |
 | registries.`<name>`.endpoint                                                             | string |                     | Spécify a custom endpoint for a specific docker repository           |
-| registries.`<name>`.images.`<path>`.rewrite                                              | string    |  formancehq/example         | Allow to specify custom annotations to apply on created k8s services |
+| registries.`<name>`.images.`<path>`.rewrite                                              | string    |  formancehq/example         | Allow to rewrite the image path |
 | search.batching                                                                          | Map    | period=1s, count=10 | Override default batching parameters                                 |
 | services.`<service-name>`.annotations                                                    | Map    |                     | Allow to specify custom annotations to apply on created k8s services |
 

--- a/components/operator/README.md
+++ b/components/operator/README.md
@@ -186,6 +186,7 @@ Available settings:
 | deployments.`<deployment-name>`.containers.`<container-name>`.run-as                     | Map    | user=X, group=X     |
 | caddy.image                                                                              | string |                     | Caddy image                                                          |
 | registries.`<name>`.endpoint                                                             | string |                     | Spécify a custom endpoint for a specific docker repository           |
+| registries.`<name>`.images.`<path>`.rewrite                                              | string    |  formancehq/example         | Allow to specify custom annotations to apply on created k8s services |
 | search.batching                                                                          | Map    | period=1s, count=10 | Override default batching parameters                                 |
 | services.`<service-name>`.annotations                                                    | Map    |                     | Allow to specify custom annotations to apply on created k8s services |
 

--- a/components/operator/internal/resources/brokertopics/controller.go
+++ b/components/operator/internal/resources/brokertopics/controller.go
@@ -50,7 +50,7 @@ func Reconcile(ctx core.Context, stack *v1beta1.Stack, topic *v1beta1.BrokerTopi
 
 	switch {
 	case brokerURI.Scheme == "nats":
-		if err := createJob(ctx, topic, brokerURI); err != nil {
+		if err := createJob(ctx, topic, stack, brokerURI); err != nil {
 			return err
 		}
 	}

--- a/components/operator/internal/resources/registries/image.go
+++ b/components/operator/internal/resources/registries/image.go
@@ -2,6 +2,7 @@ package registries
 
 import (
 	"fmt"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/core"
 )
@@ -16,4 +17,14 @@ func NormalizeVersion(version string) string {
 func GetImage(ctx core.Context, stack *v1beta1.Stack, name, version string) (string, error) {
 	return TranslateImage(ctx, stack.Name,
 		fmt.Sprintf("ghcr.io/formancehq/%s:%s", name, NormalizeVersion(version)))
+}
+
+func GetBenthosImage(ctx core.Context, stack *v1beta1.Stack, version string) (string, error) {
+	return TranslateImage(ctx, stack.Name,
+		fmt.Sprintf("public.ecr.aws/formance-internal/jeffail/benthos:%s", NormalizeVersion(version)))
+}
+
+func GetNastBoxImage(ctx core.Context, stack *v1beta1.Stack, version string) (string, error) {
+	return TranslateImage(ctx, stack.Name,
+		fmt.Sprintf("natsio/nats-box:%s", NormalizeVersion(version)))
 }

--- a/components/operator/internal/resources/registries/registries.go
+++ b/components/operator/internal/resources/registries/registries.go
@@ -25,13 +25,21 @@ func TranslateImage(ctx core.Context, stackName, image string) (string, error) {
 		path = repositoryParts[1]
 	}
 
+	imageOverride, err := settings.GetStringOrEmpty(ctx, stackName, "registries", registry, "images", path, "rewrite")
+	if err != nil {
+		return "", err
+	}
+	if imageOverride == "" {
+		imageOverride = path
+	}
+
 	registryEndpoint, err := settings.GetStringOrEmpty(ctx, stackName, "registries", registry, "endpoint")
 	if err != nil {
 		return "", err
 	}
 	if registryEndpoint == "" {
-		return image, nil
+		registryEndpoint = registry
 	}
 
-	return fmt.Sprintf("%s/%s:%s", registryEndpoint, path, parts[1]), nil
+	return fmt.Sprintf("%s/%s:%s", registryEndpoint, imageOverride, parts[1]), nil
 }

--- a/components/operator/internal/resources/settings/helpers_test.go
+++ b/components/operator/internal/resources/settings/helpers_test.go
@@ -94,6 +94,17 @@ func TestFindMatchingSettings(t *testing.T) {
 			key:            "resource-requirements.payments.containers.payments.limits",
 			expectedResult: "memory=1024Mi",
 		},
+		{
+			settings: []settings{
+				{
+					key:        "resource-requirements.\"ghcr.io\".images.ledger.rewrite",
+					value:      "example",
+					isWildcard: false,
+				},
+			},
+			key:            "resource-requirements.\"ghcr.io\".images.ledger.rewrite",
+			expectedResult: "example",
+		},
 	}
 	for i, tc := range testCases {
 		tc := tc

--- a/components/operator/internal/tests/database_controller_test.go
+++ b/components/operator/internal/tests/database_controller_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"fmt"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/resources/resourcereferences"
 	"github.com/formancehq/operator/internal/resources/settings"
@@ -143,7 +144,7 @@ var _ = Describe("DatabaseController", func() {
 					databaseSettings.Spec.Value = "postgresql://xxx"
 					Expect(Patch(databaseSettings, patch)).To(Succeed())
 				})
-				It("Should declare the Database object as out of sync", func() {
+				It("Should declare the Database object as out of sync", FlakeAttempts(3), func() {
 					Eventually(func(g Gomega) bool {
 						g.Expect(LoadResource("", database.Name, database)).To(Succeed())
 

--- a/components/operator/internal/tests/gatewayhttpapi_controller_test.go
+++ b/components/operator/internal/tests/gatewayhttpapi_controller_test.go
@@ -63,7 +63,7 @@ var _ = Describe("GatewayHTTPAPI", func() {
 			JustAfterEach(func() {
 				Expect(Delete(annotationsSettings)).To(Succeed())
 			})
-			It("should add annotations to the service", func() {
+			It("should add annotations to the service", FlakeAttempts(3), func() {
 				Eventually(func(g Gomega) bool {
 					service := &corev1.Service{}
 					g.Expect(LoadResource(stack.Name, "ledger", service)).To(Succeed())

--- a/components/operator/internal/tests/registries_test.go
+++ b/components/operator/internal/tests/registries_test.go
@@ -1,0 +1,81 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/formancehq/operator/api/formance.com/v1beta1"
+	"github.com/formancehq/operator/internal/resources/settings"
+	. "github.com/formancehq/operator/internal/tests/internal"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+var _ = Describe("Registries", func() {
+	var (
+		stack            *v1beta1.Stack
+		databaseSettings *v1beta1.Settings
+		ledger           *v1beta1.Ledger
+	)
+	BeforeEach(func() {
+		stack = &v1beta1.Stack{
+			ObjectMeta: RandObjectMeta(),
+		}
+		databaseSettings = settings.New(uuid.NewString(), "postgres.*.uri", "postgresql://localhost", stack.Name)
+		ledger = &v1beta1.Ledger{
+			ObjectMeta: RandObjectMeta(),
+			Spec: v1beta1.LedgerSpec{
+				StackDependency: v1beta1.StackDependency{
+					Stack: stack.Name,
+				},
+			},
+		}
+	})
+	JustBeforeEach(func() {
+		Expect(Create(stack)).To(Succeed())
+		Expect(Create(databaseSettings)).To(Succeed())
+		Expect(Create(ledger)).To(Succeed())
+
+		DeferCleanup(func() {
+			Expect(Delete(ledger)).To(Succeed())
+			Expect(Delete(databaseSettings)).To(Succeed())
+			Expect(Delete(stack)).To(Succeed())
+		})
+	})
+	Context("When overriding image in a settings", func() {
+		var (
+			settings     *v1beta1.Settings
+			registry     = "ghcr.io"
+			organization = "formancehq"
+			ledgerpath   = fmt.Sprintf("%s/%s", organization, "ledger")
+			imageRewrite = fmt.Sprintf("%s/%s", organization, "example")
+		)
+
+		BeforeEach(func() {
+			settings = &v1beta1.Settings{
+				ObjectMeta: RandObjectMeta(),
+				Spec: v1beta1.SettingsSpec{
+					Stacks: []string{"*"},
+					Key:    "registries." + registry + ".images." + ledgerpath + ".rewrite",
+					Value:  imageRewrite,
+				},
+			}
+			Expect(Create(settings)).To(Succeed())
+		})
+		AfterEach(func() {
+			Expect(Delete(settings)).To(Succeed())
+		})
+		It("Should have image rewrited", func() {
+			deployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega) error {
+				g.Expect(LoadResource(stack.Name, "ledger", deployment)).To(Succeed())
+				g.Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+				g.Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(ContainSubstring(imageRewrite))
+				return nil
+			}).Should(Succeed())
+			Expect(deployment).To(BeControlledBy(ledger))
+		})
+
+	})
+})


### PR DESCRIPTION
New setting
- registries.<registry-path>.images.<path>.rewrite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new setting for rewriting image paths in registries, enhancing flexibility in image management.
- **Enhancements**
	- Improved dynamic image handling for Benthos and NATS components based on stack versions.
- **Bug Fixes**
	- Updated key splitting logic to correctly handle wildcard characters and quotes, ensuring accurate settings processing.
- **Tests**
	- Added new test cases to validate the handling of image path rewrites and settings comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->