### PR TITLE
fix: strip component-level servers blocks before OpenAPI merge

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -21,7 +21,7 @@ sources:
 
 build-final-spec:
     FROM core+base-image
-    RUN apk update && apk add yarn nodejs npm jq
+    RUN apk update && apk add yarn nodejs npm jq yq
     WORKDIR /src/releases
     COPY releases/package.* .
     RUN npm install
@@ -41,6 +41,9 @@ build-final-spec:
     COPY (wallets+openapi/openapi.yaml) /src/ee/wallets/
     COPY (reconciliation+openapi/openapi.yaml) /src/ee/reconciliation/
     COPY (orchestration+openapi/openapi.yaml) /src/ee/orchestration/
+
+    # Strip component-level servers blocks so only base.yaml servers survive the merge
+    RUN find /src/components /src/ee -name 'openapi.yaml' -exec yq -i 'del(.servers)' {} \;
 
     RUN npm run build
     RUN jq -s '.[0] * .[1]' build/generate.json openapi-overlay.json > build/latest.json


### PR DESCRIPTION
## Summary
- Component specs declare their own `servers` block (`http://localhost:8080/`) which conflicts with `base.yaml` during the openapi-merge
- This causes all operations to inherit an operation-level `servers` block while the root-level servers from `base.yaml` are lost
- Adds a `yq del(.servers)` step in the Earthfile after copying component specs and before the merge, using `find` so any new component is automatically handled

## Test plan
- [ ] Run `earthly +build-final-spec` and verify root-level servers from `base.yaml` are present and no operation has an operation-level `servers` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)