### PR TITLE
feat(ledger): ENG-986 ability to filter on a metadata existence

### DIFF
--- a/components/ledger/internal/api/v2/controllers_accounts_test.go
+++ b/components/ledger/internal/api/v2/controllers_accounts_test.go
@@ -116,6 +116,17 @@ func TestGetAccounts(t *testing.T) {
 				WithPageSize(v2.DefaultPageSize),
 		},
 		{
+			name: "using exists filter",
+			body: `{"$exists": { "metadata": "foo" }}`,
+			expectQuery: ledgerstore.NewPaginatedQueryOptions(ledgerstore.PITFilterWithVolumes{
+				PITFilter: ledgerstore.PITFilter{
+					PIT: &before,
+				},
+			}).
+				WithQueryBuilder(query.Exists("metadata", "foo")).
+				WithPageSize(v2.DefaultPageSize),
+		},
+		{
 			name:              "using invalid query payload",
 			body:              `[]`,
 			expectStatusCode:  http.StatusBadRequest,

--- a/components/ledger/internal/api/v2/controllers_balances_test.go
+++ b/components/ledger/internal/api/v2/controllers_balances_test.go
@@ -53,6 +53,16 @@ func TestGetBalancesAggregated(t *testing.T) {
 			},
 		},
 		{
+			name: "using exists metadata filter",
+			body: `{"$exists": {"metadata": "foo"}}`,
+			expectQuery: ledgerstore.GetAggregatedBalanceQuery{
+				PITFilter: ledgerstore.PITFilter{
+					PIT: &now,
+				},
+				QueryBuilder: query.Exists("metadata", "foo"),
+			},
+		},
+		{
 			name: "using pit",
 			queryParams: url.Values{
 				"pit": []string{now.Format(time.RFC3339Nano)},

--- a/components/ledger/internal/api/v2/controllers_transactions_test.go
+++ b/components/ledger/internal/api/v2/controllers_transactions_test.go
@@ -696,6 +696,16 @@ func TestGetTransactions(t *testing.T) {
 			},
 			expectQuery: ledgerstore.NewPaginatedQueryOptions(ledgerstore.PITFilterWithVolumes{}),
 		},
+		{
+			name: "using $exists metadata filter",
+			body: `{"$exists": {"metadata": "foo"}}`,
+			expectQuery: ledgerstore.NewPaginatedQueryOptions(ledgerstore.PITFilterWithVolumes{
+				PITFilter: ledgerstore.PITFilter{
+					PIT: &now,
+				},
+			}).
+				WithQueryBuilder(query.Exists("metadata", "foo")),
+		},
 	}
 	for _, testCase := range testCases {
 		testCase := testCase

--- a/components/ledger/internal/api/v2/controllers_volumes_test.go
+++ b/components/ledger/internal/api/v2/controllers_volumes_test.go
@@ -94,6 +94,16 @@ func TestGetVolumes(t *testing.T) {
 				GroupLvl: 3,
 			}).WithPageSize(v2.DefaultPageSize),
 		},
+		{
+			name: "using Exists metadata filter",
+			body: `{"$exists": { "metadata": "foo" }}`,
+			expectQuery: ledgerstore.NewPaginatedQueryOptions(ledgerstore.FiltersForVolumes{
+				PITFilter: ledgerstore.PITFilter{
+					PIT: &before,
+					OOT: &zero,
+				},
+			}).WithPageSize(v2.DefaultPageSize).WithQueryBuilder(query.Exists("metadata", "foo")),
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/components/ledger/internal/storage/ledgerstore/accounts.go
+++ b/components/ledger/internal/storage/ledgerstore/accounts.go
@@ -122,7 +122,7 @@ func (store *Store) accountQueryContext(qb query.Builder, q GetAccountsQuery) (s
 				order by seq desc
 				limit 1
 			) %s ?`, convertOperatorToSQL()), []any{store.name, value}, nil
-		
+
 		case key == "metadata":
 			if operator != "$exists" {
 				return "", nil, newErrInvalidQuery("'metadata' key filter can only be used with $exists")
@@ -131,7 +131,7 @@ func (store *Store) accountQueryContext(qb query.Builder, q GetAccountsQuery) (s
 				key = "accounts_metadata.metadata"
 			}
 
-			return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil 
+			return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil
 		default:
 			return "", nil, newErrInvalidQuery("unknown key '%s' when building query", key)
 		}

--- a/components/ledger/internal/storage/ledgerstore/accounts.go
+++ b/components/ledger/internal/storage/ledgerstore/accounts.go
@@ -122,6 +122,16 @@ func (store *Store) accountQueryContext(qb query.Builder, q GetAccountsQuery) (s
 				order by seq desc
 				limit 1
 			) %s ?`, convertOperatorToSQL()), []any{store.name, value}, nil
