### PR TITLE
fix(operator): opentelemetry configuration for caddy's containers

### DIFF
--- a/components/operator/internal/core/volumes.go
+++ b/components/operator/internal/core/volumes.go
@@ -17,10 +17,10 @@ func NewVolumeFromConfigMap(name string, configMap *corev1.ConfigMap) corev1.Vol
 	}
 }
 
-func NewVolumeMount(name, mountPath string) corev1.VolumeMount {
+func NewVolumeMount(name, mountPath string, readOnly bool) corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      name,
-		ReadOnly:  true,
+		ReadOnly:  readOnly,
 		MountPath: mountPath,
 	}
 }

--- a/components/operator/internal/resources/auths/deployment.go
+++ b/components/operator/internal/resources/auths/deployment.go
@@ -98,7 +98,7 @@ func createDeployment(ctx Context, stack *v1beta1.Stack, auth *v1beta1.Auth, dat
 				Env:   env,
 				Image: image,
 				VolumeMounts: []corev1.VolumeMount{
-					NewVolumeMount("config", "/config"),
+					NewVolumeMount("config", "/config", true),
 				},
 				Ports:         []corev1.ContainerPort{deployments.StandardHTTPPort()},
 				LivenessProbe: deployments.DefaultLiveness("http"),

--- a/components/operator/internal/resources/deployments/deployments.go
+++ b/components/operator/internal/resources/deployments/deployments.go
@@ -84,6 +84,16 @@ func WithVolumes(volumes ...corev1.Volume) func(t *appsv1.Deployment) error {
 	}
 }
 
+func WithVolumeMounts(mounts ...corev1.VolumeMount) func(t *appsv1.Deployment) error {
+	return func(t *appsv1.Deployment) error {
+		for _, container := range t.Spec.Template.Spec.Containers {
+			container.VolumeMounts = mounts
+		}
+
+		return nil
+	}
+}
+
 func CreateOrUpdate(ctx core.Context, owner interface {
 	client.Object
 	GetStack() string

--- a/components/operator/internal/resources/gateways/deployment.go
+++ b/components/operator/internal/resources/gateways/deployment.go
@@ -17,17 +17,11 @@ func createDeployment(ctx core.Context, stack *v1beta1.Stack,
 	broker *v1beta1.Broker, version string) error {
 
 	env := GetEnvVars(gateway)
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, gateway))
-	if err != nil {
-		return err
-	}
-
 	resourceReference, licenceEnvVars, err := licence.GetLicenceEnvVars(ctx, stack, "gateway", gateway)
 	if err != nil {
 		return err
 	}
 
-	env = append(env, otlpEnv...)
 	env = append(env, licenceEnvVars...)
 	env = append(env, core.GetDevEnvVars(stack, gateway)...)
 
@@ -48,7 +42,7 @@ func createDeployment(ctx core.Context, stack *v1beta1.Stack,
 	_, err = deployments.CreateOrUpdate(ctx, gateway, "gateway",
 		resourcereferences.Annotate("licence-secret-hash", resourceReference),
 		deployments.WithReplicasFromSettings(ctx, stack),
-		settings.ConfigureCaddy(caddyfileConfigMap, image, env),
+		settings.ConfigureCaddy(ctx, stack, gateway, caddyfileConfigMap, image, env),
 		deployments.WithMatchingLabels("gateway"),
 	)
 

--- a/components/operator/internal/resources/ledgers/deployments.go
+++ b/components/operator/internal/resources/ledgers/deployments.go
@@ -304,11 +304,6 @@ func createGatewayDeployment(ctx core.Context, stack *v1beta1.Stack, ledger *v1b
 	}
 
 	env := make([]corev1.EnvVar, 0)
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, ledger))
-	if err != nil {
-		return err
-	}
-	env = append(env, otlpEnv...)
 	env = append(env, core.GetDevEnvVars(stack, ledger)...)
 
 	caddyImage, err := registries.GetCaddyImage(ctx, stack, "2.7.6-alpine")
@@ -317,7 +312,7 @@ func createGatewayDeployment(ctx core.Context, stack *v1beta1.Stack, ledger *v1b
 	}
 
 	_, err = deployments.CreateOrUpdate(ctx, ledger, "ledger-gateway",
-		settings.ConfigureCaddy(caddyfileConfigMap, caddyImage, env),
+		settings.ConfigureCaddy(ctx, stack, ledger, caddyfileConfigMap, caddyImage, env),
 		deployments.WithReplicasFromSettings(ctx, stack),
 		deployments.WithMatchingLabels("ledger"),
 	)

--- a/components/operator/internal/resources/payments/deployments.go
+++ b/components/operator/internal/resources/payments/deployments.go
@@ -241,11 +241,7 @@ func createGateway(ctx core.Context, stack *v1beta1.Stack, p *v1beta1.Payments) 
 	}
 
 	env := make([]v1.EnvVar, 0)
-	otlpEnv, err := settings.GetOTELEnvVars(ctx, stack.Name, core.LowerCamelCaseKind(ctx, p))
-	if err != nil {
-		return err
-	}
-	env = append(env, otlpEnv...)
+
 	env = append(env, core.GetDevEnvVars(stack, p)...)
 
 	caddyImage, err := registries.GetCaddyImage(ctx, stack, "2.7.6-alpine")
@@ -255,7 +251,7 @@ func createGateway(ctx core.Context, stack *v1beta1.Stack, p *v1beta1.Payments) 
 
 	_, err = deployments.CreateOrUpdate(ctx, p, "payments",
 		deployments.WithReplicasFromSettings(ctx, stack),
-		settings.ConfigureCaddy(caddyfileConfigMap, caddyImage, env),
+		settings.ConfigureCaddy(ctx, stack, p, caddyfileConfigMap, caddyImage, env),
 		deployments.WithMatchingLabels("payments"),
 		// notes(gfyrag): reset init containers in case of upgrading from v1 to v2
 		deployments.WithInitContainers(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functionality to specify read-only volume mounts in deployments.
  - Enhanced configuration options for Caddy in various deployment settings.

- **Refactor**
  - Streamlined environment variable management and deployment configurations across multiple components.

- **Bug Fixes**
  - Adjusted volume mount settings to accurately reflect read-only status as required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->