### PR TITLE
chore(speakeasy): Avoid publishing twice and fix base openAPI

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -14,7 +14,6 @@ workflow:
     sources:
         stacks-source:
             inputs:
-                - location: ./releases/base.yaml
                 - location: ./components/auth.openapi.yaml
                   modelNamespace: auth
                 - location: ./components/gateway.openapi.yaml
@@ -33,6 +32,7 @@ workflow:
                   modelNamespace: orchestration
                 - location: ./components/reconciliation.openapi.yaml
                   modelNamespace: reconciliation
+                - location: ./releases/base.yaml
             overlays:
                 - location: ./releases/overlays/shared.overlay.yaml
             output: ./releases/build/generate.json

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,6 @@ speakeasyVersion: latest
 sources:
     stacks-source:
         inputs:
-            - location: ./releases/base.yaml
             - location: ./components/auth.openapi.yaml
               modelNamespace: auth
             - location: ./components/gateway.openapi.yaml
@@ -22,6 +21,7 @@ sources:
               modelNamespace: orchestration
             - location: ./components/reconciliation.openapi.yaml
               modelNamespace: reconciliation
+            - location: ./releases/base.yaml
         overlays:
             - location: ./releases/overlays/shared.overlay.yaml
         output: ./releases/build/generate.json

--- a/Justfile
+++ b/Justfile
@@ -36,7 +36,7 @@ prepend-paths: download-specs
 # Build the merged OpenAPI spec using Speakeasy
 build-openapi version="v0.0.0": prepend-paths
     mkdir -p releases/build
-    speakeasy run -s all
+    speakeasy run -s all --skip-upload-spec
     cd releases && sed -i'' -e 's/SDK_VERSION/{{version}}/g' build/generate.json
 
 # Generate event schemas


### PR DESCRIPTION
When putting the base.yaml first, it is overwritten afterwards and ends up with Reconciliation API as title (and without contact, logo...)

Also added --skip-upload-spec because it is only used then to release the artifact.