### PR TITLE
fix(payments): wrong related payment ids

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/client/transactions.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/client/transactions.go
@@ -21,3 +21,16 @@ func (c *Client) GetV1Transactions(ctx context.Context, token string, pageSize i
 
 	return c.client.Transactions.GetV1Transactions(&params)
 }
+
+func (c *Client) GetV1TransactionsID(ctx context.Context, id string) (*transactions.GetV1TransactionsIDOK, error) {
+	f := connectors.ClientMetrics(ctx, "atlar", "list_transactions")
+	now := time.Now()
+	defer f(ctx, now)
+
+	params := transactions.GetV1TransactionsIDParams{
+		Context: ctx,
+		ID:      id,
+	}
+
+	return c.client.Transactions.GetV1TransactionsID(&params)
+}

--- a/components/payments/docker-compose.yml
+++ b/components/payments/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./local_env/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   payments-migrate:
-    image: golang:1.20.11-alpine3.18
+    image: golang:1.22.4-alpine3.19
     command: go run ./ migrate up
     depends_on:
       postgres:
@@ -34,7 +34,7 @@ services:
       POSTGRES_URI: postgres://payments:payments@postgres:${POSTGRES_PORT:-5432}/payments?sslmode=disable
 
   payments-api:
-    image: golang:1.20.11-alpine3.18
+    image: golang:1.22.4-alpine3.19
     command: go run ./ api server
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/_healthcheck" ]
@@ -58,7 +58,7 @@ services:
       CONFIG_ENCRYPTION_KEY: mysuperencryptionkey
 
   payments-connectors:
-    image: golang:1.20.11-alpine3.18
+    image: golang:1.22.4-alpine3.19
     command: go run ./ connectors server
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://127.0.0.1:8081/_healthcheck" ]


### PR DESCRIPTION
This PR adds a Payment ID to a transfer initiation only once once Atlar reports a transaction (Formance "Payment") connected to the transfer initiation.
