### PR TITLE
fix(api): fix polling duration wrongfully marshalled

### DIFF
--- a/components/payments/cmd/connectors/internal/api/connector.go
+++ b/components/payments/cmd/connectors/internal/api/connector.go
@@ -13,7 +13,6 @@ import (
 	"github.com/formancehq/payments/internal/otel"
 	"github.com/formancehq/stack/libs/go-libs/api"
 	"github.com/formancehq/stack/libs/go-libs/bun/bunpaginate"
-	"github.com/formancehq/stack/libs/go-libs/logging"
 	"github.com/formancehq/stack/libs/go-libs/pointer"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -131,24 +130,6 @@ func readConfig[Config models.ConnectorConfigObject](
 		// inject provider into config json so SDK can distinguish between config types
 		caser := cases.Title(language.English)
 		m["provider"] = caser.String(connectorID.Provider.String())
-
-		// rewrite pollingDuration struct as a string to match API spec
-		pollingPeriod, ok := m["pollingPeriod"].(map[string]interface{})
-		if ok {
-			duration, found := pollingPeriod["duration"]
-			if found {
-				var ns int64
-				switch v := duration.(type) {
-				case int64:
-					ns = v
-				case float64:
-					ns = int64(v)
-				default:
-					logging.FromContext(ctx).Debugf("pollingPeriod.Duration was of an unexpected type: %T", v)
-				}
-				m["pollingPeriod"] = time.Duration(ns).String()
-			}
-		}
 
 		result, err := json.Marshal(m)
 		if err != nil {

--- a/components/payments/cmd/connectors/internal/connectors/duration.go
+++ b/components/payments/cmd/connectors/internal/connectors/duration.go
@@ -10,7 +10,7 @@ type Duration struct {
 	time.Duration `json:"duration"`
 }
 
-func (d *Duration) MarshalJSON() ([]byte, error) {
+func (d Duration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.Duration.String())
 }
 


### PR DESCRIPTION
# Description

## Context

One of our customers has some problems when getting the config of the Atlar connector. After investigation, it was the custom duration struct that was failing to be marshalled before being sent to the client. A fix has been done a few weeks ago to fix the "pollingPeriod" custom duration in the configs, but Atlar has one more custom duration struct.

## Solution

After investigation, it seems that the custom duration struct was not implementing correctly the Marshal interface, which was the cause of the wrong json sent through the api. Fixing this implementation allows us also to remove the api fix we've made.

Fixes PMNT-109