### PR TITLE
fix(operator): update Caddyfile templates to set Host header for reverse proxy

### DIFF
--- a/components/operator/api/formance.com/v1beta1/auth_types.go
+++ b/components/operator/api/formance.com/v1beta1/auth_types.go
@@ -23,9 +23,9 @@ import (
 
 type DelegatedOIDCServerConfiguration struct {
 	// Issuer is the url of the delegated oidc server
-	Issuer       string `json:"issuer,omitempty"`
+	Issuer string `json:"issuer,omitempty"`
 	// ClientID is the client id to use for authentication
-	ClientID     string `json:"clientID,omitempty"`
+	ClientID string `json:"clientID,omitempty"`
 	// ClientSecret is the client secret to use for authentication
 	ClientSecret string `json:"clientSecret,omitempty"`
 }
@@ -65,14 +65,14 @@ type AuthStatus struct {
 // Creating it for a stack automatically add authentication on all supported modules.
 //
 // The auth service is basically a proxy to another OIDC compliant server.
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
-//+kubebuilder:printcolumn:name="Clients",type=string,JSONPath=".status.clients",description="Synchronized auth clients"
-//+kubebuilder:printcolumn:name="Stack",type=string,JSONPath=".spec.stack",description="Stack"
-//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=".status.ready",description="Is ready"
-//+kubebuilder:printcolumn:name="Info",type=string,JSONPath=".status.info",description="Info"
-//+kubebuilder:metadata:labels=formance.com/kind=module
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Clients",type=string,JSONPath=".status.clients",description="Synchronized auth clients"
+// +kubebuilder:printcolumn:name="Stack",type=string,JSONPath=".spec.stack",description="Stack"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=".status.ready",description="Is ready"
+// +kubebuilder:printcolumn:name="Info",type=string,JSONPath=".status.info",description="Info"
+// +kubebuilder:metadata:labels=formance.com/kind=module
 type Auth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/components/operator/api/formance.com/v1beta1/database_types.go
+++ b/components/operator/api/formance.com/v1beta1/database_types.go
@@ -25,7 +25,7 @@ type DatabaseSpec struct {
 	// Service is a discriminator for the created database.
 	// Actually, it will be the module name (ledger, payments...).
 	// Therefore, the created database will be named `<stack-name><service>`
-	Service         string `json:"service"`
+	Service string `json:"service"`
 	// +kubebuilder:default:=false
 	Debug bool `json:"debug,omitempty"`
 }
@@ -63,13 +63,13 @@ type DatabaseStatus struct {
 //
 // Therefore, to switch to a new server, you must change the setting value, then drop the Database object.
 // It will be recreated with correct uri.
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
-//+kubebuilder:printcolumn:name="Stack",type=string,JSONPath=".spec.stack",description="Stack"
-//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=".status.ready",description="Ready"
-//+kubebuilder:printcolumn:name="Out of sync",type=string,JSONPath=".status.outOfSync",description="Is the databse configuration out of sync"
-//+kubebuilder:printcolumn:name="Info",type=string,JSONPath=".status.info",description="Info"
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Stack",type=string,JSONPath=".spec.stack",description="Stack"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=".status.ready",description="Ready"
+// +kubebuilder:printcolumn:name="Out of sync",type=string,JSONPath=".status.outOfSync",description="Is the databse configuration out of sync"
+// +kubebuilder:printcolumn:name="Info",type=string,JSONPath=".status.info",description="Info"
 type Database struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/components/operator/api/formance.com/v1beta1/ledger_types.go
+++ b/components/operator/api/formance.com/v1beta1/ledger_types.go
@@ -81,17 +81,18 @@ type LedgerStatus struct {
 // * single writer / multiple reader: In this mode, we will have a single writer and multiple readers if needed.
 //
 // Use setting `ledger.deployment-strategy` with either the value :
-// * single : For the single instance mode.
-// * single-writer: For the single writer / multiple reader mode.
-//   Under the hood, the operator create two deployments and force the scaling of the writer to stay at 1.
-//   Then you can scale the deployment of the reader to the value you want.
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
-//+kubebuilder:printcolumn:name="Stack",type=string,JSONPath=".spec.stack",description="Stack"
-//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=".status.ready",description="Is ready"
-//+kubebuilder:printcolumn:name="Info",type=string,JSONPath=".status.info",description="Info"
-//+kubebuilder:metadata:labels=formance.com/kind=module
+//   - single : For the single instance mode.
+//   - single-writer: For the single writer / multiple reader mode.
+//     Under the hood, the operator create two deployments and force the scaling of the writer to stay at 1.
+//     Then you can scale the deployment of the reader to the value you want.
+//
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Stack",type=string,JSONPath=".spec.stack",description="Stack"
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=".status.ready",description="Is ready"
+// +kubebuilder:printcolumn:name="Info",type=string,JSONPath=".status.info",description="Info"
+// +kubebuilder:metadata:labels=formance.com/kind=module
 type Ledger struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/components/operator/api/formance.com/v1beta1/resourcereference_types.go
+++ b/components/operator/api/formance.com/v1beta1/resourcereference_types.go
@@ -51,31 +51,37 @@ type ResourceReferenceStatus struct {
 // apiVersion: formance.com/v1beta1
 // kind: ResourceReference
 // metadata:
-//   name: jqkuffjxcezj-qlii-auth-postgres
-//   ownerReferences:
-//   - apiVersion: formance.com/v1beta1
-//     blockOwnerDeletion: true
-//     controller: true
-//     kind: Database
-//     name: jqkuffjxcezj-qlii-auth
-//     uid: 2cc4b788-3ffb-4e3d-8a30-07ed3941c8d2
+//
+//	name: jqkuffjxcezj-qlii-auth-postgres
+//	ownerReferences:
+//	- apiVersion: formance.com/v1beta1
+//	  blockOwnerDeletion: true
+//	  controller: true
+//	  kind: Database
+//	  name: jqkuffjxcezj-qlii-auth
+//	  uid: 2cc4b788-3ffb-4e3d-8a30-07ed3941c8d2
+//
 // spec:
-//   gvk:
-//     group: ""
-//     kind: Secret
-//     version: v1
-//   name: postgres
-//   stack: jqkuffjxcezj-qlii
+//
+//	gvk:
+//	  group: ""
+//	  kind: Secret
+//	  version: v1
+//	name: postgres
+//	stack: jqkuffjxcezj-qlii
+//
 // status:
-//   ...
+//
+//	...
+//
 // ```
 // This reconciler behind this ResourceReference will search, in all namespaces, for a secret named "postgres".
 // The secret must have a label `formance.com/stack` with the value matching either a specific stack or `any` to target any stack.
 //
 // Once the reconciler has found the secret, it will copy it inside the stack namespace, allowing the ResourceReconciler owner to use it.
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
 type ResourceReference struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/components/operator/api/formance.com/v1beta1/settings_types.go
+++ b/components/operator/api/formance.com/v1beta1/settings_types.go
@@ -25,9 +25,9 @@ type SettingsSpec struct {
 	// Stacks on which the setting is applied. Can contain `*` to indicate a wildcard.
 	Stacks []string `json:"stacks,omitempty"`
 	// The setting Key. See the documentation of each module or [global settings](#global-settings) to discover them.
-	Key    string   `json:"key"`
+	Key string `json:"key"`
 	// The value. It must have a specific format following the Key.
-	Value  string   `json:"value"`
+	Value string `json:"value"`
 }
 
 // Settings represents a configurable piece of the stacks.
@@ -39,12 +39,16 @@ type SettingsSpec struct {
 // apiVersion: formance.com/v1beta1
 // kind: Settings
 // metadata:
-//   name: postgres-uri
+//
+//	name: postgres-uri
+//
 // spec:
-//   key: postgres.ledger.uri
-//   stacks:
-//   - stack0
-//   value: postgresql://postgresql.formance.svc.cluster.local:5432
+//
+//	key: postgres.ledger.uri
+//	stacks:
+//	- stack0
+//	value: postgresql://postgresql.formance.svc.cluster.local:5432
+//
 // ```
 //
 // This example create a setting named `postgres-uri` targeting the stack named `stack0` and the service `ledger` (see the key `postgres.ledger.uri`).
@@ -58,12 +62,16 @@ type SettingsSpec struct {
 // apiVersion: formance.com/v1beta1
 // kind: Settings
 // metadata:
-//   name: postgres-uri
+//
+//	name: postgres-uri
+//
 // spec:
-//   key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting of all services of the stack `stack0`
-//   stacks:
-//   - stack0
-//   value: postgresql://postgresql.formance.svc.cluster.local:5432
+//
+//	key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting of all services of the stack `stack0`
+//	stacks:
+//	- stack0
+//	value: postgresql://postgresql.formance.svc.cluster.local:5432
+//
 // ```
 //
 // Also, we could use that setting for all of our stacks using :
@@ -71,12 +79,16 @@ type SettingsSpec struct {
 // apiVersion: formance.com/v1beta1
 // kind: Settings
 // metadata:
-//   name: postgres-uri
+//
+//	name: postgres-uri
+//
 // spec:
-//   key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting for all services of all stacks
-//   stacks:
-//   - * # There we select all the stacks
-//   value: postgresql://postgresql.formance.svc.cluster.local:5432
+//
+//	key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting for all services of all stacks
+//	stacks:
+//	- * # There we select all the stacks
+//	value: postgresql://postgresql.formance.svc.cluster.local:5432
+//
 // ```
 //
 // Some settings are really global, while some are used by specific module.
@@ -95,12 +107,16 @@ type SettingsSpec struct {
 // apiVersion: formance.com/v1beta1
 // kind: Settings
 // metadata:
-//   name: aws-service-account
+//
+//	name: aws-service-account
+//
 // spec:
-//   key: aws.service-account
-//   stacks:
-//   - '*'
-//   value: aws-access
+//
+//	key: aws.service-account
+//	stacks:
+//	- '*'
+//	value: aws-access
+//
 // ```
 // This setting instruct the operator than there is somewhere on the cluster a service account named `aws-access`.
 //
@@ -111,16 +127,18 @@ type SettingsSpec struct {
 // apiVersion: v1
 // kind: ServiceAccount
 // metadata:
-//   annotations:
-//     eks.amazonaws.com/role-arn: arn:aws:iam::************:role/staging-eu-west-1-hosting-stack-access
-//   labels:
-//     formance.com/stack: any
-//   name: aws-access
+//
+//	annotations:
+//	  eks.amazonaws.com/role-arn: arn:aws:iam::************:role/staging-eu-west-1-hosting-stack-access
+//	labels:
+//	  formance.com/stack: any
+//	name: aws-access
+//
 // ```
 // You can note two things :
-// 1. We have an annotation indicating the role arn used to connect to AWS. Refer to the AWS documentation to create this role
-// 2. We have a label `formance.com/stack=any` indicating we are targeting all stacks.
-//    Refer to the documentation of [ResourceReference](#resourcereference) for further information.
+//  1. We have an annotation indicating the role arn used to connect to AWS. Refer to the AWS documentation to create this role
+//  2. We have a label `formance.com/stack=any` indicating we are targeting all stacks.
+//     Refer to the documentation of [ResourceReference](#resourcereference) for further information.
 //
 // ###### JSON logging
 //
@@ -130,23 +148,27 @@ type SettingsSpec struct {
 // apiVersion: formance.com/v1beta1
 // kind: Settings
 // metadata:
-//   name: json-logging
+//
+//	name: json-logging
+//
 // spec:
-//   key: logging.json
-//   stacks:
-//   - '*'
-//   value: "true"
+//
+//	key: logging.json
+//	stacks:
+//	- '*'
+//	value: "true"
+//
 // ```
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
-//+kubebuilder:printcolumn:name="Key",type=string,JSONPath=".spec.key",description="Key"
-//+kubebuilder:printcolumn:name="Value",type=string,JSONPath=".spec.value",description="Value"
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Key",type=string,JSONPath=".spec.key",description="Key"
+// +kubebuilder:printcolumn:name="Value",type=string,JSONPath=".spec.value",description="Value"
 type Settings struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   SettingsSpec   `json:"spec,omitempty"`
+	Spec SettingsSpec `json:"spec,omitempty"`
 }
 
 func (in *Settings) GetStacks() []string {

--- a/components/operator/api/formance.com/v1beta1/stack_types.go
+++ b/components/operator/api/formance.com/v1beta1/stack_types.go
@@ -45,7 +45,7 @@ type StackSpec struct {
 }
 
 type StackStatus struct {
-	Status  `json:",inline"`
+	Status `json:",inline"`
 	// Modules register detected modules
 	Modules []string `json:"modules,omitempty"`
 }

--- a/components/operator/api/stack.formance.com/v1beta3/stack_types.go
+++ b/components/operator/api/stack.formance.com/v1beta3/stack_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1beta3
 
 import (
-	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"reflect"
+
+	"github.com/formancehq/operator/api/formance.com/v1beta1"
 
 	"github.com/iancoleman/strcase"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/components/operator/config/crd/bases/formance.com_ledgers.yaml
+++ b/components/operator/config/crd/bases/formance.com_ledgers.yaml
@@ -46,10 +46,10 @@ spec:
 
 
           Use setting `ledger.deployment-strategy` with either the value :
-          * single : For the single instance mode.
-          * single-writer: For the single writer / multiple reader mode.
-            Under the hood, the operator create two deployments and force the scaling of the writer to stay at 1.
-            Then you can scale the deployment of the reader to the value you want.
+            - single : For the single instance mode.
+            - single-writer: For the single writer / multiple reader mode.
+              Under the hood, the operator create two deployments and force the scaling of the writer to stay at 1.
+              Then you can scale the deployment of the reader to the value you want.
         properties:
           apiVersion:
             description: |-

--- a/components/operator/config/crd/bases/formance.com_resourcereferences.yaml
+++ b/components/operator/config/crd/bases/formance.com_resourcereferences.yaml
@@ -17,51 +17,26 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: |-
-          ResourceReference is a special resources used to refer to externally created resources.
-
-
-          It includes k8s service accounts and secrets.
-
-
-          Why? Because the operator create a namespace by stack, so, a stack does not have access to secrets and service
-          accounts created externally.
-
-
-          A ResourceReference is created by other resource who need to use a specific secret or service account.
-          For example, if you want to use a secret for your database connection (see [Database](#database), you will
-          create a setting indicating a secret name. You will need to create this secret yourself, and you will put this
-          secret inside the namespace you want (`default` maybe).
-
-
-          The Database reconciler will create a ResourceReference looking like that :
-          ```
-          apiVersion: formance.com/v1beta1
-          kind: ResourceReference
-          metadata:
-            name: jqkuffjxcezj-qlii-auth-postgres
-            ownerReferences:
-            - apiVersion: formance.com/v1beta1
-              blockOwnerDeletion: true
-              controller: true
-              kind: Database
-              name: jqkuffjxcezj-qlii-auth
-              uid: 2cc4b788-3ffb-4e3d-8a30-07ed3941c8d2
-          spec:
-            gvk:
-              group: ""
-              kind: Secret
-              version: v1
-            name: postgres
-            stack: jqkuffjxcezj-qlii
-          status:
-            ...
-          ```
-          This reconciler behind this ResourceReference will search, in all namespaces, for a secret named "postgres".
-          The secret must have a label `formance.com/stack` with the value matching either a specific stack or `any` to target any stack.
-
-
-          Once the reconciler has found the secret, it will copy it inside the stack namespace, allowing the ResourceReconciler owner to use it.
+        description: "ResourceReference is a special resources used to refer to externally
+          created resources.\n\n\nIt includes k8s service accounts and secrets.\n\n\nWhy?
+          Because the operator create a namespace by stack, so, a stack does not have
+          access to secrets and service\naccounts created externally.\n\n\nA ResourceReference
+          is created by other resource who need to use a specific secret or service
+          account.\nFor example, if you want to use a secret for your database connection
+          (see [Database](#database), you will\ncreate a setting indicating a secret
+          name. You will need to create this secret yourself, and you will put this\nsecret
+          inside the namespace you want (`default` maybe).\n\n\nThe Database reconciler
+          will create a ResourceReference looking like that :\n```\napiVersion: formance.com/v1beta1\nkind:
+          ResourceReference\nmetadata:\n\n\n\tname: jqkuffjxcezj-qlii-auth-postgres\n\townerReferences:\n\t-
+          apiVersion: formance.com/v1beta1\n\t  blockOwnerDeletion: true\n\t  controller:
+          true\n\t  kind: Database\n\t  name: jqkuffjxcezj-qlii-auth\n\t  uid: 2cc4b788-3ffb-4e3d-8a30-07ed3941c8d2\n\n\nspec:\n\n\n\tgvk:\n\t
+          \ group: \"\"\n\t  kind: Secret\n\t  version: v1\n\tname: postgres\n\tstack:
+          jqkuffjxcezj-qlii\n\n\nstatus:\n\n\n\t...\n\n\n```\nThis reconciler behind
+          this ResourceReference will search, in all namespaces, for a secret named
+          \"postgres\".\nThe secret must have a label `formance.com/stack` with the
+          value matching either a specific stack or `any` to target any stack.\n\n\nOnce
+          the reconciler has found the secret, it will copy it inside the stack namespace,
+          allowing the ResourceReconciler owner to use it."
         properties:
           apiVersion:
             description: |-

--- a/components/operator/config/crd/bases/formance.com_settings.yaml
+++ b/components/operator/config/crd/bases/formance.com_settings.yaml
@@ -26,131 +26,49 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: |-
-          Settings represents a configurable piece of the stacks.
-
-
-          The purpose of this resource is to be able to configure some common settings between a set of stacks.
-
-
-          Example :
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: postgres-uri
-          spec:
-            key: postgres.ledger.uri
-            stacks:
-            - stack0
-            value: postgresql://postgresql.formance.svc.cluster.local:5432
-          ```
-
-
-          This example create a setting named `postgres-uri` targeting the stack named `stack0` and the service `ledger` (see the key `postgres.ledger.uri`).
-
-
-          Therefore, a [Database](#database) created for the stack `stack0` and the service named 'ledger' will use the uri `postgresql://postgresql.formance.svc.cluster.local:5432`.
-
-
-          Settings allow to use wildcards in keys and in stacks list.
-
-
-          For example, if you want to use the same database server for all the modules of a specific stack, you can write :
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: postgres-uri
-          spec:
-            key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting of all services of the stack `stack0`
-            stacks:
-            - stack0
-            value: postgresql://postgresql.formance.svc.cluster.local:5432
-          ```
-
-
-          Also, we could use that setting for all of our stacks using :
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: postgres-uri
-          spec:
-            key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting for all services of all stacks
-            stacks:
-            - * # There we select all the stacks
-            value: postgresql://postgresql.formance.svc.cluster.local:5432
-          ```
-
-
-          Some settings are really global, while some are used by specific module.
-
-
-          Refer to the documentation of each module and resource to discover available Settings.
-
-
-          ##### Global settings
-          ###### AWS account
-
-
-          A stack can use an AWS account for authentication.
-
-
-          It can be used to connect to any AWS service we could use.
-
-
-          It includes RDS, OpenSearch and MSK. To do so, you can create the following setting:
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: aws-service-account
-          spec:
-            key: aws.service-account
-            stacks:
-            - '*'
-            value: aws-access
-          ```
-          This setting instruct the operator than there is somewhere on the cluster a service account named `aws-access`.
-
-
-          So, each time a service has the capability to use AWS, the operator will use this service account.
-
-
-          The service account could look like that :
-          ```yaml
-          apiVersion: v1
-          kind: ServiceAccount
-          metadata:
-            annotations:
-              eks.amazonaws.com/role-arn: arn:aws:iam::************:role/staging-eu-west-1-hosting-stack-access
-            labels:
-              formance.com/stack: any
-            name: aws-access
-          ```
-          You can note two things :
-          1. We have an annotation indicating the role arn used to connect to AWS. Refer to the AWS documentation to create this role
-          2. We have a label `formance.com/stack=any` indicating we are targeting all stacks.
-             Refer to the documentation of [ResourceReference](#resourcereference) for further information.
-
-
-          ###### JSON logging
-
-
-          You can use the setting `logging.json` with the value `true` to configure elligible service to log as json.
-          Example:
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: json-logging
-          spec:
-            key: logging.json
-            stacks:
-            - '*'
-            value: "true"
-          ```
+        description: "Settings represents a configurable piece of the stacks.\n\n\nThe
+          purpose of this resource is to be able to configure some common settings
+          between a set of stacks.\n\n\nExample :\n```yaml\napiVersion: formance.com/v1beta1\nkind:
+          Settings\nmetadata:\n\n\n\tname: postgres-uri\n\n\nspec:\n\n\n\tkey: postgres.ledger.uri\n\tstacks:\n\t-
+          stack0\n\tvalue: postgresql://postgresql.formance.svc.cluster.local:5432\n\n\n```\n\n\nThis
+          example create a setting named `postgres-uri` targeting the stack named
+          `stack0` and the service `ledger` (see the key `postgres.ledger.uri`).\n\n\nTherefore,
+          a [Database](#database) created for the stack `stack0` and the service named
+          'ledger' will use the uri `postgresql://postgresql.formance.svc.cluster.local:5432`.\n\n\nSettings
+          allow to use wildcards in keys and in stacks list.\n\n\nFor example, if
+          you want to use the same database server for all the modules of a specific
+          stack, you can write :\n```yaml\napiVersion: formance.com/v1beta1\nkind:
+          Settings\nmetadata:\n\n\n\tname: postgres-uri\n\n\nspec:\n\n\n\tkey: postgres.*.uri
+          # There, we use a wildcard to indicate we want to use that setting of all
+          services of the stack `stack0`\n\tstacks:\n\t- stack0\n\tvalue: postgresql://postgresql.formance.svc.cluster.local:5432\n\n\n```\n\n\nAlso,
+          we could use that setting for all of our stacks using :\n```yaml\napiVersion:
+          formance.com/v1beta1\nkind: Settings\nmetadata:\n\n\n\tname: postgres-uri\n\n\nspec:\n\n\n\tkey:
+          postgres.*.uri # There, we use a wildcard to indicate we want to use that
+          setting for all services of all stacks\n\tstacks:\n\t- * # There we select
+          all the stacks\n\tvalue: postgresql://postgresql.formance.svc.cluster.local:5432\n\n\n```\n\n\nSome
+          settings are really global, while some are used by specific module.\n\n\nRefer
+          to the documentation of each module and resource to discover available Settings.\n\n\n#####
+          Global settings\n###### AWS account\n\n\nA stack can use an AWS account
+          for authentication.\n\n\nIt can be used to connect to any AWS service we
+          could use.\n\n\nIt includes RDS, OpenSearch and MSK. To do so, you can create
+          the following setting:\n```yaml\napiVersion: formance.com/v1beta1\nkind:
+          Settings\nmetadata:\n\n\n\tname: aws-service-account\n\n\nspec:\n\n\n\tkey:
+          aws.service-account\n\tstacks:\n\t- '*'\n\tvalue: aws-access\n\n\n```\nThis
+          setting instruct the operator than there is somewhere on the cluster a service
+          account named `aws-access`.\n\n\nSo, each time a service has the capability
+          to use AWS, the operator will use this service account.\n\n\nThe service
+          account could look like that :\n```yaml\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n\n\n\tannotations:\n\t
+          \ eks.amazonaws.com/role-arn: arn:aws:iam::************:role/staging-eu-west-1-hosting-stack-access\n\tlabels:\n\t
+          \ formance.com/stack: any\n\tname: aws-access\n\n\n```\nYou can note two
+          things :\n 1. We have an annotation indicating the role arn used to connect
+          to AWS. Refer to the AWS documentation to create this role\n 2. We have
+          a label `formance.com/stack=any` indicating we are targeting all stacks.\n
+          \   Refer to the documentation of [ResourceReference](#resourcereference)
+          for further information.\n\n\n###### JSON logging\n\n\nYou can use the setting
+          `logging.json` with the value `true` to configure elligible service to log
+          as json.\nExample:\n```yaml\napiVersion: formance.com/v1beta1\nkind: Settings\nmetadata:\n\n\n\tname:
+          json-logging\n\n\nspec:\n\n\n\tkey: logging.json\n\tstacks:\n\t- '*'\n\tvalue:
+          \"true\"\n\n\n```"
         properties:
           apiVersion:
             description: |-

--- a/components/operator/docs/09-Configuration reference/02-Custom Resource Definitions.md
+++ b/components/operator/docs/09-Configuration reference/02-Custom Resource Definitions.md
@@ -166,12 +166,20 @@ Example :
 apiVersion: formance.com/v1beta1
 kind: Settings
 metadata:
-  name: postgres-uri
+
+
+	name: postgres-uri
+
+
 spec:
-  key: postgres.ledger.uri
-  stacks:
-  - stack0
-  value: postgresql://postgresql.formance.svc.cluster.local:5432
+
+
+	key: postgres.ledger.uri
+	stacks:
+	- stack0
+	value: postgresql://postgresql.formance.svc.cluster.local:5432
+
+
 ```
 
 
@@ -189,12 +197,20 @@ For example, if you want to use the same database server for all the modules of 
 apiVersion: formance.com/v1beta1
 kind: Settings
 metadata:
-  name: postgres-uri
+
+
+	name: postgres-uri
+
+
 spec:
-  key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting of all services of the stack `stack0`
-  stacks:
-  - stack0
-  value: postgresql://postgresql.formance.svc.cluster.local:5432
+
+
+	key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting of all services of the stack `stack0`
+	stacks:
+	- stack0
+	value: postgresql://postgresql.formance.svc.cluster.local:5432
+
+
 ```
 
 
@@ -203,12 +219,20 @@ Also, we could use that setting for all of our stacks using :
 apiVersion: formance.com/v1beta1
 kind: Settings
 metadata:
-  name: postgres-uri
+
+
+	name: postgres-uri
+
+
 spec:
-  key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting for all services of all stacks
-  stacks:
-  - * # There we select all the stacks
-  value: postgresql://postgresql.formance.svc.cluster.local:5432
+
+
+	key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting for all services of all stacks
+	stacks:
+	- * # There we select all the stacks
+	value: postgresql://postgresql.formance.svc.cluster.local:5432
+
+
 ```
 
 
@@ -233,12 +257,20 @@ It includes RDS, OpenSearch and MSK. To do so, you can create the following sett
 apiVersion: formance.com/v1beta1
 kind: Settings
 metadata:
-  name: aws-service-account
+
+
+	name: aws-service-account
+
+
 spec:
-  key: aws.service-account
-  stacks:
-  - '*'
-  value: aws-access
+
+
+	key: aws.service-account
+	stacks:
+	- '*'
+	value: aws-access
+
+
 ```
 This setting instruct the operator than there is somewhere on the cluster a service account named `aws-access`.
 
@@ -251,16 +283,20 @@ The service account could look like that :
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::************:role/staging-eu-west-1-hosting-stack-access
-  labels:
-    formance.com/stack: any
-  name: aws-access
+
+
+	annotations:
+	  eks.amazonaws.com/role-arn: arn:aws:iam::************:role/staging-eu-west-1-hosting-stack-access
+	labels:
+	  formance.com/stack: any
+	name: aws-access
+
+
 ```
 You can note two things :
-1. We have an annotation indicating the role arn used to connect to AWS. Refer to the AWS documentation to create this role
-2. We have a label `formance.com/stack=any` indicating we are targeting all stacks.
-   Refer to the documentation of [ResourceReference](#resourcereference) for further information.
+ 1. We have an annotation indicating the role arn used to connect to AWS. Refer to the AWS documentation to create this role
+ 2. We have a label `formance.com/stack=any` indicating we are targeting all stacks.
+    Refer to the documentation of [ResourceReference](#resourcereference) for further information.
 
 
 ###### JSON logging
@@ -272,12 +308,20 @@ Example:
 apiVersion: formance.com/v1beta1
 kind: Settings
 metadata:
-  name: json-logging
+
+
+	name: json-logging
+
+
 spec:
-  key: logging.json
-  stacks:
-  - '*'
-  value: "true"
+
+
+	key: logging.json
+	stacks:
+	- '*'
+	value: "true"
+
+
 ```
 
 
@@ -707,10 +751,10 @@ So, the ledger can run in two modes :
 
 
 Use setting `ledger.deployment-strategy` with either the value :
-* single : For the single instance mode.
-* single-writer: For the single writer / multiple reader mode.
-  Under the hood, the operator create two deployments and force the scaling of the writer to stay at 1.
-  Then you can scale the deployment of the reader to the value you want.
+  - single : For the single instance mode.
+  - single-writer: For the single writer / multiple reader mode.
+    Under the hood, the operator create two deployments and force the scaling of the writer to stay at 1.
+    Then you can scale the deployment of the reader to the value you want.
 
 
 
@@ -2364,23 +2408,35 @@ The Database reconciler will create a ResourceReference looking like that :
 apiVersion: formance.com/v1beta1
 kind: ResourceReference
 metadata:
-  name: jqkuffjxcezj-qlii-auth-postgres
-  ownerReferences:
-  - apiVersion: formance.com/v1beta1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Database
-    name: jqkuffjxcezj-qlii-auth
-    uid: 2cc4b788-3ffb-4e3d-8a30-07ed3941c8d2
+
+
+	name: jqkuffjxcezj-qlii-auth-postgres
+	ownerReferences:
+	- apiVersion: formance.com/v1beta1
+	  blockOwnerDeletion: true
+	  controller: true
+	  kind: Database
+	  name: jqkuffjxcezj-qlii-auth
+	  uid: 2cc4b788-3ffb-4e3d-8a30-07ed3941c8d2
+
+
 spec:
-  gvk:
-    group: ""
-    kind: Secret
-    version: v1
-  name: postgres
-  stack: jqkuffjxcezj-qlii
+
+
+	gvk:
+	  group: ""
+	  kind: Secret
+	  version: v1
+	name: postgres
+	stack: jqkuffjxcezj-qlii
+
+
 status:
-  ...
+
+
+	...
+
+
 ```
 This reconciler behind this ResourceReference will search, in all namespaces, for a secret named "postgres".
 The secret must have a label `formance.com/stack` with the value matching either a specific stack or `any` to target any stack.

--- a/components/operator/helm/crds/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_ledgers.formance.com.yaml
+++ b/components/operator/helm/crds/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_ledgers.formance.com.yaml
@@ -46,10 +46,10 @@ spec:
 
 
           Use setting `ledger.deployment-strategy` with either the value :
-          * single : For the single instance mode.
-          * single-writer: For the single writer / multiple reader mode.
-            Under the hood, the operator create two deployments and force the scaling of the writer to stay at 1.
-            Then you can scale the deployment of the reader to the value you want.
+            - single : For the single instance mode.
+            - single-writer: For the single writer / multiple reader mode.
+              Under the hood, the operator create two deployments and force the scaling of the writer to stay at 1.
+              Then you can scale the deployment of the reader to the value you want.
         properties:
           apiVersion:
             description: |-

--- a/components/operator/helm/crds/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_resourcereferences.formance.com.yaml
+++ b/components/operator/helm/crds/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_resourcereferences.formance.com.yaml
@@ -17,51 +17,26 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: |-
-          ResourceReference is a special resources used to refer to externally created resources.
-
-
-          It includes k8s service accounts and secrets.
-
-
-          Why? Because the operator create a namespace by stack, so, a stack does not have access to secrets and service
-          accounts created externally.
-
-
-          A ResourceReference is created by other resource who need to use a specific secret or service account.
-          For example, if you want to use a secret for your database connection (see [Database](#database), you will
-          create a setting indicating a secret name. You will need to create this secret yourself, and you will put this
-          secret inside the namespace you want (`default` maybe).
-
-
-          The Database reconciler will create a ResourceReference looking like that :
-          ```
-          apiVersion: formance.com/v1beta1
-          kind: ResourceReference
-          metadata:
-            name: jqkuffjxcezj-qlii-auth-postgres
-            ownerReferences:
-            - apiVersion: formance.com/v1beta1
-              blockOwnerDeletion: true
-              controller: true
-              kind: Database
-              name: jqkuffjxcezj-qlii-auth
-              uid: 2cc4b788-3ffb-4e3d-8a30-07ed3941c8d2
-          spec:
-            gvk:
-              group: ""
-              kind: Secret
-              version: v1
-            name: postgres
-            stack: jqkuffjxcezj-qlii
-          status:
-            ...
-          ```
-          This reconciler behind this ResourceReference will search, in all namespaces, for a secret named "postgres".
-          The secret must have a label `formance.com/stack` with the value matching either a specific stack or `any` to target any stack.
-
-
-          Once the reconciler has found the secret, it will copy it inside the stack namespace, allowing the ResourceReconciler owner to use it.
+        description: "ResourceReference is a special resources used to refer to externally
+          created resources.\n\n\nIt includes k8s service accounts and secrets.\n\n\nWhy?
+          Because the operator create a namespace by stack, so, a stack does not have
+          access to secrets and service\naccounts created externally.\n\n\nA ResourceReference
+          is created by other resource who need to use a specific secret or service
+          account.\nFor example, if you want to use a secret for your database connection
+          (see [Database](#database), you will\ncreate a setting indicating a secret
+          name. You will need to create this secret yourself, and you will put this\nsecret
+          inside the namespace you want (`default` maybe).\n\n\nThe Database reconciler
+          will create a ResourceReference looking like that :\n```\napiVersion: formance.com/v1beta1\nkind:
+          ResourceReference\nmetadata:\n\n\n\tname: jqkuffjxcezj-qlii-auth-postgres\n\townerReferences:\n\t-
+          apiVersion: formance.com/v1beta1\n\t  blockOwnerDeletion: true\n\t  controller:
+          true\n\t  kind: Database\n\t  name: jqkuffjxcezj-qlii-auth\n\t  uid: 2cc4b788-3ffb-4e3d-8a30-07ed3941c8d2\n\n\nspec:\n\n\n\tgvk:\n\t
+          \ group: \"\"\n\t  kind: Secret\n\t  version: v1\n\tname: postgres\n\tstack:
+          jqkuffjxcezj-qlii\n\n\nstatus:\n\n\n\t...\n\n\n```\nThis reconciler behind
+          this ResourceReference will search, in all namespaces, for a secret named
+          \"postgres\".\nThe secret must have a label `formance.com/stack` with the
+          value matching either a specific stack or `any` to target any stack.\n\n\nOnce
+          the reconciler has found the secret, it will copy it inside the stack namespace,
+          allowing the ResourceReconciler owner to use it."
         properties:
           apiVersion:
             description: |-

--- a/components/operator/helm/crds/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_settings.formance.com.yaml
+++ b/components/operator/helm/crds/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_settings.formance.com.yaml
@@ -26,131 +26,49 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: |-
-          Settings represents a configurable piece of the stacks.
-
-
-          The purpose of this resource is to be able to configure some common settings between a set of stacks.
-
-
-          Example :
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: postgres-uri
-          spec:
-            key: postgres.ledger.uri
-            stacks:
-            - stack0
-            value: postgresql://postgresql.formance.svc.cluster.local:5432
-          ```
-
-
-          This example create a setting named `postgres-uri` targeting the stack named `stack0` and the service `ledger` (see the key `postgres.ledger.uri`).
-
-
-          Therefore, a [Database](#database) created for the stack `stack0` and the service named 'ledger' will use the uri `postgresql://postgresql.formance.svc.cluster.local:5432`.
-
-
-          Settings allow to use wildcards in keys and in stacks list.
-
-
-          For example, if you want to use the same database server for all the modules of a specific stack, you can write :
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: postgres-uri
-          spec:
-            key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting of all services of the stack `stack0`
-            stacks:
-            - stack0
-            value: postgresql://postgresql.formance.svc.cluster.local:5432
-          ```
-
-
-          Also, we could use that setting for all of our stacks using :
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: postgres-uri
-          spec:
-            key: postgres.*.uri # There, we use a wildcard to indicate we want to use that setting for all services of all stacks
-            stacks:
-            - * # There we select all the stacks
-            value: postgresql://postgresql.formance.svc.cluster.local:5432
-          ```
-
-
-          Some settings are really global, while some are used by specific module.
-
-
-          Refer to the documentation of each module and resource to discover available Settings.
-
-
-          ##### Global settings
-          ###### AWS account
-
-
-          A stack can use an AWS account for authentication.
-
-
-          It can be used to connect to any AWS service we could use.
-
-
-          It includes RDS, OpenSearch and MSK. To do so, you can create the following setting:
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: aws-service-account
-          spec:
-            key: aws.service-account
-            stacks:
-            - '*'
-            value: aws-access
-          ```
-          This setting instruct the operator than there is somewhere on the cluster a service account named `aws-access`.
-
-
-          So, each time a service has the capability to use AWS, the operator will use this service account.
-
-
-          The service account could look like that :
-          ```yaml
-          apiVersion: v1
-          kind: ServiceAccount
-          metadata:
-            annotations:
-              eks.amazonaws.com/role-arn: arn:aws:iam::************:role/staging-eu-west-1-hosting-stack-access
-            labels:
-              formance.com/stack: any
-            name: aws-access
-          ```
-          You can note two things :
-          1. We have an annotation indicating the role arn used to connect to AWS. Refer to the AWS documentation to create this role
-          2. We have a label `formance.com/stack=any` indicating we are targeting all stacks.
-             Refer to the documentation of [ResourceReference](#resourcereference) for further information.
-
-
-          ###### JSON logging
-
-
-          You can use the setting `logging.json` with the value `true` to configure elligible service to log as json.
-          Example:
-          ```yaml
-          apiVersion: formance.com/v1beta1
-          kind: Settings
-          metadata:
-            name: json-logging
-          spec:
-            key: logging.json
-            stacks:
-            - '*'
-            value: "true"
-          ```
+        description: "Settings represents a configurable piece of the stacks.\n\n\nThe
+          purpose of this resource is to be able to configure some common settings
+          between a set of stacks.\n\n\nExample :\n```yaml\napiVersion: formance.com/v1beta1\nkind:
+          Settings\nmetadata:\n\n\n\tname: postgres-uri\n\n\nspec:\n\n\n\tkey: postgres.ledger.uri\n\tstacks:\n\t-
+          stack0\n\tvalue: postgresql://postgresql.formance.svc.cluster.local:5432\n\n\n```\n\n\nThis
+          example create a setting named `postgres-uri` targeting the stack named
+          `stack0` and the service `ledger` (see the key `postgres.ledger.uri`).\n\n\nTherefore,
+          a [Database](#database) created for the stack `stack0` and the service named
+          'ledger' will use the uri `postgresql://postgresql.formance.svc.cluster.local:5432`.\n\n\nSettings
+          allow to use wildcards in keys and in stacks list.\n\n\nFor example, if
+          you want to use the same database server for all the modules of a specific
+          stack, you can write :\n```yaml\napiVersion: formance.com/v1beta1\nkind:
+          Settings\nmetadata:\n\n\n\tname: postgres-uri\n\n\nspec:\n\n\n\tkey: postgres.*.uri
+          # There, we use a wildcard to indicate we want to use that setting of all
+          services of the stack `stack0`\n\tstacks:\n\t- stack0\n\tvalue: postgresql://postgresql.formance.svc.cluster.local:5432\n\n\n```\n\n\nAlso,
+          we could use that setting for all of our stacks using :\n```yaml\napiVersion:
+          formance.com/v1beta1\nkind: Settings\nmetadata:\n\n\n\tname: postgres-uri\n\n\nspec:\n\n\n\tkey:
+          postgres.*.uri # There, we use a wildcard to indicate we want to use that
+          setting for all services of all stacks\n\tstacks:\n\t- * # There we select
+          all the stacks\n\tvalue: postgresql://postgresql.formance.svc.cluster.local:5432\n\n\n```\n\n\nSome
+          settings are really global, while some are used by specific module.\n\n\nRefer
+          to the documentation of each module and resource to discover available Settings.\n\n\n#####
+          Global settings\n###### AWS account\n\n\nA stack can use an AWS account
+          for authentication.\n\n\nIt can be used to connect to any AWS service we
+          could use.\n\n\nIt includes RDS, OpenSearch and MSK. To do so, you can create
+          the following setting:\n```yaml\napiVersion: formance.com/v1beta1\nkind:
+          Settings\nmetadata:\n\n\n\tname: aws-service-account\n\n\nspec:\n\n\n\tkey:
+          aws.service-account\n\tstacks:\n\t- '*'\n\tvalue: aws-access\n\n\n```\nThis
+          setting instruct the operator than there is somewhere on the cluster a service
+          account named `aws-access`.\n\n\nSo, each time a service has the capability
+          to use AWS, the operator will use this service account.\n\n\nThe service
+          account could look like that :\n```yaml\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n\n\n\tannotations:\n\t
+          \ eks.amazonaws.com/role-arn: arn:aws:iam::************:role/staging-eu-west-1-hosting-stack-access\n\tlabels:\n\t
+          \ formance.com/stack: any\n\tname: aws-access\n\n\n```\nYou can note two
+          things :\n 1. We have an annotation indicating the role arn used to connect
+          to AWS. Refer to the AWS documentation to create this role\n 2. We have
+          a label `formance.com/stack=any` indicating we are targeting all stacks.\n
+          \   Refer to the documentation of [ResourceReference](#resourcereference)
+          for further information.\n\n\n###### JSON logging\n\n\nYou can use the setting
+          `logging.json` with the value `true` to configure elligible service to log
+          as json.\nExample:\n```yaml\napiVersion: formance.com/v1beta1\nkind: Settings\nmetadata:\n\n\n\tname:
+          json-logging\n\n\nspec:\n\n\n\tkey: logging.json\n\tstacks:\n\t- '*'\n\tvalue:
+          \"true\"\n\n\n```"
         properties:
           apiVersion:
             description: |-

--- a/components/operator/internal/core/reconciler.go
+++ b/components/operator/internal/core/reconciler.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/components/operator/internal/resources/auths/deployment.go
+++ b/components/operator/internal/resources/auths/deployment.go
@@ -2,6 +2,7 @@ package auths
 
 import (
 	"fmt"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	. "github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/applications"

--- a/components/operator/internal/resources/benthos/controller.go
+++ b/components/operator/internal/resources/benthos/controller.go
@@ -3,6 +3,8 @@ package benthos
 import (
 	"embed"
 	"fmt"
+	"sort"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	. "github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/applications"
@@ -21,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
 )
 
 //+kubebuilder:rbac:groups=formance.com,resources=benthos,verbs=get;list;watch;create;update;patch;delete

--- a/components/operator/internal/resources/brokerconsumers/controller.go
+++ b/components/operator/internal/resources/brokerconsumers/controller.go
@@ -18,6 +18,8 @@ package brokerconsumers
 
 import (
 	"fmt"
+	"strings"
+
 	v1beta1 "github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/jobs"
@@ -30,7 +32,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
 )
 
 const (

--- a/components/operator/internal/resources/brokers/reconcile.go
+++ b/components/operator/internal/resources/brokers/reconcile.go
@@ -2,6 +2,8 @@ package brokers
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/jobs"
@@ -14,7 +16,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
 )
 
 func Reconcile(ctx core.Context, stack *v1beta1.Stack, broker *v1beta1.Broker) error {

--- a/components/operator/internal/resources/brokers/utils.go
+++ b/components/operator/internal/resources/brokers/utils.go
@@ -2,10 +2,11 @@ package brokers
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/formancehq/operator/internal/resources/settings"
 	"github.com/formancehq/stack/libs/go-libs/collectionutils"
 	"k8s.io/apimachinery/pkg/types"
-	"strings"
 
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/core"

--- a/components/operator/internal/resources/brokers/watch.go
+++ b/components/operator/internal/resources/brokers/watch.go
@@ -1,9 +1,10 @@
 package brokers
 
 import (
+	"reflect"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/core"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )

--- a/components/operator/internal/resources/caddy/caddy.go
+++ b/components/operator/internal/resources/caddy/caddy.go
@@ -3,9 +3,10 @@ package caddy
 import (
 	"bytes"
 	"fmt"
-	"github.com/formancehq/operator/internal/resources/settings"
 	"strings"
 	"text/template"
+
+	"github.com/formancehq/operator/internal/resources/settings"
 
 	"github.com/formancehq/operator/internal/core"
 

--- a/components/operator/internal/resources/databases/env.go
+++ b/components/operator/internal/resources/databases/env.go
@@ -2,13 +2,14 @@ package databases
 
 import (
 	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/settings"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"strconv"
-	"time"
 )
 
 func GetPostgresEnvVars(ctx core.Context, stack *v1beta1.Stack, db *v1beta1.Database) ([]corev1.EnvVar, error) {

--- a/components/operator/internal/resources/gateways/Caddyfile.gotpl
+++ b/components/operator/internal/resources/gateways/Caddyfile.gotpl
@@ -95,7 +95,9 @@
         {{- if and (not $rule.Secured) $values.Auth }}
         import auth {{ $service.Name }}
         {{- end }}
-		reverse_proxy {{ $service.Name }}:8080
+		reverse_proxy {{ $service.Name }}:8080 {
+            header_up Host {upstream_hostport}
+        }
     }
 	{{- end }}
 	{{- end }}

--- a/components/operator/internal/resources/gateways/caddyfile.go
+++ b/components/operator/internal/resources/gateways/caddyfile.go
@@ -2,6 +2,7 @@ package gateways
 
 import (
 	"fmt"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/caddy"

--- a/components/operator/internal/resources/gateways/init.go
+++ b/components/operator/internal/resources/gateways/init.go
@@ -18,8 +18,9 @@ package gateways
 
 import (
 	_ "embed"
-	"k8s.io/apimachinery/pkg/types"
 	"sort"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	. "github.com/formancehq/operator/internal/core"

--- a/components/operator/internal/resources/ledgers/assets/Caddyfile.gotpl
+++ b/components/operator/internal/resources/ledgers/assets/Caddyfile.gotpl
@@ -17,10 +17,14 @@
 
     handle {
         method GET
-        reverse_proxy ledger-read:8080
+        reverse_proxy ledger-read:8080{
+          header_up Host {upstream_hostport}
+       }
     }
 
     handle {
-        reverse_proxy ledger-write:8080
+        reverse_proxy ledger-write:8080{
+          header_up Host {upstream_hostport}
+        }
     }
 }

--- a/components/operator/internal/resources/ledgers/init.go
+++ b/components/operator/internal/resources/ledgers/init.go
@@ -19,6 +19,7 @@ package ledgers
 import (
 	_ "embed"
 	"fmt"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	. "github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/benthosstreams"

--- a/components/operator/internal/resources/orchestrations/deployments.go
+++ b/components/operator/internal/resources/orchestrations/deployments.go
@@ -2,11 +2,12 @@ package orchestrations
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/formancehq/operator/internal/resources/brokers"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"strings"
 
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	. "github.com/formancehq/operator/internal/core"

--- a/components/operator/internal/resources/searches/init.go
+++ b/components/operator/internal/resources/searches/init.go
@@ -18,8 +18,9 @@ package searches
 
 import (
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	. "github.com/formancehq/operator/internal/core"

--- a/components/operator/internal/resources/webhooks/deployment.go
+++ b/components/operator/internal/resources/webhooks/deployment.go
@@ -2,10 +2,11 @@ package webhooks
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/formancehq/operator/internal/resources/brokers"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/core"

--- a/components/operator/internal/tests/database_controller_test.go
+++ b/components/operator/internal/tests/database_controller_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"fmt"
+
 	"github.com/formancehq/operator/api/formance.com/v1beta1"
 	"github.com/formancehq/operator/internal/resources/resourcereferences"
 	"github.com/formancehq/operator/internal/resources/settings"

--- a/components/operator/internal/tests/gateway_controller_test.go
+++ b/components/operator/internal/tests/gateway_controller_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"fmt"
+
 	"github.com/formancehq/operator/internal/core"
 	"github.com/formancehq/operator/internal/resources/settings"
 	"github.com/google/uuid"

--- a/components/operator/internal/tests/orchestration_controller_test.go
+++ b/components/operator/internal/tests/orchestration_controller_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"fmt"
+
 	"github.com/formancehq/operator/internal/resources/settings"
 	. "github.com/formancehq/operator/internal/tests/internal"
 	"github.com/google/uuid"

--- a/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-audit.yaml
+++ b/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-audit.yaml
@@ -28,7 +28,9 @@
 	handle /api/ledger* {
 		uri strip_prefix /api/ledger
         import cors
-		reverse_proxy ledger:8080
+		reverse_proxy ledger:8080 {
+            header_up Host {upstream_hostport}
+        }
     }
 
 	handle /versions {

--- a/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-another-service.yaml
+++ b/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-another-service.yaml
@@ -29,17 +29,23 @@
 		method POST
 		uri strip_prefix /api/another
         import cors
-		reverse_proxy another:8080
+		reverse_proxy another:8080 {
+            header_up Host {upstream_hostport}
+        }
     }
 	handle /api/another* {
 		uri strip_prefix /api/another
         import cors
-		reverse_proxy another:8080
+		reverse_proxy another:8080 {
+            header_up Host {upstream_hostport}
+        }
     }
 	handle /api/ledger* {
 		uri strip_prefix /api/ledger
         import cors
-		reverse_proxy ledger:8080
+		reverse_proxy ledger:8080 {
+            header_up Host {upstream_hostport}
+        }
     }
 
 	handle /versions {

--- a/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-auth.yaml
+++ b/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-and-auth.yaml
@@ -36,13 +36,17 @@
 	handle /api/auth* {
 		uri strip_prefix /api/auth
         import cors
-		reverse_proxy auth:8080
+		reverse_proxy auth:8080 {
+            header_up Host {upstream_hostport}
+        }
     }
 	handle /api/ledger* {
 		uri strip_prefix /api/ledger
         import cors
         import auth ledger
-		reverse_proxy ledger:8080
+		reverse_proxy ledger:8080 {
+            header_up Host {upstream_hostport}
+        }
     }
 
 	handle /versions {

--- a/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-only.yaml
+++ b/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-ledger-only.yaml
@@ -28,7 +28,9 @@
 	handle /api/ledger* {
 		uri strip_prefix /api/ledger
         import cors
-		reverse_proxy ledger:8080
+		reverse_proxy ledger:8080 {
+            header_up Host {upstream_hostport}
+        }
     }
 
 	handle /versions {

--- a/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-opentelemetry.yaml
+++ b/components/operator/internal/tests/testdata/resources/gateway-controller/configmap-with-opentelemetry.yaml
@@ -31,7 +31,9 @@
 	handle /api/ledger* {
 		uri strip_prefix /api/ledger
         import cors
-		reverse_proxy ledger:8080
+		reverse_proxy ledger:8080 {
+            header_up Host {upstream_hostport}
+        }
     }
 
 	handle /versions {


### PR DESCRIPTION
Add `header_up Host {upstream_hostport}` to reverse_proxy directives in Caddyfile templates to ensure correct Host header is passed to upstream services.