+		
+		case key == "metadata":
+			if operator != "$exists" {
+				return "", nil, newErrInvalidQuery("'metadata' key filter can only be used with $exists")
+			}
+			if q.Options.Options.PIT != nil && !q.Options.Options.PIT.IsZero() {
+				key = "accounts_metadata.metadata"
+			}
+
+			return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil 
 		default:
 			return "", nil, newErrInvalidQuery("unknown key '%s' when building query", key)
 		}

--- a/components/ledger/internal/storage/ledgerstore/accounts_test.go
+++ b/components/ledger/internal/storage/ledgerstore/accounts_test.go
@@ -189,7 +189,7 @@ func TestGetAccounts(t *testing.T) {
 			WithQueryBuilder(query.Exists("metadata", "foo")),
 		))
 		require.NoError(t, err)
-		require.Len(t, accounts.Data, 2) 
+		require.Len(t, accounts.Data, 2)
 
 		accounts, err = store.GetAccountsWithVolumes(ctx, NewGetAccountsQuery(NewPaginatedQueryOptions(PITFilterWithVolumes{}).
 			WithQueryBuilder(query.Exists("metadata", "category")),

--- a/components/ledger/internal/storage/ledgerstore/accounts_test.go
+++ b/components/ledger/internal/storage/ledgerstore/accounts_test.go
@@ -182,6 +182,22 @@ func TestGetAccounts(t *testing.T) {
 		require.Equal(t, "account:1", accounts.Data[0].Account.Address)
 		require.Equal(t, "bank", accounts.Data[1].Account.Address)
 	})
+
+	t.Run("list using filter on exists metadata", func(t *testing.T) {
+		t.Parallel()
+		accounts, err := store.GetAccountsWithVolumes(ctx, NewGetAccountsQuery(NewPaginatedQueryOptions(PITFilterWithVolumes{}).
+			WithQueryBuilder(query.Exists("metadata", "foo")),
+		))
+		require.NoError(t, err)
+		require.Len(t, accounts.Data, 2) 
+
+		accounts, err = store.GetAccountsWithVolumes(ctx, NewGetAccountsQuery(NewPaginatedQueryOptions(PITFilterWithVolumes{}).
+			WithQueryBuilder(query.Exists("metadata", "category")),
+		))
+		require.NoError(t, err)
+		require.Len(t, accounts.Data, 3)
+	})
+
 	t.Run("list using filter invalid field", func(t *testing.T) {
 		t.Parallel()
 		_, err := store.GetAccountsWithVolumes(ctx, NewGetAccountsQuery(NewPaginatedQueryOptions(PITFilterWithVolumes{}).

--- a/components/ledger/internal/storage/ledgerstore/balances.go
+++ b/components/ledger/internal/storage/ledgerstore/balances.go
@@ -50,7 +50,7 @@ func (store *Store) GetAggregatedBalances(ctx context.Context, q GetAggregatedBa
 				return key + " @> ?", []any{map[string]any{
 					match[0][1]: value,
 				}}, nil
-			
+
 			case key == "metadata":
 				if operator != "$exists" {
 					return "", nil, newErrInvalidQuery("'metadata' key filter can only be used with $exists")
@@ -60,8 +60,8 @@ func (store *Store) GetAggregatedBalances(ctx context.Context, q GetAggregatedBa
 				if q.PIT != nil && !q.PIT.IsZero() {
 					key = "am.metadata"
 				}
-	
-				return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil 
+
+				return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil
 			default:
 				return "", nil, newErrInvalidQuery("unknown key '%s' when building query", key)
 			}

--- a/components/ledger/internal/storage/ledgerstore/balances.go
+++ b/components/ledger/internal/storage/ledgerstore/balances.go
@@ -50,6 +50,18 @@ func (store *Store) GetAggregatedBalances(ctx context.Context, q GetAggregatedBa
 				return key + " @> ?", []any{map[string]any{
 					match[0][1]: value,
 				}}, nil
+			
+			case key == "metadata":
+				if operator != "$exists" {
+					return "", nil, newErrInvalidQuery("'metadata' key filter can only be used with $exists")
+				}
+				needMetadata = true
+				key := "accounts.metadata"
+				if q.PIT != nil && !q.PIT.IsZero() {
+					key = "am.metadata"
+				}
+	
+				return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil 
 			default:
 				return "", nil, newErrInvalidQuery("unknown key '%s' when building query", key)
 			}

--- a/components/ledger/internal/storage/ledgerstore/balances_test.go
+++ b/components/ledger/internal/storage/ledgerstore/balances_test.go
@@ -58,6 +58,9 @@ func TestGetBalancesAggregated(t *testing.T) {
 			TargetID:   "users:2",
 			Key:        "category",
 		}),
+		ledger.NewSetMetadataOnAccountLog(time.Now(), "users:1", metadata.Metadata{"category": "1"}).WithDate(now.Add(time.Minute)),
+		ledger.NewSetMetadataOnAccountLog(time.Now(), "users:2", metadata.Metadata{"category": "2"}).WithDate(now.Add(time.Minute)),
+		ledger.NewSetMetadataOnAccountLog(time.Now(), "world", metadata.Metadata{"foo": "bar"}).WithDate(now.Add(time.Minute)),
 	}
 
 	require.NoError(t, store.InsertLogs(ctx, ledger.ChainLogs(logs...)...))
@@ -137,5 +140,19 @@ func TestGetBalancesAggregated(t *testing.T) {
 			query.Match("metadata[category]", "guest"), false))
 		require.NoError(t, err)
 		require.Equal(t, ledger.BalancesByAssets{}, ret)
+	})
+
+	t.Run("using a filter exist on metadata", func(t *testing.T) {
+		t.Parallel()
+		ret, err := store.GetAggregatedBalances(ctx, NewGetAggregatedBalancesQuery(PITFilter{
+			
+		}, query.Exists("metadata", "category"), false))
+		require.NoError(t, err)
+		require.Equal(t, ledger.BalancesByAssets{
+			"USD": big.NewInt(0).Add(
+				big.NewInt(0).Mul(bigInt, big.NewInt(2)),
+				big.NewInt(0).Mul(smallInt, big.NewInt(2)),
+			),
+		}, ret)
 	})
 }

--- a/components/ledger/internal/storage/ledgerstore/balances_test.go
+++ b/components/ledger/internal/storage/ledgerstore/balances_test.go
@@ -144,9 +144,7 @@ func TestGetBalancesAggregated(t *testing.T) {
 
 	t.Run("using a filter exist on metadata", func(t *testing.T) {
 		t.Parallel()
-		ret, err := store.GetAggregatedBalances(ctx, NewGetAggregatedBalancesQuery(PITFilter{
-			
-		}, query.Exists("metadata", "category"), false))
+		ret, err := store.GetAggregatedBalances(ctx, NewGetAggregatedBalancesQuery(PITFilter{}, query.Exists("metadata", "category"), false))
 		require.NoError(t, err)
 		require.Equal(t, ledger.BalancesByAssets{
 			"USD": big.NewInt(0).Add(

--- a/components/ledger/internal/storage/ledgerstore/transactions.go
+++ b/components/ledger/internal/storage/ledgerstore/transactions.go
@@ -245,6 +245,16 @@ func (store *Store) transactionQueryContext(qb query.Builder, q GetTransactionsQ
 			return key + " @> ?", []any{map[string]any{
 				match[0][1]: value,
 			}}, nil
+
+		case key == "metadata":
+			if operator != "$exists" {
+				return "", nil, newErrInvalidQuery("'metadata' key filter can only be used with $exists")
+			}
+			if q.Options.Options.PIT != nil && !q.Options.Options.PIT.IsZero() {
+				key = "transactions_metadata.metadata"
+			}
+
+			return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil 
 		default:
 			return "", nil, newErrInvalidQuery("unknown key '%s' when building query", key)
 		}

--- a/components/ledger/internal/storage/ledgerstore/transactions.go
+++ b/components/ledger/internal/storage/ledgerstore/transactions.go
@@ -254,7 +254,7 @@ func (store *Store) transactionQueryContext(qb query.Builder, q GetTransactionsQ
 				key = "transactions_metadata.metadata"
 			}
 
-			return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil 
+			return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil
 		default:
 			return "", nil, newErrInvalidQuery("unknown key '%s' when building query", key)
 		}

--- a/components/ledger/internal/storage/ledgerstore/transactions_test.go
+++ b/components/ledger/internal/storage/ledgerstore/transactions_test.go
@@ -1057,6 +1057,27 @@ func TestGetTransactions(t *testing.T) {
 				Data:     expandLogs(logs...)[2:3],
 			},
 		},
+		{
+			name: "filter using exists metadata",
+			query: NewPaginatedQueryOptions(PITFilterWithVolumes{}).
+				WithQueryBuilder(query.Exists("metadata", "category")),
+			expected: &bunpaginate.Cursor[ledger.ExpandedTransaction]{
+				PageSize: 15,
+				HasMore:  false,
+				Data:     Reverse(expandLogs(logs...)[0:3]...),
+			},
+		},
+		{
+			name: "filter using exists metadata2",
+			query: NewPaginatedQueryOptions(PITFilterWithVolumes{}).
+				WithQueryBuilder(query.Not(query.Exists("metadata", "category"))),
+			expected: &bunpaginate.Cursor[ledger.ExpandedTransaction]{
+				PageSize: 15,
+				HasMore:  false,
+				Data:     Reverse(expandLogs(logs...)[3:5]...),
+			},
+		},
+	
 	}
 
 	for _, tc := range testCases {
@@ -1076,6 +1097,7 @@ func TestGetTransactions(t *testing.T) {
 
 				count, err := store.CountTransactions(ctx, NewGetTransactionsQuery(tc.query))
 				require.NoError(t, err)
+				
 				require.EqualValues(t, len(tc.expected.Data), count)
 			}
 		})

--- a/components/ledger/internal/storage/ledgerstore/transactions_test.go
+++ b/components/ledger/internal/storage/ledgerstore/transactions_test.go
@@ -1077,7 +1077,6 @@ func TestGetTransactions(t *testing.T) {
 				Data:     Reverse(expandLogs(logs...)[3:5]...),
 			},
 		},
-	
 	}
 
 	for _, tc := range testCases {
@@ -1097,7 +1096,7 @@ func TestGetTransactions(t *testing.T) {
 
 				count, err := store.CountTransactions(ctx, NewGetTransactionsQuery(tc.query))
 				require.NoError(t, err)
-				
+
 				require.EqualValues(t, len(tc.expected.Data), count)
 			}
 		})

