### PR TITLE
feat(payments): only send one events when updating tf

### DIFF
--- a/components/payments/cmd/connectors/internal/connectors/atlar/task_payments.go
+++ b/components/payments/cmd/connectors/internal/connectors/atlar/task_payments.go
@@ -249,13 +249,8 @@ func UpdatePaymentStatusTask(
 				},
 				ConnectorID: connectorID,
 			}
-			err = ingester.AddTransferInitiationPaymentID(ctx, transfer, paymentID, time.Now())
-			if err != nil {
-				otel.RecordError(span, err)
-				return err
-			}
 
-			err = ingester.UpdateTransferInitiationPaymentsStatus(ctx, transfer, paymentID, models.TransferInitiationStatusProcessed, "", time.Now())
+			err = ingester.UpdateTransferInitiationPayment(ctx, transfer, paymentID, models.TransferInitiationStatusProcessed, "", time.Now())
 			if err != nil {
 				otel.RecordError(span, err)
 				return err

--- a/components/payments/cmd/connectors/internal/connectors/dummypay/connector_test.go
+++ b/components/payments/cmd/connectors/internal/connectors/dummypay/connector_test.go
@@ -98,6 +98,10 @@ func (m *MockIngester) UpdateTaskState(ctx context.Context, state any) error {
 	return nil
 }
 
+func (m *MockIngester) UpdateTransferInitiationPayment(ctx context.Context, tf *models.TransferInitiation, paymentID *models.PaymentID, status models.TransferInitiationStatus, errorMessage string, updatedAt time.Time) error {
+	return nil
+}
+
 func (m *MockIngester) UpdateTransferInitiationPaymentsStatus(ctx context.Context, tf *models.TransferInitiation, paymentID *models.PaymentID, status models.TransferInitiationStatus, errorMessage string, updatedAt time.Time) error {
 	return nil
 }

--- a/components/payments/cmd/connectors/internal/ingestion/ingester.go
+++ b/components/payments/cmd/connectors/internal/ingestion/ingester.go
@@ -15,6 +15,7 @@ type Ingester interface {
 	IngestPayments(ctx context.Context, batch PaymentBatch) error
 	IngestBalances(ctx context.Context, batch BalanceBatch, checkIfAccountExists bool) error
 	UpdateTaskState(ctx context.Context, state any) error
+	UpdateTransferInitiationPayment(ctx context.Context, tf *models.TransferInitiation, paymentID *models.PaymentID, status models.TransferInitiationStatus, errorMessage string, updatedAt time.Time) error
 	UpdateTransferInitiationPaymentsStatus(ctx context.Context, tf *models.TransferInitiation, paymentID *models.PaymentID, status models.TransferInitiationStatus, errorMessage string, updatedAt time.Time) error
 	UpdateTransferReversalStatus(ctx context.Context, transfer *models.TransferInitiation, transferReversal *models.TransferReversal) error
 	AddTransferInitiationPaymentID(ctx context.Context, tf *models.TransferInitiation, paymentID *models.PaymentID, updatedAt time.Time) error

--- a/components/payments/cmd/connectors/internal/ingestion/transfer_initiation.go
+++ b/components/payments/cmd/connectors/internal/ingestion/transfer_initiation.go
@@ -22,6 +22,10 @@ func (i *DefaultIngester) UpdateTransferInitiationPayment(
 	errorMessage string,
 	updatedAt time.Time,
 ) error {
+	if err := i.addTransferInitiationPaymentID(ctx, tf, paymentID, updatedAt); err != nil {
+		return err
+	}
+
 	if err := i.updateTransferInitiationPaymentStatus(
 		ctx,
 		tf,
@@ -30,10 +34,6 @@ func (i *DefaultIngester) UpdateTransferInitiationPayment(
 		errorMessage,
 		updatedAt,
 	); err != nil {
-		return err
-	}
-
-	if err := i.addTransferInitiationPaymentID(ctx, tf, paymentID, updatedAt); err != nil {
 		return err
 	}
 

--- a/components/payments/cmd/connectors/internal/ingestion/transfer_initiation.go
+++ b/components/payments/cmd/connectors/internal/ingestion/transfer_initiation.go
@@ -11,18 +11,29 @@ import (
 	"github.com/google/uuid"
 )
 
-func (i *DefaultIngester) UpdateTransferInitiationPaymentsStatus(ctx context.Context, tf *models.TransferInitiation, paymentID *models.PaymentID, status models.TransferInitiationStatus, errorMessage string, updatedAt time.Time) error {
-	adjustment := &models.TransferInitiationAdjustment{
-		ID:                   uuid.New(),
-		TransferInitiationID: tf.ID,
-		CreatedAt:            updatedAt.UTC(),
-		Status:               status,
-		Error:                errorMessage,
+// In some cases, we want to do the two udpates to the transfer initiations
+// (update the payment status and add a related payment id) and send only one
+// events for both of them.
+func (i *DefaultIngester) UpdateTransferInitiationPayment(
+	ctx context.Context,
+	tf *models.TransferInitiation,
+	paymentID *models.PaymentID,
+	status models.TransferInitiationStatus,
+	errorMessage string,
+	updatedAt time.Time,
+) error {
+	if err := i.updateTransferInitiationPaymentStatus(
+		ctx,
+		tf,
+		paymentID,
+		status,
+		errorMessage,
+		updatedAt,
+	); err != nil {
+		return err
 	}
 
-	tf.RelatedAdjustments = append([]*models.TransferInitiationAdjustment{adjustment}, tf.RelatedAdjustments...)
-
-	if err := i.store.UpdateTransferInitiationPaymentsStatus(ctx, tf.ID, paymentID, adjustment); err != nil {
+	if err := i.addTransferInitiationPaymentID(ctx, tf, paymentID, updatedAt); err != nil {
 		return err
 	}
 
@@ -39,7 +50,82 @@ func (i *DefaultIngester) UpdateTransferInitiationPaymentsStatus(ctx context.Con
 	return nil
 }
 
+// Updates only the transfer initiation payment status
+func (i *DefaultIngester) UpdateTransferInitiationPaymentsStatus(ctx context.Context, tf *models.TransferInitiation, paymentID *models.PaymentID, status models.TransferInitiationStatus, errorMessage string, updatedAt time.Time) error {
+	if err := i.updateTransferInitiationPaymentStatus(
+		ctx,
+		tf,
+		paymentID,
+		status,
+		errorMessage,
+		updatedAt,
+	); err != nil {
+		return err
+	}
+
+	if err := i.publisher.Publish(
+		events.TopicPayments,
+		publish.NewMessage(
+			ctx,
+			i.messages.NewEventSavedTransferInitiations(tf),
+		),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Only adds a related payment id to the transfer initiation
 func (i *DefaultIngester) AddTransferInitiationPaymentID(ctx context.Context, tf *models.TransferInitiation, paymentID *models.PaymentID, updatedAt time.Time) error {
+	if err := i.addTransferInitiationPaymentID(ctx, tf, paymentID, updatedAt); err != nil {
+		return err
+	}
+
+	if err := i.publisher.Publish(
+		events.TopicPayments,
+		publish.NewMessage(
+			ctx,
+			i.messages.NewEventSavedTransferInitiations(tf),
+		),
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *DefaultIngester) updateTransferInitiationPaymentStatus(
+	ctx context.Context,
+	tf *models.TransferInitiation,
+	paymentID *models.PaymentID,
+	status models.TransferInitiationStatus,
+	errorMessage string,
+	updatedAt time.Time,
+) error {
+	adjustment := &models.TransferInitiationAdjustment{
+		ID:                   uuid.New(),
+		TransferInitiationID: tf.ID,
+		CreatedAt:            updatedAt.UTC(),
+		Status:               status,
+		Error:                errorMessage,
+	}
+
+	tf.RelatedAdjustments = append([]*models.TransferInitiationAdjustment{adjustment}, tf.RelatedAdjustments...)
+
+	if err := i.store.UpdateTransferInitiationPaymentsStatus(ctx, tf.ID, paymentID, adjustment); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *DefaultIngester) addTransferInitiationPaymentID(
+	ctx context.Context,
+	tf *models.TransferInitiation,
+	paymentID *models.PaymentID,
+	updatedAt time.Time,
+) error {
 	if paymentID == nil {
 		return fmt.Errorf("payment id is nil")
 	}
@@ -52,16 +138,6 @@ func (i *DefaultIngester) AddTransferInitiationPaymentID(ctx context.Context, tf
 	})
 
 	if err := i.store.AddTransferInitiationPaymentID(ctx, tf.ID, paymentID, updatedAt, tf.Metadata); err != nil {
-		return err
-	}
-
-	if err := i.publisher.Publish(
-		events.TopicPayments,
-		publish.NewMessage(
-			ctx,
-			i.messages.NewEventSavedTransferInitiations(tf),
-		),
-	); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
In some cases, we only want to send one events when updating the status and adding a new related payments to a transfer initiation instead of two events like we have right now.

Fixes ENG-1161