### PR TITLE
feat(events): add reconciliation alert events

### DIFF
--- a/events/events_test.go
+++ b/events/events_test.go
@@ -1,0 +1,59 @@
+package events
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestReconciliationAlertEventSchemas(t *testing.T) {
+	eventTypes := map[string]string{
+		"OPENED_ALERT":       "fail",
+		"UPDATED_ALERT":      "fail",
+		"ACKNOWLEDGED_ALERT": "ack",
+		"RESOLVED_ALERT":     "resolve",
+		"ACCEPTED_ALERT":     "accept",
+		"REOPENED_ALERT":     "fail",
+		"SNOOZED_ALERT":      "snooze",
+		"UNSNOOZED_ALERT":    "unsnooze",
+	}
+
+	for eventName, alertEventType := range eventTypes {
+		t.Run(eventName, func(t *testing.T) {
+			event := fmt.Sprintf(`{
+				"app": "reconciliation",
+				"version": "v1",
+				"date": "2026-08-03T12:00:00Z",
+				"type": %q,
+				"payload": {
+					"alert": {
+						"id": "11111111-1111-1111-1111-111111111111",
+						"ruleID": "22222222-2222-2222-2222-222222222222",
+						"fingerprint": "asset:USD/2",
+						"periodID": "2026-08",
+						"status": "OPEN",
+						"severity": "high",
+						"firstSeenAt": "2026-08-03T12:00:00Z",
+						"lastSeenAt": "2026-08-03T12:00:00Z",
+						"occurrenceCount": 1,
+						"lastEvaluationID": "33333333-3333-3333-3333-333333333333",
+						"createdAt": "2026-08-03T12:00:00Z",
+						"updatedAt": "2026-08-03T12:00:00Z"
+					},
+					"event": {
+						"id": "44444444-4444-4444-4444-444444444444",
+						"alertID": "11111111-1111-1111-1111-111111111111",
+						"type": %q,
+						"newStatus": "OPEN",
+						"notify": true,
+						"at": "2026-08-03T12:00:00Z",
+						"createdAt": "2026-08-03T12:00:00Z"
+					}
+				}
+			}`, eventName, alertEventType)
+
+			if err := Check([]byte(event), "reconciliation", eventName); err != nil {
+				t.Fatalf("validate event: %v", err)
+			}
+		})
+	}
+}

--- a/events/generated/all.json
+++ b/events/generated/all.json
@@ -2745,5 +2745,2138 @@
         ]
       }
     }
+  },
+  "reconciliation": {
+    "v2.4.0": {
+      "ACCEPTED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "accept"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "ACKNOWLEDGED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "ack"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "OPENED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fail"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "REOPENED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fail"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "RESOLVED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "pass",
+                      "resolve"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "SNOOZED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "snooze"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "UNSNOOZED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "unsnooze"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "UPDATED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fail"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      }
+    }
   }
 }