--- a/components/ledger/internal/storage/ledgerstore/volumes.go
+++ b/components/ledger/internal/storage/ledgerstore/volumes.go
@@ -48,8 +48,8 @@ func (store *Store) volumesQueryContext(qb lquery.Builder, q GetVolumesWithBalan
 					return "", nil, newErrInvalidQuery("'metadata' key filter can only be used with $exists")
 				}
 				key := "accounts.metadata"
-	
-				return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil 
+
+				return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil
 			default:
 				return "", nil, newErrInvalidQuery("unknown key '%s' when building query", key)
 			}

--- a/components/ledger/internal/storage/ledgerstore/volumes.go
+++ b/components/ledger/internal/storage/ledgerstore/volumes.go
@@ -43,6 +43,13 @@ func (store *Store) volumesQueryContext(qb lquery.Builder, q GetVolumesWithBalan
 				return key + " @> ?", []any{map[string]any{
 					match[0][1]: value,
 				}}, nil
+			case key == "metadata":
+				if operator != "$exists" {
+					return "", nil, newErrInvalidQuery("'metadata' key filter can only be used with $exists")
+				}
+				key := "accounts.metadata"
+	
+				return fmt.Sprintf("%s -> ? IS NOT NULL", key), []any{value}, nil 
 			default:
 				return "", nil, newErrInvalidQuery("unknown key '%s' when building query", key)
 			}

