### PR TITLE
feat: Automate changelog generation for releases

### DIFF
--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -18,58 +18,20 @@ ORCHESTRATION_VERSION=$(extract_version "ORCHESTRATION_VERSION")
 RECONCILIATION_VERSION=$(extract_version "RECONCILIATION_VERSION")
 GATEWAY_VERSION=$(extract_version "GATEWAY_VERSION")
 
-get_release_notes() {
-  local repo=$1
-  local version=$2
-  local notes
-  notes=$(gh api "repos/formancehq/${repo}/releases/tags/${version}" --jq '.body' 2>/dev/null) || true
-  if [ -z "$notes" ] || [ "$notes" = "null" ]; then
-    echo "_No release notes available._"
-  else
-    echo "$notes"
-  fi
-}
-
 {
   echo "## Component Versions"
   echo ""
-  echo "| Component | Version |"
-  echo "|-----------|---------|"
-  echo "| Ledger | [\`${LEDGER_VERSION}\`](https://github.com/formancehq/ledger/releases/tag/${LEDGER_VERSION}) |"
-  echo "| Payments | [\`${PAYMENTS_VERSION}\`](https://github.com/formancehq/payments/releases/tag/${PAYMENTS_VERSION}) |"
-  echo "| Wallets | [\`${WALLETS_VERSION}\`](https://github.com/formancehq/wallets/releases/tag/${WALLETS_VERSION}) |"
-  echo "| Webhooks | [\`${WEBHOOKS_VERSION}\`](https://github.com/formancehq/webhooks/releases/tag/${WEBHOOKS_VERSION}) |"
-  echo "| Auth | [\`${AUTH_VERSION}\`](https://github.com/formancehq/auth/releases/tag/${AUTH_VERSION}) |"
-  echo "| Search | [\`${SEARCH_VERSION}\`](https://github.com/formancehq/search/releases/tag/${SEARCH_VERSION}) |"
-  echo "| Orchestration | [\`${ORCHESTRATION_VERSION}\`](https://github.com/formancehq/flows/releases/tag/${ORCHESTRATION_VERSION}) |"
-  echo "| Reconciliation | [\`${RECONCILIATION_VERSION}\`](https://github.com/formancehq/reconciliation/releases/tag/${RECONCILIATION_VERSION}) |"
-  echo "| Gateway | [\`${GATEWAY_VERSION}\`](https://github.com/formancehq/gateway/releases/tag/${GATEWAY_VERSION}) |"
-  echo ""
-  echo "---"
-  echo ""
-
-  declare -a COMPONENTS=(
-    "ledger:Ledger:${LEDGER_VERSION}"
-    "payments:Payments:${PAYMENTS_VERSION}"
-    "wallets:Wallets:${WALLETS_VERSION}"
-    "webhooks:Webhooks:${WEBHOOKS_VERSION}"
-    "auth:Auth:${AUTH_VERSION}"
-    "search:Search:${SEARCH_VERSION}"
-    "flows:Orchestration:${ORCHESTRATION_VERSION}"
-    "reconciliation:Reconciliation:${RECONCILIATION_VERSION}"
-    "gateway:Gateway:${GATEWAY_VERSION}"
-  )
-
-  for entry in "${COMPONENTS[@]}"; do
-    IFS=':' read -r repo label version <<< "$entry"
-    notes=$(get_release_notes "$repo" "$version")
-    echo "## ${label} \`${version}\`"
-    echo ""
-    echo "${notes}"
-    echo ""
-    echo "---"
-    echo ""
-  done
+  echo "| Component | Version | Changelog |"
+  echo "|-----------|---------|-----------|"
+  echo "| Ledger | \`${LEDGER_VERSION}\` | [Release notes](https://github.com/formancehq/ledger/releases/tag/${LEDGER_VERSION}) |"
+  echo "| Payments | \`${PAYMENTS_VERSION}\` | [Release notes](https://github.com/formancehq/payments/releases/tag/${PAYMENTS_VERSION}) |"
+  echo "| Wallets | \`${WALLETS_VERSION}\` | [Release notes](https://github.com/formancehq/wallets/releases/tag/${WALLETS_VERSION}) |"
+  echo "| Webhooks | \`${WEBHOOKS_VERSION}\` | [Release notes](https://github.com/formancehq/webhooks/releases/tag/${WEBHOOKS_VERSION}) |"
+  echo "| Auth | \`${AUTH_VERSION}\` | [Release notes](https://github.com/formancehq/auth/releases/tag/${AUTH_VERSION}) |"
+  echo "| Search | \`${SEARCH_VERSION}\` | [Release notes](https://github.com/formancehq/search/releases/tag/${SEARCH_VERSION}) |"
+  echo "| Orchestration | \`${ORCHESTRATION_VERSION}\` | [Release notes](https://github.com/formancehq/flows/releases/tag/${ORCHESTRATION_VERSION}) |"
+  echo "| Reconciliation | \`${RECONCILIATION_VERSION}\` | [Release notes](https://github.com/formancehq/reconciliation/releases/tag/${RECONCILIATION_VERSION}) |"
+  echo "| Gateway | \`${GATEWAY_VERSION}\` | [Release notes](https://github.com/formancehq/gateway/releases/tag/${GATEWAY_VERSION}) |"
 } > "$OUTPUT"
 
 echo "Changelog written to $OUTPUT"

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JUSTFILE="${JUSTFILE_PATH:-Justfile}"
+OUTPUT="${OUTPUT_FILE:-/tmp/changelog.md}"
+
+extract_version() {
+  grep "^${1}" "$JUSTFILE" | sed 's/.*"\(.*\)".*/\1/'
+}
+
+LEDGER_VERSION=$(extract_version "LEDGER_VERSION")
+PAYMENTS_VERSION=$(extract_version "PAYMENTS_VERSION")
+WALLETS_VERSION=$(extract_version "WALLETS_VERSION")
+WEBHOOKS_VERSION=$(extract_version "WEBHOOKS_VERSION")
+AUTH_VERSION=$(extract_version "AUTH_VERSION")
+SEARCH_VERSION=$(extract_version "SEARCH_VERSION")
+ORCHESTRATION_VERSION=$(extract_version "ORCHESTRATION_VERSION")
+RECONCILIATION_VERSION=$(extract_version "RECONCILIATION_VERSION")
+GATEWAY_VERSION=$(extract_version "GATEWAY_VERSION")
+
+get_release_notes() {
+  local repo=$1
+  local version=$2
+  local notes
+  notes=$(gh api "repos/formancehq/${repo}/releases/tags/${version}" --jq '.body' 2>/dev/null) || true
+  if [ -z "$notes" ] || [ "$notes" = "null" ]; then
+    echo "_No release notes available._"
+  else
+    echo "$notes"
+  fi
+}
+
+{
+  echo "## Component Versions"
+  echo ""
+  echo "| Component | Version |"
+  echo "|-----------|---------|"
+  echo "| Ledger | [\`${LEDGER_VERSION}\`](https://github.com/formancehq/ledger/releases/tag/${LEDGER_VERSION}) |"
+  echo "| Payments | [\`${PAYMENTS_VERSION}\`](https://github.com/formancehq/payments/releases/tag/${PAYMENTS_VERSION}) |"
+  echo "| Wallets | [\`${WALLETS_VERSION}\`](https://github.com/formancehq/wallets/releases/tag/${WALLETS_VERSION}) |"
+  echo "| Webhooks | [\`${WEBHOOKS_VERSION}\`](https://github.com/formancehq/webhooks/releases/tag/${WEBHOOKS_VERSION}) |"
+  echo "| Auth | [\`${AUTH_VERSION}\`](https://github.com/formancehq/auth/releases/tag/${AUTH_VERSION}) |"
+  echo "| Search | [\`${SEARCH_VERSION}\`](https://github.com/formancehq/search/releases/tag/${SEARCH_VERSION}) |"
+  echo "| Orchestration | [\`${ORCHESTRATION_VERSION}\`](https://github.com/formancehq/flows/releases/tag/${ORCHESTRATION_VERSION}) |"
+  echo "| Reconciliation | [\`${RECONCILIATION_VERSION}\`](https://github.com/formancehq/reconciliation/releases/tag/${RECONCILIATION_VERSION}) |"
+  echo "| Gateway | [\`${GATEWAY_VERSION}\`](https://github.com/formancehq/gateway/releases/tag/${GATEWAY_VERSION}) |"
+  echo ""
+  echo "---"
+  echo ""
+
+  declare -a COMPONENTS=(
+    "ledger:Ledger:${LEDGER_VERSION}"
+    "payments:Payments:${PAYMENTS_VERSION}"
+    "wallets:Wallets:${WALLETS_VERSION}"
+    "webhooks:Webhooks:${WEBHOOKS_VERSION}"
+    "auth:Auth:${AUTH_VERSION}"
+    "search:Search:${SEARCH_VERSION}"
+    "flows:Orchestration:${ORCHESTRATION_VERSION}"
+    "reconciliation:Reconciliation:${RECONCILIATION_VERSION}"
+    "gateway:Gateway:${GATEWAY_VERSION}"
+  )
+
+  for entry in "${COMPONENTS[@]}"; do
+    IFS=':' read -r repo label version <<< "$entry"
+    notes=$(get_release_notes "$repo" "$version")
+    echo "## ${label} \`${version}\`"
+    echo ""
+    echo "${notes}"
+    echo ""
+    echo "---"
+    echo ""
+  done
+} > "$OUTPUT"
+
+echo "Changelog written to $OUTPUT"

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Generate changelog
         run: bash .github/scripts/generate-changelog.sh
         env:
