### PR TITLE
Add more bank details to Accounts (internal) and Payments

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/account_utils.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/account_utils.go
@@ -45,11 +45,11 @@ func ExternalAccountFromAtlarData(
 	}, nil
 }
 
-func ExtractAccountMetadata(account *atlar_models.Account) metadata.Metadata {
+func ExtractAccountMetadata(account *atlar_models.Account, bank *atlar_models.ThirdParty) metadata.Metadata {
 	result := metadata.Metadata{}
 	result = result.Merge(ComputeAccountMetadataBool("fictive", account.Fictive))
-	result = result.Merge(ComputeAccountMetadata("bank/id", account.Bank.ID))
-	result = result.Merge(ComputeAccountMetadata("bank/name", account.Bank.Name))
+	result = result.Merge(ComputeAccountMetadata("bank/id", bank.ID))
+	result = result.Merge(ComputeAccountMetadata("bank/name", bank.Name))
 	result = result.Merge(ComputeAccountMetadata("bank/bic", account.Bank.Bic))
 	result = result.Merge(IdentifiersToMetadata(account.Identifiers))
 	result = result.Merge(ComputeAccountMetadata("alias", account.Alias))

--- a/components/payments/cmd/connectors/internal/connectors/atlar/client/accounts.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/client/accounts.go
@@ -8,6 +8,19 @@ import (
 	"github.com/get-momo/atlar-v1-go-client/client/accounts"
 )
 
+func (c *Client) GetV1AccountsID(ctx context.Context, id string) (*accounts.GetV1AccountsIDOK, error) {
+	f := connectors.ClientMetrics(ctx, "atlar", "list_accounts")
+	now := time.Now()
+	defer f(ctx, now)
+
+	accountsParams := accounts.GetV1AccountsIDParams{
+		Context: ctx,
+		ID:      id,
+	}
+
+	return c.client.Accounts.GetV1AccountsID(&accountsParams)
+}
+
 func (c *Client) GetV1Accounts(ctx context.Context, token string, pageSize int64) (*accounts.GetV1AccountsOK, error) {
 	f := connectors.ClientMetrics(ctx, "atlar", "list_accounts")
 	now := time.Now()

--- a/components/payments/cmd/connectors/internal/connectors/atlar/client/third_parties.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/client/third_parties.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/formancehq/payments/cmd/connectors/internal/connectors"
+	"github.com/get-momo/atlar-v1-go-client/client/third_parties"
+)
+
+func (c *Client) GetV1BetaThirdPartiesID(ctx context.Context, id string) (*third_parties.GetV1betaThirdPartiesIDOK, error) {
+	f := connectors.ClientMetrics(ctx, "atlar", "list_third_parties")
+	now := time.Now()
+	defer f(ctx, now)
+
+	params := third_parties.GetV1betaThirdPartiesIDParams{
+		Context: ctx,
+		ID:      id,
+	}
+
+	return c.client.ThirdParties.GetV1betaThirdPartiesID(&params)
+}

--- a/components/payments/cmd/connectors/internal/connectors/atlar/currencies.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/currencies.go
@@ -5,5 +5,6 @@ import "github.com/formancehq/payments/cmd/connectors/internal/connectors/curren
 var (
 	supportedCurrenciesWithDecimal = map[string]int{
 		"EUR": currency.ISO4217Currencies["EUR"], //  Euro
+		"DKK": currency.ISO4217Currencies["DKK"],
 	}
 )


### PR DESCRIPTION
We're currently preparing for adding a second bank as  partner to work with.

Going forward, we will need to differentiate payments and internal accounts by bank. This PR introduces the metadata necessary to do so.