### PR TITLE
fix(payments): wrong related payment ids

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/client/transactions.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/client/transactions.go
@@ -21,3 +21,16 @@ func (c *Client) GetV1Transactions(ctx context.Context, token string, pageSize i
 
 	return c.client.Transactions.GetV1Transactions(&params)
 }
+
+func (c *Client) GetV1TransactionsID(ctx context.Context, id string) (*transactions.GetV1TransactionsIDOK, error) {
+	f := connectors.ClientMetrics(ctx, "atlar", "list_transactions")
+	now := time.Now()
+	defer f(ctx, now)
+
+	params := transactions.GetV1TransactionsIDParams{
+		Context: ctx,
+		ID:      id,
+	}
+
+	return c.client.Transactions.GetV1TransactionsID(&params)
+}

--- a/components/payments/cmd/connectors/internal/connectors/atlar/task_payments.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/task_payments.go
@@ -120,10 +120,6 @@ func InitiatePaymentTask(config Config, client *client.Client, transferID string
 			},
 			ConnectorID: connectorID,
 		}
-		err = ingester.AddTransferInitiationPaymentID(ctx, transfer, paymentID, time.Now())
-		if err != nil {
-			return err
-		}
 
 		var taskDescriptor models.TaskDescriptor
 		taskDescriptor, err = models.EncodeTaskDescriptor(TaskDescriptor{
@@ -234,7 +230,30 @@ func UpdatePaymentStatusTask(
 			return nil
 
 		case "RECONCILED":
-			// this is done
+			err = ingestAtlarTransaction(ctx,
+				ingester,
+				connectorID,
+				client,
+				getCreditTransferResponse.Payload.Reconciliation.BookedTransactionID,
+			)
+			if err != nil {
+				otel.RecordError(span, err)
+				return err
+			}
+
+			paymentID = &models.PaymentID{
+				PaymentReference: models.PaymentReference{
+					Reference: getCreditTransferResponse.Payload.Reconciliation.BookedTransactionID,
+					Type:      models.PaymentTypePayOut,
+				},
+				ConnectorID: connectorID,
+			}
+			err = ingester.AddTransferInitiationPaymentID(ctx, transfer, paymentID, time.Now())
+			if err != nil {
+				otel.RecordError(span, err)
+				return err
+			}
+
 			err = ingester.UpdateTransferInitiationPaymentsStatus(ctx, transfer, paymentID, models.TransferInitiationStatusProcessed, "", time.Now())
 			if err != nil {
 				otel.RecordError(span, err)
@@ -244,7 +263,6 @@ func UpdatePaymentStatusTask(
 			return nil
 
 		case "REJECTED", "FAILED", "RETURNED":
-			// this has failed
 			err = ingester.UpdateTransferInitiationPaymentsStatus(
 				ctx, transfer, paymentID, models.TransferInitiationStatusFailed,
 				fmt.Sprintf("paymant initiation status is \"%s\"", status), time.Now(),
@@ -332,4 +350,35 @@ func deserializeAtlarPaymentExternalID(serialized string) (string, int, error) {
 		return "", 0, errors.New("cannot deserialize malformed externalID")
 	}
 	return matches[1], attempts, nil
+}
+
+func ingestAtlarTransaction(
+	ctx context.Context,
+	ingester ingestion.Ingester,
+	connectorID models.ConnectorID,
+	client *client.Client,
+	transactionId string,
+) error {
+
+	transactionResponse, err := client.GetV1TransactionsID(ctx, transactionId)
+	if err != nil {
+		return err
+	}
+
+	batchElement, err := atlarTransactionToPaymentBatchElement(connectorID, transactionResponse.Payload)
+	if err != nil {
+		return err
+	}
+	if batchElement == nil {
+		return nil
+	}
+
+	batch := ingestion.PaymentBatch{*batchElement}
+
+	err = ingester.IngestPayments(ctx, batch)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/components/payments/docker-compose.yml
+++ b/components/payments/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ./local_env/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
 
   payments-migrate:
-    image: golang:1.20.11-alpine3.18
+    image: golang:1.22.4-alpine3.19
     command: go run ./ migrate up
     depends_on:
       postgres:
@@ -34,7 +34,7 @@ services:
       POSTGRES_URI: postgres://payments:payments@postgres:${POSTGRES_PORT:-5432}/payments?sslmode=disable
 
   payments-api:
-    image: golang:1.20.11-alpine3.18
+    image: golang:1.22.4-alpine3.19
     command: go run ./ api server
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/_healthcheck" ]
@@ -58,7 +58,7 @@ services:
       CONFIG_ENCRYPTION_KEY: mysuperencryptionkey
 
   payments-connectors:
-    image: golang:1.20.11-alpine3.18
+    image: golang:1.22.4-alpine3.19
     command: go run ./ connectors server
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://127.0.0.1:8081/_healthcheck" ]


### PR DESCRIPTION
This PR adds a Payment ID to a transfer initiation only once once Atlar reports a transaction (Formance "Payment") connected to the transfer initiation.