--- a/components/ledger/internal/storage/ledgerstore/volumes_test.go
+++ b/components/ledger/internal/storage/ledgerstore/volumes_test.go
@@ -362,13 +362,11 @@ func TestGetVolumesWithBalances(t *testing.T) {
 		volumes, err := store.GetVolumesWithBalances(ctx,
 			NewGetVolumesWithBalancesQuery(
 				NewPaginatedQueryOptions(
-					FiltersForVolumes{
-					}).WithQueryBuilder(query.Exists("metadata", "category"))),
+					FiltersForVolumes{}).WithQueryBuilder(query.Exists("metadata", "category"))),
 		)
 
 		require.NoError(t, err)
 		require.Len(t, volumes.Data, 2)
-
 
 	})
 
@@ -378,13 +376,11 @@ func TestGetVolumesWithBalances(t *testing.T) {
 		volumes, err := store.GetVolumesWithBalances(ctx,
 			NewGetVolumesWithBalancesQuery(
 				NewPaginatedQueryOptions(
-					FiltersForVolumes{
-					}).WithQueryBuilder(query.Exists("metadata", "foo"))),
+					FiltersForVolumes{}).WithQueryBuilder(query.Exists("metadata", "foo"))),
 		)
 
 		require.NoError(t, err)
 		require.Len(t, volumes.Data, 1)