--- a/events/generated/reconciliation/v2.4.0/ACCEPTED_ALERT.json
+++ b/events/generated/reconciliation/v2.4.0/ACCEPTED_ALERT.json
@@ -1,0 +1,266 @@
+{
+  "type": "object",
+  "properties": {
+    "app": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "alert",
+        "event"
+      ],
+      "properties": {
+        "alert": {
+          "type": "object",
+          "required": [
+            "id",
+            "ruleID",
+            "fingerprint",
+            "periodID",
+            "status",
+            "severity",
+            "firstSeenAt",
+            "lastSeenAt",
+            "occurrenceCount",
+            "lastEvaluationID",
+            "createdAt",
+            "updatedAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "ruleID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "fingerprint": {
+              "type": "string"
+            },
+            "periodID": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "severity": {
+              "type": "string",
+              "enum": [
+                "info",
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
+            },
+            "firstSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "lastSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "occurrenceCount": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "lastEvaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "ack": {
+              "type": "object",
+              "required": [
+                "by",
+                "at"
+              ],
+              "properties": {
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "resolution": {
+              "type": "object",
+              "required": [
+                "kind",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "fixed_by_booking",
+                    "accepted_by_business"
+                  ]
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "transactionRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "evidenceSnapshot": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "snooze": {
+              "type": "object",
+              "required": [
+                "until",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "until": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updatedAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "event": {
+          "type": "object",
+          "required": [
+            "id",
+            "alertID",
+            "type",
+            "newStatus",
+            "notify",
+            "at",
+            "createdAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "alertID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "accept"
+              ]
+            },
+            "prevStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "newStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "payload": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "date",
+    "app",
+    "version",
+    "type",
+    "payload"
+  ]
+}

--- a/events/generated/reconciliation/v2.4.0/ACKNOWLEDGED_ALERT.json
+++ b/events/generated/reconciliation/v2.4.0/ACKNOWLEDGED_ALERT.json
@@ -1,0 +1,266 @@
+{
+  "type": "object",
+  "properties": {
+    "app": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "alert",
+        "event"
+      ],
+      "properties": {
+        "alert": {
+          "type": "object",
+          "required": [
+            "id",
+            "ruleID",
+            "fingerprint",
+            "periodID",
+            "status",
+            "severity",
+            "firstSeenAt",
+            "lastSeenAt",
+            "occurrenceCount",
+            "lastEvaluationID",
+            "createdAt",
+            "updatedAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "ruleID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "fingerprint": {
+              "type": "string"
+            },
+            "periodID": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "severity": {
+              "type": "string",
+              "enum": [
+                "info",
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
+            },
+            "firstSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "lastSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "occurrenceCount": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "lastEvaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "ack": {
+              "type": "object",
+              "required": [
+                "by",
+                "at"
+              ],
+              "properties": {
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "resolution": {
+              "type": "object",
+              "required": [
+                "kind",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "fixed_by_booking",
+                    "accepted_by_business"
+                  ]
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "transactionRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "evidenceSnapshot": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "snooze": {
+              "type": "object",
+              "required": [
+                "until",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "until": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updatedAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "event": {
+          "type": "object",
+          "required": [
+            "id",
+            "alertID",
+            "type",
+            "newStatus",
+            "notify",
+            "at",
+            "createdAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "alertID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "ack"
+              ]
+            },
+            "prevStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "newStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "payload": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "date",
+    "app",
+    "version",
+    "type",
+    "payload"
+  ]
+}

--- a/events/generated/reconciliation/v2.4.0/OPENED_ALERT.json
+++ b/events/generated/reconciliation/v2.4.0/OPENED_ALERT.json
@@ -1,0 +1,266 @@
+{
+  "type": "object",
+  "properties": {
+    "app": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "alert",
+        "event"
+      ],
+      "properties": {
+        "alert": {
+          "type": "object",
+          "required": [
+            "id",
+            "ruleID",
+            "fingerprint",
+            "periodID",
+            "status",
+            "severity",
+            "firstSeenAt",
+            "lastSeenAt",
+            "occurrenceCount",
+            "lastEvaluationID",
+            "createdAt",
+            "updatedAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "ruleID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "fingerprint": {
+              "type": "string"
+            },
+            "periodID": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "severity": {
+              "type": "string",
+              "enum": [
+                "info",
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
+            },
+            "firstSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "lastSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "occurrenceCount": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "lastEvaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "ack": {
+              "type": "object",
+              "required": [
+                "by",
+                "at"
+              ],
+              "properties": {
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "resolution": {
+              "type": "object",
+              "required": [
+                "kind",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "fixed_by_booking",
+                    "accepted_by_business"
+                  ]
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "transactionRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "evidenceSnapshot": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "snooze": {
+              "type": "object",
+              "required": [
+                "until",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "until": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updatedAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "event": {
+          "type": "object",
+          "required": [
+            "id",
+            "alertID",
+            "type",
+            "newStatus",
+            "notify",
+            "at",
+            "createdAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "alertID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "fail"
+              ]
+            },
+            "prevStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "newStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "payload": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "date",
+    "app",
+    "version",
+    "type",
+    "payload"
+  ]
+}

--- a/events/generated/reconciliation/v2.4.0/REOPENED_ALERT.json
+++ b/events/generated/reconciliation/v2.4.0/REOPENED_ALERT.json
@@ -1,0 +1,266 @@
+{
+  "type": "object",
+  "properties": {
+    "app": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "alert",
+        "event"
+      ],
+      "properties": {
+        "alert": {
+          "type": "object",
+          "required": [
+            "id",
+            "ruleID",
+            "fingerprint",
+            "periodID",
+            "status",
+            "severity",
+            "firstSeenAt",
+            "lastSeenAt",
+            "occurrenceCount",
+            "lastEvaluationID",
+            "createdAt",
+            "updatedAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "ruleID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "fingerprint": {
+              "type": "string"
+            },
+            "periodID": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "severity": {
+              "type": "string",
+              "enum": [
+                "info",
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
+            },
+            "firstSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "lastSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "occurrenceCount": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "lastEvaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "ack": {
+              "type": "object",
+              "required": [
+                "by",
+                "at"
+              ],
+              "properties": {
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "resolution": {
+              "type": "object",
+              "required": [
+                "kind",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "fixed_by_booking",
+                    "accepted_by_business"
+                  ]
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "transactionRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "evidenceSnapshot": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "snooze": {
+              "type": "object",
+              "required": [
+                "until",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "until": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updatedAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "event": {
+          "type": "object",
+          "required": [
+            "id",
+            "alertID",
+            "type",
+            "newStatus",
+            "notify",
+            "at",
+            "createdAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "alertID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "fail"
+              ]
+            },
+            "prevStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "newStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "payload": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "date",
+    "app",
+    "version",
+    "type",
+    "payload"
+  ]
+}

--- a/events/generated/reconciliation/v2.4.0/RESOLVED_ALERT.json
+++ b/events/generated/reconciliation/v2.4.0/RESOLVED_ALERT.json
@@ -1,0 +1,267 @@
+{
+  "type": "object",
+  "properties": {
+    "app": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "alert",
+        "event"
+      ],
+      "properties": {
+        "alert": {
+          "type": "object",
+          "required": [
+            "id",
+            "ruleID",
+            "fingerprint",
+            "periodID",
+            "status",
+            "severity",
+            "firstSeenAt",
+            "lastSeenAt",
+            "occurrenceCount",
+            "lastEvaluationID",
+            "createdAt",
+            "updatedAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "ruleID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "fingerprint": {
+              "type": "string"
+            },
+            "periodID": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "severity": {
+              "type": "string",
+              "enum": [
+                "info",
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
+            },
+            "firstSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "lastSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "occurrenceCount": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "lastEvaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "ack": {
+              "type": "object",
+              "required": [
+                "by",
+                "at"
+              ],
+              "properties": {
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "resolution": {
+              "type": "object",
+              "required": [
+                "kind",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "fixed_by_booking",
+                    "accepted_by_business"
+                  ]
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "transactionRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "evidenceSnapshot": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "snooze": {
+              "type": "object",
+              "required": [
+                "until",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "until": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updatedAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "event": {
+          "type": "object",
+          "required": [
+            "id",
+            "alertID",
+            "type",
+            "newStatus",
+            "notify",
+            "at",
+            "createdAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "alertID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "pass",
+                "resolve"
+              ]
+            },
+            "prevStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "newStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "payload": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "date",
+    "app",
+    "version",
+    "type",
+    "payload"
+  ]
+}

--- a/events/generated/reconciliation/v2.4.0/SNOOZED_ALERT.json
+++ b/events/generated/reconciliation/v2.4.0/SNOOZED_ALERT.json
@@ -1,0 +1,266 @@
+{
+  "type": "object",
+  "properties": {
+    "app": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "alert",
+        "event"
+      ],
+      "properties": {
+        "alert": {
+          "type": "object",
+          "required": [
+            "id",
+            "ruleID",
+            "fingerprint",
+            "periodID",
+            "status",
+            "severity",
+            "firstSeenAt",
+            "lastSeenAt",
+            "occurrenceCount",
+            "lastEvaluationID",
+            "createdAt",
+            "updatedAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "ruleID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "fingerprint": {
+              "type": "string"
+            },
+            "periodID": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "severity": {
+              "type": "string",
+              "enum": [
+                "info",
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
+            },
+            "firstSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "lastSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "occurrenceCount": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "lastEvaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "ack": {
+              "type": "object",
+              "required": [
+                "by",
+                "at"
+              ],
+              "properties": {
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "resolution": {
+              "type": "object",
+              "required": [
+                "kind",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "fixed_by_booking",
+                    "accepted_by_business"
+                  ]
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "transactionRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "evidenceSnapshot": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "snooze": {
+              "type": "object",
+              "required": [
+                "until",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "until": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updatedAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "event": {
+          "type": "object",
+          "required": [
+            "id",
+            "alertID",
+            "type",
+            "newStatus",
+            "notify",
+            "at",
+            "createdAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "alertID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "snooze"
+              ]
+            },
+            "prevStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "newStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "payload": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "date",
+    "app",
+    "version",
+    "type",
+    "payload"
+  ]
+}

--- a/events/generated/reconciliation/v2.4.0/UNSNOOZED_ALERT.json
+++ b/events/generated/reconciliation/v2.4.0/UNSNOOZED_ALERT.json
@@ -1,0 +1,266 @@
+{
+  "type": "object",
+  "properties": {
+    "app": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "alert",
+        "event"
+      ],
+      "properties": {
+        "alert": {
+          "type": "object",
+          "required": [
+            "id",
+            "ruleID",
+            "fingerprint",
+            "periodID",
+            "status",
+            "severity",
+            "firstSeenAt",
+            "lastSeenAt",
+            "occurrenceCount",
+            "lastEvaluationID",
+            "createdAt",
+            "updatedAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "ruleID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "fingerprint": {
+              "type": "string"
+            },
+            "periodID": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "severity": {
+              "type": "string",
+              "enum": [
+                "info",
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
+            },
+            "firstSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "lastSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "occurrenceCount": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "lastEvaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "ack": {
+              "type": "object",
+              "required": [
+                "by",
+                "at"
+              ],
+              "properties": {
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "resolution": {
+              "type": "object",
+              "required": [
+                "kind",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "fixed_by_booking",
+                    "accepted_by_business"
+                  ]
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "transactionRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "evidenceSnapshot": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "snooze": {
+              "type": "object",
+              "required": [
+                "until",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "until": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updatedAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "event": {
+          "type": "object",
+          "required": [
+            "id",
+            "alertID",
+            "type",
+            "newStatus",
+            "notify",
+            "at",
+            "createdAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "alertID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "unsnooze"
+              ]
+            },
+            "prevStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "newStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "payload": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "date",
+    "app",
+    "version",
+    "type",
+    "payload"
+  ]
+}

--- a/events/generated/reconciliation/v2.4.0/UPDATED_ALERT.json
+++ b/events/generated/reconciliation/v2.4.0/UPDATED_ALERT.json
@@ -1,0 +1,266 @@
+{
+  "type": "object",
+  "properties": {
+    "app": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object",
+      "required": [
+        "alert",
+        "event"
+      ],
+      "properties": {
+        "alert": {
+          "type": "object",
+          "required": [
+            "id",
+            "ruleID",
+            "fingerprint",
+            "periodID",
+            "status",
+            "severity",
+            "firstSeenAt",
+            "lastSeenAt",
+            "occurrenceCount",
+            "lastEvaluationID",
+            "createdAt",
+            "updatedAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "ruleID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "fingerprint": {
+              "type": "string"
+            },
+            "periodID": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "severity": {
+              "type": "string",
+              "enum": [
+                "info",
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
+            },
+            "firstSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "lastSeenAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "occurrenceCount": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "lastEvaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evidence": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "ack": {
+              "type": "object",
+              "required": [
+                "by",
+                "at"
+              ],
+              "properties": {
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "resolution": {
+              "type": "object",
+              "required": [
+                "kind",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "fixed_by_booking",
+                    "accepted_by_business"
+                  ]
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "transactionRefs": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "evidenceSnapshot": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            },
+            "snooze": {
+              "type": "object",
+              "required": [
+                "until",
+                "by",
+                "at"
+              ],
+              "properties": {
+                "until": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "by": {
+                  "type": "string"
+                },
+                "at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "note": {
+                  "type": "string"
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updatedAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "event": {
+          "type": "object",
+          "required": [
+            "id",
+            "alertID",
+            "type",
+            "newStatus",
+            "notify",
+            "at",
+            "createdAt"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "alertID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "evaluationID": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "fail"
+              ]
+            },
+            "prevStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "newStatus": {
+              "type": "string",
+              "enum": [
+                "OPEN",
+                "ACKNOWLEDGED",
+                "RESOLVED"
+              ]
+            },
+            "payload": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "notify": {
+              "type": "boolean"
+            },
+            "at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "createdAt": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "date",
+    "app",
+    "version",
+    "type",
+    "payload"
+  ]
+}

--- a/events/index.js
+++ b/events/index.js
@@ -1,22 +1,23 @@
 const fs = require("fs/promises");
+const path = require("path");
 const yaml = require('yaml');
 
 (async () => {
 
-    const rawBase = await fs.readFile("./base.yaml", { encoding: 'utf8' });
+    const rawBase = await fs.readFile(path.join(__dirname, "base.yaml"), { encoding: 'utf8' });
     const aggregated = {};
 
-    for(const service of await fs.readdir("services")) {
+    for(const service of await fs.readdir(path.join(__dirname, "services"))) {
         aggregated[service] = {};
-        for(const version of await fs.readdir('services/' + service)) {
+        for(const version of await fs.readdir(path.join(__dirname, 'services', service))) {
             aggregated[service][version] = {};
-            for(const event of await fs.readdir('services/' + service + '/' + version)) {
-                const rawEventData = await fs.readFile('services/' + service + '/' + version + '/' + event, { encoding: 'utf8' });
+            for(const event of await fs.readdir(path.join(__dirname, 'services', service, version))) {
+                const rawEventData = await fs.readFile(path.join(__dirname, 'services', service, version, event), { encoding: 'utf8' });
                 const base = yaml.parse(rawBase);
                 base.properties.payload = yaml.parse(rawEventData);
-                const directory = 'generated/' + service + '/' + version + '/';
+                const directory = path.join(__dirname, 'generated', service, version);
                 await fs.mkdir(directory, { recursive: true });
-                await fs.writeFile(directory + event.replace('.yaml', '.json'), JSON.stringify(base, null, 2));
+                await fs.writeFile(path.join(directory, event.replace('.yaml', '.json')), JSON.stringify(base, null, 2));
 
                 aggregated[service][version][event.replace('.yaml', '')] = base;
             }
@@ -25,10 +26,11 @@ const yaml = require('yaml');
 
     console.log(aggregated);
     const aggregatedJSON = JSON.stringify(aggregated, null, 2);
-    await fs.writeFile('generated/all.json', aggregatedJSON);
+    await fs.writeFile(path.join(__dirname, 'generated', 'all.json'), aggregatedJSON);
 
     // Keep the legacy location in sync while existing consumers (notably the
     // Platform UI) still fetch the event catalogue from libs/events.
-    await fs.mkdir('../libs/events/generated', { recursive: true });
-    await fs.writeFile('../libs/events/generated/all.json', aggregatedJSON);
+    const legacyGeneratedDirectory = path.join(__dirname, '..', 'libs', 'events', 'generated');
+    await fs.mkdir(legacyGeneratedDirectory, { recursive: true });
+    await fs.writeFile(path.join(legacyGeneratedDirectory, 'all.json'), aggregatedJSON);
 })();

--- a/events/index.js
+++ b/events/index.js
@@ -24,5 +24,11 @@ const yaml = require('yaml');
     }
 
     console.log(aggregated);
-    await fs.writeFile('generated/all.json', JSON.stringify(aggregated, null, 2));
+    const aggregatedJSON = JSON.stringify(aggregated, null, 2);
+    await fs.writeFile('generated/all.json', aggregatedJSON);
+
+    // Keep the legacy location in sync while existing consumers (notably the
+    // Platform UI) still fetch the event catalogue from libs/events.
+    await fs.mkdir('../libs/events/generated', { recursive: true });
+    await fs.writeFile('../libs/events/generated/all.json', aggregatedJSON);
 })();

--- a/events/services/reconciliation/v2.4.0/ACCEPTED_ALERT.yaml
+++ b/events/services/reconciliation/v2.4.0/ACCEPTED_ALERT.yaml
@@ -1,0 +1,91 @@
+type: object
+required:
+  - alert
+  - event
+properties:
+  alert:
+    type: object
+    required:
+      - id
+      - ruleID
+      - fingerprint
+      - periodID
+      - status
+      - severity
+      - firstSeenAt
+      - lastSeenAt
+      - occurrenceCount
+      - lastEvaluationID
+      - createdAt
+      - updatedAt
+    properties:
+      id: { type: string, format: uuid }
+      ruleID: { type: string, format: uuid }
+      fingerprint: { type: string }
+      periodID: { type: string }
+      status: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      severity: { type: string, enum: [info, low, medium, high, critical] }
+      firstSeenAt: { type: string, format: date-time }
+      lastSeenAt: { type: string, format: date-time }
+      occurrenceCount: { type: integer, format: int64 }
+      lastEvaluationID: { type: string, format: uuid }
+      evidence:
+        type: object
+        additionalProperties: true
+      ack:
+        type: object
+        required: [by, at]
+        properties:
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      resolution:
+        type: object
+        required: [kind, by, at]
+        properties:
+          kind: { type: string, enum: [auto, fixed_by_booking, accepted_by_business] }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+          transactionRefs:
+            type: array
+            items: { type: string }
+          evidenceSnapshot:
+            type: object
+            additionalProperties: true
+      snooze:
+        type: object
+        required: [until, by, at]
+        properties:
+          until: { type: string, format: date-time }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      labels:
+        type: object
+        additionalProperties: { type: string }
+      createdAt: { type: string, format: date-time }
+      updatedAt: { type: string, format: date-time }
+  event:
+    type: object
+    required:
+      - id
+      - alertID
+      - type
+      - newStatus
+      - notify
+      - at
+      - createdAt
+    properties:
+      id: { type: string, format: uuid }
+      alertID: { type: string, format: uuid }
+      evaluationID: { type: string, format: uuid }
+      type: { type: string, enum: [accept] }
+      prevStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      newStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      payload:
+        type: object
+        additionalProperties: true
+      notify: { type: boolean }
+      at: { type: string, format: date-time }
+      createdAt: { type: string, format: date-time }

--- a/events/services/reconciliation/v2.4.0/ACKNOWLEDGED_ALERT.yaml
+++ b/events/services/reconciliation/v2.4.0/ACKNOWLEDGED_ALERT.yaml
@@ -1,0 +1,91 @@
+type: object
+required:
+  - alert
+  - event
+properties:
+  alert:
+    type: object
+    required:
+      - id
+      - ruleID
+      - fingerprint
+      - periodID
+      - status
+      - severity
+      - firstSeenAt
+      - lastSeenAt
+      - occurrenceCount
+      - lastEvaluationID
+      - createdAt
+      - updatedAt
+    properties:
+      id: { type: string, format: uuid }
+      ruleID: { type: string, format: uuid }
+      fingerprint: { type: string }
+      periodID: { type: string }
+      status: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      severity: { type: string, enum: [info, low, medium, high, critical] }
+      firstSeenAt: { type: string, format: date-time }
+      lastSeenAt: { type: string, format: date-time }
+      occurrenceCount: { type: integer, format: int64 }
+      lastEvaluationID: { type: string, format: uuid }
+      evidence:
+        type: object
+        additionalProperties: true
+      ack:
+        type: object
+        required: [by, at]
+        properties:
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      resolution:
+        type: object
+        required: [kind, by, at]
+        properties:
+          kind: { type: string, enum: [auto, fixed_by_booking, accepted_by_business] }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+          transactionRefs:
+            type: array
+            items: { type: string }
+          evidenceSnapshot:
+            type: object
+            additionalProperties: true
+      snooze:
+        type: object
+        required: [until, by, at]
+        properties:
+          until: { type: string, format: date-time }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      labels:
+        type: object
+        additionalProperties: { type: string }
+      createdAt: { type: string, format: date-time }
+      updatedAt: { type: string, format: date-time }
+  event:
+    type: object
+    required:
+      - id
+      - alertID
+      - type
+      - newStatus
+      - notify
+      - at
+      - createdAt
+    properties:
+      id: { type: string, format: uuid }
+      alertID: { type: string, format: uuid }
+      evaluationID: { type: string, format: uuid }
+      type: { type: string, enum: [ack] }
+      prevStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      newStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      payload:
+        type: object
+        additionalProperties: true
+      notify: { type: boolean }
+      at: { type: string, format: date-time }
+      createdAt: { type: string, format: date-time }

--- a/events/services/reconciliation/v2.4.0/OPENED_ALERT.yaml
+++ b/events/services/reconciliation/v2.4.0/OPENED_ALERT.yaml
@@ -1,0 +1,91 @@
+type: object
+required:
+  - alert
+  - event
+properties:
+  alert:
+    type: object
+    required:
+      - id
+      - ruleID
+      - fingerprint
+      - periodID
+      - status
+      - severity
+      - firstSeenAt
+      - lastSeenAt
+      - occurrenceCount
+      - lastEvaluationID
+      - createdAt
+      - updatedAt
+    properties:
+      id: { type: string, format: uuid }
+      ruleID: { type: string, format: uuid }
+      fingerprint: { type: string }
+      periodID: { type: string }
+      status: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      severity: { type: string, enum: [info, low, medium, high, critical] }
+      firstSeenAt: { type: string, format: date-time }
+      lastSeenAt: { type: string, format: date-time }
+      occurrenceCount: { type: integer, format: int64 }
+      lastEvaluationID: { type: string, format: uuid }
+      evidence:
+        type: object
+        additionalProperties: true
+      ack:
+        type: object
+        required: [by, at]
+        properties:
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      resolution:
+        type: object
+        required: [kind, by, at]
+        properties:
+          kind: { type: string, enum: [auto, fixed_by_booking, accepted_by_business] }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+          transactionRefs:
+            type: array
+            items: { type: string }
+          evidenceSnapshot:
+            type: object
+            additionalProperties: true
+      snooze:
+        type: object
+        required: [until, by, at]
+        properties:
+          until: { type: string, format: date-time }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      labels:
+        type: object
+        additionalProperties: { type: string }
+      createdAt: { type: string, format: date-time }
+      updatedAt: { type: string, format: date-time }
+  event:
+    type: object
+    required:
+      - id
+      - alertID
+      - type
+      - newStatus
+      - notify
+      - at
+      - createdAt
+    properties:
+      id: { type: string, format: uuid }
+      alertID: { type: string, format: uuid }
+      evaluationID: { type: string, format: uuid }
+      type: { type: string, enum: [fail] }
+      prevStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      newStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      payload:
+        type: object
+        additionalProperties: true
+      notify: { type: boolean }
+      at: { type: string, format: date-time }
+      createdAt: { type: string, format: date-time }

--- a/events/services/reconciliation/v2.4.0/REOPENED_ALERT.yaml
+++ b/events/services/reconciliation/v2.4.0/REOPENED_ALERT.yaml
@@ -1,0 +1,91 @@
+type: object
+required:
+  - alert
+  - event
+properties:
+  alert:
+    type: object
+    required:
+      - id
+      - ruleID
+      - fingerprint
+      - periodID
+      - status
+      - severity
+      - firstSeenAt
+      - lastSeenAt
+      - occurrenceCount
+      - lastEvaluationID
+      - createdAt
+      - updatedAt
+    properties:
+      id: { type: string, format: uuid }
+      ruleID: { type: string, format: uuid }
+      fingerprint: { type: string }
+      periodID: { type: string }
+      status: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      severity: { type: string, enum: [info, low, medium, high, critical] }
+      firstSeenAt: { type: string, format: date-time }
+      lastSeenAt: { type: string, format: date-time }
+      occurrenceCount: { type: integer, format: int64 }
+      lastEvaluationID: { type: string, format: uuid }
+      evidence:
+        type: object
+        additionalProperties: true
+      ack:
+        type: object
+        required: [by, at]
+        properties:
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      resolution:
+        type: object
+        required: [kind, by, at]
+        properties:
+          kind: { type: string, enum: [auto, fixed_by_booking, accepted_by_business] }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+          transactionRefs:
+            type: array
+            items: { type: string }
+          evidenceSnapshot:
+            type: object
+            additionalProperties: true
+      snooze:
+        type: object
+        required: [until, by, at]
+        properties:
+          until: { type: string, format: date-time }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      labels:
+        type: object
+        additionalProperties: { type: string }
+      createdAt: { type: string, format: date-time }
+      updatedAt: { type: string, format: date-time }
+  event:
+    type: object
+    required:
+      - id
+      - alertID
+      - type
+      - newStatus
+      - notify
+      - at
+      - createdAt
+    properties:
+      id: { type: string, format: uuid }
+      alertID: { type: string, format: uuid }
+      evaluationID: { type: string, format: uuid }
+      type: { type: string, enum: [fail] }
+      prevStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      newStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      payload:
+        type: object
+        additionalProperties: true
+      notify: { type: boolean }
+      at: { type: string, format: date-time }
+      createdAt: { type: string, format: date-time }

--- a/events/services/reconciliation/v2.4.0/RESOLVED_ALERT.yaml
+++ b/events/services/reconciliation/v2.4.0/RESOLVED_ALERT.yaml
@@ -1,0 +1,91 @@
+type: object
+required:
+  - alert
+  - event
+properties:
+  alert:
+    type: object
+    required:
+      - id
+      - ruleID
+      - fingerprint
+      - periodID
+      - status
+      - severity
+      - firstSeenAt
+      - lastSeenAt
+      - occurrenceCount
+      - lastEvaluationID
+      - createdAt
+      - updatedAt
+    properties:
+      id: { type: string, format: uuid }
+      ruleID: { type: string, format: uuid }
+      fingerprint: { type: string }
+      periodID: { type: string }
+      status: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      severity: { type: string, enum: [info, low, medium, high, critical] }
+      firstSeenAt: { type: string, format: date-time }
+      lastSeenAt: { type: string, format: date-time }
+      occurrenceCount: { type: integer, format: int64 }
+      lastEvaluationID: { type: string, format: uuid }
+      evidence:
+        type: object
+        additionalProperties: true
+      ack:
+        type: object
+        required: [by, at]
+        properties:
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      resolution:
+        type: object
+        required: [kind, by, at]
+        properties:
+          kind: { type: string, enum: [auto, fixed_by_booking, accepted_by_business] }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+          transactionRefs:
+            type: array
+            items: { type: string }
+          evidenceSnapshot:
+            type: object
+            additionalProperties: true
+      snooze:
+        type: object
+        required: [until, by, at]
+        properties:
+          until: { type: string, format: date-time }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      labels:
+        type: object
+        additionalProperties: { type: string }
+      createdAt: { type: string, format: date-time }
+      updatedAt: { type: string, format: date-time }
+  event:
+    type: object
+    required:
+      - id
+      - alertID
+      - type
+      - newStatus
+      - notify
+      - at
+      - createdAt
+    properties:
+      id: { type: string, format: uuid }
+      alertID: { type: string, format: uuid }
+      evaluationID: { type: string, format: uuid }
+      type: { type: string, enum: [pass, resolve] }
+      prevStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      newStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      payload:
+        type: object
+        additionalProperties: true
+      notify: { type: boolean }
+      at: { type: string, format: date-time }
+      createdAt: { type: string, format: date-time }

--- a/events/services/reconciliation/v2.4.0/SNOOZED_ALERT.yaml
+++ b/events/services/reconciliation/v2.4.0/SNOOZED_ALERT.yaml
@@ -1,0 +1,91 @@
+type: object
+required:
+  - alert
+  - event
+properties:
+  alert:
+    type: object
+    required:
+      - id
+      - ruleID
+      - fingerprint
+      - periodID
+      - status
+      - severity
+      - firstSeenAt
+      - lastSeenAt
+      - occurrenceCount
+      - lastEvaluationID
+      - createdAt
+      - updatedAt
+    properties:
+      id: { type: string, format: uuid }
+      ruleID: { type: string, format: uuid }
+      fingerprint: { type: string }
+      periodID: { type: string }
+      status: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      severity: { type: string, enum: [info, low, medium, high, critical] }
+      firstSeenAt: { type: string, format: date-time }
+      lastSeenAt: { type: string, format: date-time }
+      occurrenceCount: { type: integer, format: int64 }
+      lastEvaluationID: { type: string, format: uuid }
+      evidence:
+        type: object
+        additionalProperties: true
+      ack:
+        type: object
+        required: [by, at]
+        properties:
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      resolution:
+        type: object
+        required: [kind, by, at]
+        properties:
+          kind: { type: string, enum: [auto, fixed_by_booking, accepted_by_business] }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+          transactionRefs:
+            type: array
+            items: { type: string }
+          evidenceSnapshot:
+            type: object
+            additionalProperties: true
+      snooze:
+        type: object
+        required: [until, by, at]
+        properties:
+          until: { type: string, format: date-time }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      labels:
+        type: object
+        additionalProperties: { type: string }
+      createdAt: { type: string, format: date-time }
+      updatedAt: { type: string, format: date-time }
+  event:
+    type: object
+    required:
+      - id
+      - alertID
+      - type
+      - newStatus
+      - notify
+      - at
+      - createdAt
+    properties:
+      id: { type: string, format: uuid }
+      alertID: { type: string, format: uuid }
+      evaluationID: { type: string, format: uuid }
+      type: { type: string, enum: [snooze] }
+      prevStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      newStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      payload:
+        type: object
+        additionalProperties: true
+      notify: { type: boolean }
+      at: { type: string, format: date-time }
+      createdAt: { type: string, format: date-time }

--- a/events/services/reconciliation/v2.4.0/UNSNOOZED_ALERT.yaml
+++ b/events/services/reconciliation/v2.4.0/UNSNOOZED_ALERT.yaml
@@ -1,0 +1,91 @@
+type: object
+required:
+  - alert
+  - event
+properties:
+  alert:
+    type: object
+    required:
+      - id
+      - ruleID
+      - fingerprint
+      - periodID
+      - status
+      - severity
+      - firstSeenAt
+      - lastSeenAt
+      - occurrenceCount
+      - lastEvaluationID
+      - createdAt
+      - updatedAt
+    properties:
+      id: { type: string, format: uuid }
+      ruleID: { type: string, format: uuid }
+      fingerprint: { type: string }
+      periodID: { type: string }
+      status: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      severity: { type: string, enum: [info, low, medium, high, critical] }
+      firstSeenAt: { type: string, format: date-time }
+      lastSeenAt: { type: string, format: date-time }
+      occurrenceCount: { type: integer, format: int64 }
+      lastEvaluationID: { type: string, format: uuid }
+      evidence:
+        type: object
+        additionalProperties: true
+      ack:
+        type: object
+        required: [by, at]
+        properties:
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      resolution:
+        type: object
+        required: [kind, by, at]
+        properties:
+          kind: { type: string, enum: [auto, fixed_by_booking, accepted_by_business] }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+          transactionRefs:
+            type: array
+            items: { type: string }
+          evidenceSnapshot:
+            type: object
+            additionalProperties: true
+      snooze:
+        type: object
+        required: [until, by, at]
+        properties:
+          until: { type: string, format: date-time }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      labels:
+        type: object
+        additionalProperties: { type: string }
+      createdAt: { type: string, format: date-time }
+      updatedAt: { type: string, format: date-time }
+  event:
+    type: object
+    required:
+      - id
+      - alertID
+      - type
+      - newStatus
+      - notify
+      - at
+      - createdAt
+    properties:
+      id: { type: string, format: uuid }
+      alertID: { type: string, format: uuid }
+      evaluationID: { type: string, format: uuid }
+      type: { type: string, enum: [unsnooze] }
+      prevStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      newStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      payload:
+        type: object
+        additionalProperties: true
+      notify: { type: boolean }
+      at: { type: string, format: date-time }
+      createdAt: { type: string, format: date-time }

--- a/events/services/reconciliation/v2.4.0/UPDATED_ALERT.yaml
+++ b/events/services/reconciliation/v2.4.0/UPDATED_ALERT.yaml
@@ -1,0 +1,91 @@
+type: object
+required:
+  - alert
+  - event
+properties:
+  alert:
+    type: object
+    required:
+      - id
+      - ruleID
+      - fingerprint
+      - periodID
+      - status
+      - severity
+      - firstSeenAt
+      - lastSeenAt
+      - occurrenceCount
+      - lastEvaluationID
+      - createdAt
+      - updatedAt
+    properties:
+      id: { type: string, format: uuid }
+      ruleID: { type: string, format: uuid }
+      fingerprint: { type: string }
+      periodID: { type: string }
+      status: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      severity: { type: string, enum: [info, low, medium, high, critical] }
+      firstSeenAt: { type: string, format: date-time }
+      lastSeenAt: { type: string, format: date-time }
+      occurrenceCount: { type: integer, format: int64 }
+      lastEvaluationID: { type: string, format: uuid }
+      evidence:
+        type: object
+        additionalProperties: true
+      ack:
+        type: object
+        required: [by, at]
+        properties:
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      resolution:
+        type: object
+        required: [kind, by, at]
+        properties:
+          kind: { type: string, enum: [auto, fixed_by_booking, accepted_by_business] }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+          transactionRefs:
+            type: array
+            items: { type: string }
+          evidenceSnapshot:
+            type: object
+            additionalProperties: true
+      snooze:
+        type: object
+        required: [until, by, at]
+        properties:
+          until: { type: string, format: date-time }
+          by: { type: string }
+          at: { type: string, format: date-time }
+          note: { type: string }
+      labels:
+        type: object
+        additionalProperties: { type: string }
+      createdAt: { type: string, format: date-time }
+      updatedAt: { type: string, format: date-time }
+  event:
+    type: object
+    required:
+      - id
+      - alertID
+      - type
+      - newStatus
+      - notify
+      - at
+      - createdAt
+    properties:
+      id: { type: string, format: uuid }
+      alertID: { type: string, format: uuid }
+      evaluationID: { type: string, format: uuid }
+      type: { type: string, enum: [fail] }
+      prevStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      newStatus: { type: string, enum: [OPEN, ACKNOWLEDGED, RESOLVED] }
+      payload:
+        type: object
+        additionalProperties: true
+      notify: { type: boolean }
+      at: { type: string, format: date-time }
+      createdAt: { type: string, format: date-time }

--- a/libs/events/generated/all.json
+++ b/libs/events/generated/all.json
@@ -2745,5 +2745,2138 @@
         ]
       }
     }
+  },
+  "reconciliation": {
+    "v2.4.0": {
+      "ACCEPTED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "accept"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "ACKNOWLEDGED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "ack"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "OPENED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fail"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "REOPENED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fail"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "RESOLVED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "pass",
+                      "resolve"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "SNOOZED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "snooze"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "UNSNOOZED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "unsnooze"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      },
+      "UPDATED_ALERT": {
+        "type": "object",
+        "properties": {
+          "app": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "required": [
+              "alert",
+              "event"
+            ],
+            "properties": {
+              "alert": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "ruleID",
+                  "fingerprint",
+                  "periodID",
+                  "status",
+                  "severity",
+                  "firstSeenAt",
+                  "lastSeenAt",
+                  "occurrenceCount",
+                  "lastEvaluationID",
+                  "createdAt",
+                  "updatedAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "ruleID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "fingerprint": {
+                    "type": "string"
+                  },
+                  "periodID": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "severity": {
+                    "type": "string",
+                    "enum": [
+                      "info",
+                      "low",
+                      "medium",
+                      "high",
+                      "critical"
+                    ]
+                  },
+                  "firstSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "lastSeenAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "occurrenceCount": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "lastEvaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evidence": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "ack": {
+                    "type": "object",
+                    "required": [
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "object",
+                    "required": [
+                      "kind",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "auto",
+                          "fixed_by_booking",
+                          "accepted_by_business"
+                        ]
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      },
+                      "transactionRefs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "evidenceSnapshot": {
+                        "type": "object",
+                        "additionalProperties": true
+                      }
+                    }
+                  },
+                  "snooze": {
+                    "type": "object",
+                    "required": [
+                      "until",
+                      "by",
+                      "at"
+                    ],
+                    "properties": {
+                      "until": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "by": {
+                        "type": "string"
+                      },
+                      "at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "note": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              },
+              "event": {
+                "type": "object",
+                "required": [
+                  "id",
+                  "alertID",
+                  "type",
+                  "newStatus",
+                  "notify",
+                  "at",
+                  "createdAt"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "alertID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "evaluationID": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fail"
+                    ]
+                  },
+                  "prevStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "newStatus": {
+                    "type": "string",
+                    "enum": [
+                      "OPEN",
+                      "ACKNOWLEDGED",
+                      "RESOLVED"
+                    ]
+                  },
+                  "payload": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "notify": {
+                    "type": "boolean"
+                  },
+                  "at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "date",
+          "app",
+          "version",
+          "type",
+          "payload"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- add schemas for the eight Reconciliation alert lifecycle events introduced in Reconciliation v2.4.0
- use the Stack ACTION_ENTITY naming convention (`OPENED_ALERT`, `RESOLVED_ALERT`, etc.)
- keep the canonical and legacy generated event catalogues synchronized
- validate all event payload schemas with Go tests

## Impact

Webhook event catalogues can expose the new `reconciliation.*_alert` subscriptions with payload schemas matching the Reconciliation alert and alert-event models.

## Validation

- `cd events && go test ./...`
- event catalogue regeneration with `node index.js`
- generated catalogue equality check
- `git diff --check`