### PR TITLE
chore: update stack component releases

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.790.1
+speakeasyVersion: 1.791.1
 sources:
     stacks-source:
         sourceNamespace: stacks-source
-        sourceRevisionDigest: sha256:29bcc13579975f77dd3c03533a712fe17b643af1c516b86f4a499f42856f32b7
-        sourceBlobDigest: sha256:78f47f273db89d72d6e74f2f284483f751ee4449fb7f46efadc4525882a6f955
+        sourceRevisionDigest: sha256:6c3c89b43c0d8a0f2fecf34ff86937fc61d691088dc23ac99c12b455daefb396
+        sourceBlobDigest: sha256:13724b4f3a2771b9912c10beaaecd2e73b3ca8203d7f7b40cadaca7014f45994
         tags:
             - latest
             - SDK_VERSION

--- a/Justfile
+++ b/Justfile
@@ -1,20 +1,20 @@
 # Component versions
-LEDGER_VERSION := "v2.4.6"
+LEDGER_VERSION := "v2.4.12"
 PAYMENTS_VERSION := "v3.4.0"
-WALLETS_VERSION := "v2.1.5"
-WEBHOOKS_VERSION := "v2.3.2"
-AUTH_VERSION := "v2.4.3"
+WALLETS_VERSION := "v2.2.0"
+WEBHOOKS_VERSION := "v2.5.0"
+AUTH_VERSION := "v2.5.0"
 SEARCH_VERSION := "v2.1.0"
 ORCHESTRATION_VERSION := "v2.6.0"
-RECONCILIATION_VERSION := "v2.2.2"
-GATEWAY_VERSION := "v2.2.0"
+RECONCILIATION_VERSION := "v2.4.0"
+GATEWAY_VERSION := "v2.3.1"
 
 # Download all component OpenAPI specs from GitHub releases
 download-specs:
     mkdir -p components
     wget -q https://github.com/formancehq/ledger/releases/download/{{ LEDGER_VERSION }}/openapi.yaml -O components/ledger.openapi.yaml
     wget -q https://github.com/formancehq/payments/releases/download/{{ PAYMENTS_VERSION }}/openapi.yaml -O components/payments.openapi.yaml
-    wget -q https://github.com/formancehq/gateway/releases/download/{{ GATEWAY_VERSION }}/openapi.yaml -O components/gateway.openapi.yaml
+    wget -q https://raw.githubusercontent.com/formancehq/gateway/{{ GATEWAY_VERSION }}/openapi.yaml -O components/gateway.openapi.yaml
     wget -q https://github.com/formancehq/auth/releases/download/{{ AUTH_VERSION }}/openapi.yaml -O components/auth.openapi.yaml
     wget -q https://github.com/formancehq/search/releases/download/{{ SEARCH_VERSION }}/openapi.yaml -O components/search.openapi.yaml
     wget -q https://github.com/formancehq/webhooks/releases/download/{{ WEBHOOKS_VERSION }}/openapi.yaml -O components/webhooks.openapi.yaml


### PR DESCRIPTION
## Summary

Update the Stack v3.2 component inputs to their latest stable releases:

- Ledger: `v2.4.6` → `v2.4.12`
- Wallets: `v2.1.5` → `v2.2.0`
- Webhooks: `v2.3.2` → `v2.5.0`
- Auth: `v2.4.3` → `v2.5.0`
- Reconciliation: `v2.2.2` → `v2.4.0`
- Gateway: `v2.2.0` → `v2.3.1`

Payments `v3.4.0`, Search `v2.1.0`, and Flows `v2.6.0` were already current.

## Gateway OpenAPI source

Gateway `v2.3.1` is a published stable release, but its GitHub release does not include the `openapi.yaml` asset that older releases exposed. The tagged source still contains the file, so the Gateway download now uses the immutable version tag on `raw.githubusercontent.com`.

## Impact

The next Stack v3.2 release will merge and publish the OpenAPI definitions from the current stable service releases.

## Validation

- checked all nine component versions against the latest non-draft, non-prerelease GitHub releases
- verified every selected version exposes an OpenAPI document through either its release asset or, for Gateway, its immutable release tag
- ran `nix develop --impure --command just pre-commit`
- Speakeasy merged all 10 schemas and reported 0 OpenAPI errors
- regenerated event schemas
- regenerated `.speakeasy/workflow.lock`
- `git diff --check`

Speakeasy reported existing validation warnings/hints and a non-fatal cross-device warning while attempting to promote its downloaded CLI binary; generation completed successfully.
