### PR TITLE
fix(openapi): preserve typed default errors

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -55,8 +55,8 @@ validate-openapi:
     jq -e '.components.schemas as $schemas | [ $schemas | .. | objects | select(.discriminator.mapping? != null) | .discriminator.mapping[] | select(type == "string" and startswith("#/components/schemas/")) | sub("^#/components/schemas/"; "") | select($schemas[.] == null) ] | length == 0' releases/build/generate.json >/dev/null
     # Ledger query-template helpers rely on these resource constants.
     jq -e '[.components.schemas.ledger_V2QueryParams.oneOf[].properties.resource | select(.const == null or .enum != null)] | length == 0' releases/build/generate.json >/dev/null
-    # Error responses must not be generated as successful response variants.
-    test "$(jq -c '.paths["x-speakeasy-errors"].statusCodes' releases/build/generate.json)" = '["4XX","5XX","default"]'
+    # Preserve typed default errors instead of shadowing them with generic range matchers.
+    test "$(jq -c '.paths["x-speakeasy-errors"].statusCodes' releases/build/generate.json)" = '["default"]'
     # Every operation tag must be declared globally.
     jq -e '[.tags[].name] as $tags | [.paths[] | to_entries[] | select(.key | IN("get", "post", "put", "patch", "delete", "options", "head", "trace")) | .value.tags[]? | select(. as $tag | $tags | index($tag) == null)] | length == 0' releases/build/generate.json >/dev/null
     # Composition cleanups must remain applied when component specs change.

--- a/releases/overlays/shared.overlay.yaml
+++ b/releases/overlays/shared.overlay.yaml
@@ -62,14 +62,13 @@ actions:
   - target: $.components.schemas.payments_LegacyPaymentStatus.enum[14]
     remove: true
 
-  # Treat all HTTP error responses as errors. Component specs contribute their
-  # own defaults during merge, so remove the merged value before replacing it.
+  # Preserve each component's typed default error response. Global 4XX/5XX
+  # matchers take precedence over the default schema in generated SDKs and
+  # would turn structured API errors into generic SDK errors.
   - target: $.paths.x-speakeasy-errors
     remove: true
   - target: $.paths
     update:
       x-speakeasy-errors:
         statusCodes:
-          - 4XX
-          - 5XX
           - default


### PR DESCRIPTION
## Summary

- keep the global Speakeasy error policy on `default` only
- prevent generic `4XX`/`5XX` matchers from shadowing typed default error schemas in generated SDKs
- update the OpenAPI build invariant to reject a reintroduction of range matchers

## Root cause

The `4XX` and `5XX` matchers introduced in v3.2.9 run before each operation's typed `default` error response in generated SDKs. Structured API errors are therefore converted into generic SDK errors, and explicit error statuses can disappear from generated response models.

## Validation

- `nix develop --impure --command bash -c 'just generate-composition-overlay && speakeasy run -s all --skip-upload-spec --auto-yes && just validate-openapi'`
- OpenAPI lint: 0 errors
- generated policy: `["default"]`
- normalized v3.2.9 and candidate documents are byte-identical after removing `paths.x-speakeasy-errors` (`ac36525febc56af5e96654b57a70824625137631053f19c71481375364681b3e`)
- `git diff --check`

## Release

This is intended for Stack v3.2.10. SDKs should regenerate from the v3.2.10 Registry revision before any generated PR is merged.