-          GH_TOKEN: ${{ secrets.NUMARY_GITHUB_TOKEN }}
           OUTPUT_FILE: /tmp/changelog.md
       - name: Create Release
         run: gh release create ${{github.ref_name}} --notes-file /tmp/changelog.md

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,8 +18,13 @@ jobs:
         run: nix develop --impure --command just build ${{github.ref_name}}
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+      - name: Generate changelog
+        run: bash .github/scripts/generate-changelog.sh
+        env:
+          GH_TOKEN: ${{ secrets.NUMARY_GITHUB_TOKEN }}
+          OUTPUT_FILE: /tmp/changelog.md
       - name: Create Release
-        run: gh release create ${{github.ref_name}} --generate-notes
+        run: gh release create ${{github.ref_name}} --notes-file /tmp/changelog.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add the OpenAPI file to the release assets


### PR DESCRIPTION
## Summary
This PR adds automated changelog generation to the release workflow by extracting component versions from the Justfile and generating a formatted markdown table with links to each component's release notes.

## Key Changes
- **New script**: Added `.github/scripts/generate-changelog.sh` that:
  - Extracts version numbers for 9 components (Ledger, Payments, Wallets, Webhooks, Auth, Search, Orchestration, Reconciliation, Gateway) from the Justfile
  - Generates a markdown table with component names, versions, and links to their respective GitHub release notes
  - Outputs the changelog to a configurable file location (default: `/tmp/changelog.md`)

- **Updated workflow**: Modified `.github/workflows/releases.yml` to:
  - Add a new "Generate changelog" step that runs the script before creating the release
  - Change the release creation command from `--generate-notes` to `--notes-file /tmp/changelog.md` to use the generated changelog instead of GitHub's auto-generated notes

## Implementation Details
- The script uses bash with strict error handling (`set -euo pipefail`)
- Version extraction is done via grep and sed pattern matching on the Justfile
- The output is a well-formatted markdown table with inline code formatting for versions and clickable links to each component's release notes on GitHub
- The script supports environment variable overrides for both the Justfile path and output file location

https://claude.ai/code/session_014AvKoA5CKttZo2e5pKEf5f