### PR TITLE
fix: pgtesting parallelism

### DIFF
--- a/helm/regions/Chart.lock
+++ b/helm/regions/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: operator
   repository: file://../../components/operator/helm
   version: v2.0.0-rc.19
-digest: sha256:768a7dc54e3e3ca5cb52b6c3e2113715850ea315a60777fa684f302335cdc187
-generated: "2024-03-21T14:11:38.472173564Z"
+digest: sha256:8f3879ec8ecbfd12347d14890333ea9b616311784b243f46b57a9313c1bb4b4b
+generated: "2024-04-04T20:01:13.148027959Z"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Improved the setup of PostgreSQL servers for testing by introducing a global server configuration.
- **Refactor**
	- Updated the internal representation and handling of PostgreSQL servers to enhance testing reliability and efficiency.
- **Refactor**
	- Introduced a new file `pagination_query_options.go` in the `bunpaginate` package to manage paginated query options with generic type support.
- **New Features**
	- Added a new function `parseNot` in the `expression.go` file to handle parsing for the "$not" operator in a map.
	- Modified the JSON query structure in `expression_test.go` to include "$not" in addition to existing "$and" and "$or" combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->