### PR TITLE
fix: strip component-level servers blocks before OpenAPI merge

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.768.2
 sources:
     stacks-source:
         sourceNamespace: stacks-source
-        sourceRevisionDigest: sha256:8e24b24261d6d29c5d7c91f8756cb9e47d21d0a8297e6dbe2acf706410a84747
-        sourceBlobDigest: sha256:d6ef9edab168ce242ff12833d07c2be33b42d4e66fa4159f5a4f12bc5a5543b3
+        sourceRevisionDigest: sha256:45c10ea1febd1e251f079e49a7b0517f74e6b8b5416e12daf850cd551347688a
+        sourceBlobDigest: sha256:c4a8e0d72bb2f338b2195495b4cd51647e3cbb8f4bf161a3b8370eb33e2511be
         tags:
             - latest
             - SDK_VERSION

--- a/Justfile
+++ b/Justfile
@@ -33,8 +33,12 @@ prepend-paths: download-specs
     yq -i '.paths |= (to_entries | map(select(.key == "/*").key = "/api/orchestration" + .key) | from_entries)' components/orchestration.openapi.yaml
     yq -i '.paths |= (to_entries | map(select(.key == "/*").key = "/api/reconciliation" + .key) | from_entries)' components/reconciliation.openapi.yaml
 
+# Strip component-level servers blocks so only base.yaml servers survive the merge
+strip-servers: prepend-paths
+    for f in components/*.openapi.yaml; do yq -i 'del(.servers)' "$f"; done
+
 # Build the merged OpenAPI spec using Speakeasy
-build-openapi version="v0.0.0": prepend-paths
+build-openapi version="v0.0.0": strip-servers
     mkdir -p releases/build
     speakeasy run -s all
     cd releases && sed -i'' -e 's/SDK_VERSION/{{version}}/g' build/generate.json


### PR DESCRIPTION
## Summary
- Component specs declare their own `servers` block (`http://localhost:8080/`) which conflicts with `base.yaml` during the Speakeasy merge
- This causes all 249 operations to inherit an operation-level `servers` block while the root-level servers from `base.yaml` are lost
- Adds a `strip-servers` step in the Justfile that removes `servers` from all component specs before merge, using a glob so any new component is automatically handled

## Test plan
- [x] Ran `just build-openapi` — root-level servers from `base.yaml` now present, 0/249 operations have operation-level servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)