### PR TITLE
chore: gitignore CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ node_modules/
 
 # Helm
 *.tgz
+
+# AI coding assistants
+CLAUDE.md


### PR DESCRIPTION
## What

Adds `CLAUDE.md` to `.gitignore`, so a local assistant working file cannot get committed by accident.

Nothing is removed from the repo: `CLAUDE.md` is not tracked here today (`git ls-files` has no match), so this is purely preventative.

Also terminates `.gitignore` with a newline. The file was missing one, so the `*.tgz` line showed up in the diff regardless — worth fixing while it was already being touched.