-
 
 	})
 

--- a/components/ledger/internal/storage/ledgerstore/volumes_test.go
+++ b/components/ledger/internal/storage/ledgerstore/volumes_test.go
@@ -28,7 +28,9 @@ func TestGetVolumesWithBalances(t *testing.T) {
 
 	require.NoError(t, store.InsertLogs(ctx,
 		ledger.ChainLogs(
-
+			ledger.NewSetMetadataOnAccountLog(time.Now(), "account:1", metadata.Metadata{"category": "1"}).WithDate(now),
+			ledger.NewSetMetadataOnAccountLog(time.Now(), "account:2", metadata.Metadata{"category": "2"}).WithDate(now),
+			ledger.NewSetMetadataOnAccountLog(time.Now(), "world", metadata.Metadata{"foo": "bar"}).WithDate(now),
 			ledger.NewTransactionLog(
 				ledger.NewTransaction().
 					WithPostings(ledger.NewPosting("world", "account:1", "USD", big.NewInt(100))).
@@ -351,6 +353,38 @@ func TestGetVolumesWithBalances(t *testing.T) {
 				Balance: big.NewInt(-50),
 			},
 		}, volumes.Data[0])
+
+	})
+
+	t.Run("Using exists metadata filter", func(t *testing.T) {
+		t.Parallel()
+
+		volumes, err := store.GetVolumesWithBalances(ctx,
+			NewGetVolumesWithBalancesQuery(
+				NewPaginatedQueryOptions(
+					FiltersForVolumes{
+					}).WithQueryBuilder(query.Exists("metadata", "category"))),
+		)
+
+		require.NoError(t, err)
+		require.Len(t, volumes.Data, 2)
+
+
+	})
+
+	t.Run("Using exists metadata filter", func(t *testing.T) {
+		t.Parallel()
+
+		volumes, err := store.GetVolumesWithBalances(ctx,
+			NewGetVolumesWithBalancesQuery(
+				NewPaginatedQueryOptions(
+					FiltersForVolumes{
+					}).WithQueryBuilder(query.Exists("metadata", "foo"))),
+		)
+
+		require.NoError(t, err)
+		require.Len(t, volumes.Data, 1)
+
 
 	})
 

--- a/libs/go-libs/query/expression.go
+++ b/libs/go-libs/query/expression.go
@@ -154,8 +154,8 @@ func Gte(key string, value any) keyValue {
 func Exists(key string, value any) keyValue {
 	return keyValue{
 		operator: "$exists",
-		key: key,
-		value: value,
+		key:      key,
+		value:    value,
 	}
 }
 

--- a/libs/go-libs/query/expression.go
+++ b/libs/go-libs/query/expression.go
@@ -151,6 +151,14 @@ func Gte(key string, value any) keyValue {
 	}
 }
 
+func Exists(key string, value any) keyValue {
+	return keyValue{
+		operator: "$exists",
+		key: key,
+		value: value,
+	}
+}
+
 func singleKey(m map[string]any) (string, any, error) {
 	switch {
 	case len(m) == 0:
@@ -237,7 +245,7 @@ func mapMapToExpression(m map[string]any) (Builder, error) {
 			return nil, errors.Wrap(err, "parsing $and")
 		}
 		return and, nil
-	case "$match", "$gte", "$lte", "$gt", "$lt":
+	case "$match", "$gte", "$lte", "$gt", "$lt", "$exists":
 		match, err := parseKeyValue(operator, value)
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing %s", operator)


### PR DESCRIPTION
Add filter $exists: { metadata: XXX} to endpoints accounts, transactions, volumes and balances