### PR TITLE
feat(events): add Ledger v3 broker schemas

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -6,6 +6,22 @@ Each "vX" folder contains a "base" folder that contains the base event format, w
 
 For example, an event with "type" == "SAVED_PAYMENT" and "app" == "payments" must have a payload matching schema in the file "payments/SAVED_PAYMENT.yaml".
 
+## Event Envelopes
+
+By default, event schemas are payload schemas composed with `base.yaml`, which
+describes the historical Stack envelope (`app`, `version`, `type`, `date`, and
+`payload`).
+
+A service version can define a complete, version-specific envelope in
+`services/<service>/<version>/base.yaml`. The generator composes each sibling
+event schema with that base through JSON Schema `allOf`; `base.yaml` is not
+published as an event type.
+
+Ledger v3 uses this mechanism because its NATS and Kafka sinks publish the same
+new envelope directly: `type`, `ledger`, `date`, `logSequence`, and the complete
+`log`. It does not contain the historical `app`, `version`, or `payload`
+properties.
+
 ## Payments Versions
 
 We decided to go with stack releases starting at v2.0.x.

--- a/events/events.go
+++ b/events/events.go
@@ -1,10 +1,12 @@
 package events
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
 
 	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
@@ -19,28 +21,44 @@ var baseEvent string
 var services embed.FS
 
 func ComputeSchema(serviceName, eventName string) (*gojsonschema.Schema, error) {
-	base := map[string]any{}
-	if err := yaml.Unmarshal([]byte(baseEvent), &base); err != nil {
-		return nil, err
-	}
-
 	ls, err := services.ReadDir(filepath.Join("services", serviceName))
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading events directory for service '%s'", serviceName)
 	}
 
-	var moreRecent string
+	versions := make([]string, 0, len(ls))
 	for _, directory := range ls {
-		if moreRecent == "" || semver.Compare(directory.Name(), moreRecent) > 0 {
-			moreRecent = directory.Name()
+		if directory.IsDir() && semver.IsValid(directory.Name()) {
+			versions = append(versions, directory.Name())
 		}
 	}
+	sort.Slice(versions, func(i, j int) bool {
+		return semver.Compare(versions[i], versions[j]) > 0
+	})
 
-	if moreRecent == "" {
+	if len(versions) == 0 {
 		return nil, fmt.Errorf("error retrieving more recent version directory for service '%s'", serviceName)
 	}
 
-	eventData, err := services.ReadFile(fmt.Sprintf("services/%s/%s/%s.yaml", serviceName, moreRecent, eventName))
+	for _, version := range versions {
+		_, err := services.ReadFile(fmt.Sprintf("services/%s/%s/%s.yaml", serviceName, version, eventName))
+		if err == nil {
+			return ComputeSchemaForVersion(serviceName, version, eventName)
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+	}
+
+	return nil, fmt.Errorf("event schema '%s' not found for service '%s'", eventName, serviceName)
+}
+
+// ComputeSchemaForVersion returns the schema for an exact service version.
+// Versions with a base.yaml describe a complete event envelope and compose
+// the event-specific constraints through allOf. Older versions keep using the
+// historical shared envelope with the event schema injected under payload.
+func ComputeSchemaForVersion(serviceName, version, eventName string) (*gojsonschema.Schema, error) {
+	eventData, err := services.ReadFile(fmt.Sprintf("services/%s/%s/%s.yaml", serviceName, version, eventName))
 	if err != nil {
 		return nil, err
 	}
@@ -50,10 +68,42 @@ func ComputeSchema(serviceName, eventName string) (*gojsonschema.Schema, error) 
 		return nil, err
 	}
 
-	base["properties"].(map[string]any)["payload"] = event
+	versionBaseData, err := services.ReadFile(fmt.Sprintf("services/%s/%s/base.yaml", serviceName, version))
+	if err == nil {
+		base := map[string]any{}
+		if err := yaml.Unmarshal(versionBaseData, &base); err != nil {
+			return nil, err
+		}
 
-	loader := gojsonschema.NewGoLoader(base)
-	return gojsonschema.NewSchema(loader)
+		allOf, _ := base["allOf"].([]any)
+		base["allOf"] = append(allOf, event)
+
+		return compileSchema(base)
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+
+	base := map[string]any{}
+	if err := yaml.Unmarshal([]byte(baseEvent), &base); err != nil {
+		return nil, err
+	}
+
+	properties, ok := base["properties"].(map[string]any)
+	if !ok {
+		return nil, errors.New("base event schema has no properties object")
+	}
+	properties["payload"] = event
+
+	return compileSchema(base)
+}
+
+func compileSchema(schema map[string]any) (*gojsonschema.Schema, error) {
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshaling schema")
+	}
+	return gojsonschema.NewSchema(gojsonschema.NewBytesLoader(data))
 }
 
 func Check(data []byte, serviceName, eventName string) error {
@@ -61,6 +111,21 @@ func Check(data []byte, serviceName, eventName string) error {
 	if err != nil {
 		return errors.Wrap(err, "computing schema")
 	}
+
+	return validate(data, schema)
+}
+
+// CheckForVersion validates an event against an exact service version.
+func CheckForVersion(data []byte, serviceName, version, eventName string) error {
+	schema, err := ComputeSchemaForVersion(serviceName, version, eventName)
+	if err != nil {
+		return errors.Wrap(err, "computing schema")
+	}
+
+	return validate(data, schema)
+}
+
+func validate(data []byte, schema *gojsonschema.Schema) error {
 	result, err := schema.Validate(gojsonschema.NewStringLoader(string(data)))
 	if err != nil {
 		return errors.Wrap(err, "validating schema")

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -57,3 +57,172 @@ func TestReconciliationAlertEventSchemas(t *testing.T) {
 		})
 	}
 }
+
+func TestLedgerV3EventSchemas(t *testing.T) {
+	t.Parallel()
+
+	events := map[string]string{
+		"CREATED_LEDGER": `{
+			"type":"CREATED_LEDGER",
+			"ledger":"orders",
+			"date":"2026-08-28T22:29:41.133323Z",
+			"logSequence":1,
+			"log":{
+				"sequence":1,
+				"payload":{"createLedger":{"name":"orders","createdAt":"2026-08-28T22:29:41.133323Z"}},
+				"responseSignature":{}
+			}
+		}`,
+		"COMMITTED_TRANSACTION": `{
+			"type":"COMMITTED_TRANSACTION",
+			"ledger":"orders",
+			"date":"2026-08-28T22:29:41.133323Z",
+			"logSequence":2,
+			"log":{
+				"sequence":2,
+				"payload":{"apply":{"ledgerName":"orders","log":{
+					"type":"NEW_TRANSACTION",
+					"data":{"createdTransaction":{
+						"transaction":{
+							"postings":[{"source":"world","destination":"users:123","amount":1000,"asset":"USD/2","color":""}],
+							"metadata":{"kind":"sale"},
+							"timestamp":"2026-08-28T22:29:41.133323Z",
+							"reference":"order-42",
+							"id":42,
+							"reverted":false
+						},
+						"accountMetadata":{"users:123":{"tier":"gold"}},
+						"chapterId":7
+					}},
+					"date":"2026-08-28T22:29:41.133323Z",
+					"id":1
+				}}},
+				"responseSignature":{}
+			}
+		}`,
+		"REVERTED_TRANSACTION": `{
+			"type":"REVERTED_TRANSACTION",
+			"ledger":"orders",
+			"date":"2026-08-28T22:29:41.133323Z",
+			"logSequence":3,
+			"log":{
+				"sequence":3,
+				"payload":{"apply":{"ledgerName":"orders","log":{
+					"type":"REVERTED_TRANSACTION",
+					"data":{"revertedTransaction":{
+						"revertedTransactionId":42,
+						"revertTransaction":{
+							"postings":[{"source":"users:123","destination":"world","amount":1000,"asset":"USD/2","color":""}],
+							"metadata":{},
+							"timestamp":"2026-08-28T22:29:41.133323Z",
+							"id":43,
+							"reverted":false
+						}
+					}},
+					"date":"2026-08-28T22:29:41.133323Z",
+					"id":2
+				}}},
+				"responseSignature":{}
+			}
+		}`,
+		"SAVED_METADATA": `{
+			"type":"SAVED_METADATA",
+			"ledger":"orders",
+			"date":"2026-08-28T22:29:41.133323Z",
+			"logSequence":4,
+			"log":{
+				"sequence":4,
+				"payload":{"apply":{"ledgerName":"orders","log":{
+					"type":"SET_METADATA",
+					"data":{"savedMetadata":{"targetType":"ACCOUNT","accountId":"users:123","metadata":{"tier":"platinum"}}},
+					"date":"2026-08-28T22:29:41.133323Z",
+					"id":3
+				}}},
+				"responseSignature":{}
+			}
+		}`,
+		"DELETED_METADATA": `{
+			"type":"DELETED_METADATA",
+			"ledger":"orders",
+			"date":"2026-08-28T22:29:41.133323Z",
+			"logSequence":5,
+			"log":{
+				"sequence":5,
+				"payload":{"apply":{"ledgerName":"orders","log":{
+					"type":"DELETE_METADATA",
+					"data":{"deletedMetadata":{"targetType":"TRANSACTION","transactionId":42,"key":"kind"}},
+					"date":"2026-08-28T22:29:41.133323Z",
+					"id":4
+				}}},
+				"responseSignature":{}
+			}
+		}`,
+		"DELETED_LEDGER": `{
+			"type":"DELETED_LEDGER",
+			"ledger":"orders",
+			"date":"2026-08-28T22:29:41.133323Z",
+			"logSequence":6,
+			"log":{
+				"sequence":6,
+				"payload":{"deleteLedger":{"name":"orders","deletedAt":"2026-08-28T22:29:41.133323Z"}},
+				"responseSignature":{}
+			}
+		}`,
+		"SKIPPED_ORDER": `{
+			"type":"SKIPPED_ORDER",
+			"ledger":"orders",
+			"date":"2026-08-28T22:29:41.133323Z",
+			"logSequence":7,
+			"log":{
+				"sequence":7,
+				"payload":{"apply":{"ledgerName":"orders","log":{
+					"type":"ORDER_SKIPPED",
+					"data":{"reason":"TRANSACTION_REFERENCE_CONFLICT","context":{"reference":"order-42","existingTransactionId":"42"}},
+					"date":"2026-08-28T22:29:41.133323Z",
+					"id":5
+				}}},
+				"responseSignature":{}
+			}
+		}`,
+	}
+
+	for eventName, event := range events {
+		eventName, event := eventName, event
+		t.Run(eventName, func(t *testing.T) {
+			t.Parallel()
+
+			if err := CheckForVersion([]byte(event), "ledger", "v3.0.0", eventName); err != nil {
+				t.Fatalf("validate event: %v", err)
+			}
+		})
+	}
+
+	if err := CheckForVersion([]byte(events["COMMITTED_TRANSACTION"]), "ledger", "v3.0.0", "SAVED_METADATA"); err == nil {
+		t.Fatal("expected a committed transaction to be rejected by the saved metadata schema")
+	}
+}
+
+func TestComputeSchemaUsesLatestVersionContainingEvent(t *testing.T) {
+	t.Parallel()
+
+	legacyEvent := []byte(`{
+		"app":"ledger",
+		"version":"v2",
+		"date":"2026-08-28T22:29:41Z",
+		"type":"COMMITTED_TRANSACTIONS",
+		"payload":{
+			"ledger":"orders",
+			"transactions":[{
+				"postings":[],
+				"metadata":{},
+				"id":42,
+				"timestamp":"2026-08-28T22:29:41Z",
+				"reverted":false
+			}]
+		}
+	}`)
+
+	if err := Check(legacyEvent, "ledger", "COMMITTED_TRANSACTIONS"); err != nil {
+		t.Fatalf("validate legacy event from newest version containing it: %v", err)
+	}
+}

--- a/events/generated/all.json
+++ b/events/generated/all.json
@@ -643,6 +643,3468 @@
           "payload"
         ]
       }
+    },
+    "v3.0.0": {
+      "COMMITTED_TRANSACTION": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "COMMITTED_TRANSACTION"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "NEW_TRANSACTION"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "object",
+                                    "required": [
+                                      "createdTransaction"
+                                    ],
+                                    "properties": {
+                                      "createdTransaction": {
+                                        "$ref": "#/definitions/createdTransaction"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "CREATED_LEDGER": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "CREATED_LEDGER"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "createLedger"
+                    ],
+                    "properties": {
+                      "createLedger": {
+                        "$ref": "#/definitions/createdLedger"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "DELETED_LEDGER": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "DELETED_LEDGER"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "deleteLedger"
+                    ],
+                    "properties": {
+                      "deleteLedger": {
+                        "$ref": "#/definitions/deletedLedger"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "DELETED_METADATA": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "DELETED_METADATA"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "DELETE_METADATA"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "object",
+                                    "required": [
+                                      "deletedMetadata"
+                                    ],
+                                    "properties": {
+                                      "deletedMetadata": {
+                                        "$ref": "#/definitions/deletedMetadata"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "REVERTED_TRANSACTION": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "REVERTED_TRANSACTION"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "REVERTED_TRANSACTION"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "object",
+                                    "required": [
+                                      "revertedTransaction"
+                                    ],
+                                    "properties": {
+                                      "revertedTransaction": {
+                                        "$ref": "#/definitions/revertedTransaction"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "SAVED_METADATA": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "SAVED_METADATA"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "SET_METADATA"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "object",
+                                    "required": [
+                                      "savedMetadata"
+                                    ],
+                                    "properties": {
+                                      "savedMetadata": {
+                                        "$ref": "#/definitions/savedMetadata"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "SKIPPED_ORDER": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "SKIPPED_ORDER"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "ORDER_SKIPPED"
+                                    ]
+                                  },
+                                  "data": {
+                                    "$ref": "#/definitions/skippedOrder"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
     }
   },
   "orchestration": {

--- a/events/generated/ledger/v3.0.0/COMMITTED_TRANSACTION.json
+++ b/events/generated/ledger/v3.0.0/COMMITTED_TRANSACTION.json
@@ -1,0 +1,504 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "type",
+    "ledger",
+    "date",
+    "logSequence",
+    "log"
+  ],
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "logSequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "log": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "payload"
+      ],
+      "properties": {
+        "sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload": {
+          "type": "object"
+        },
+        "receipt": {
+          "type": "string"
+        },
+        "responseSignature": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "definitions": {
+    "metadataValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/metadataValue"
+      }
+    },
+    "posting": {
+      "type": "object",
+      "required": [
+        "source",
+        "destination",
+        "amount",
+        "asset",
+        "color"
+      ],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolume": {
+      "type": "object",
+      "required": [
+        "asset",
+        "color",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolumes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/postCommitVolume"
+        }
+      }
+    },
+    "transaction": {
+      "type": "object",
+      "required": [
+        "postings",
+        "metadata",
+        "id",
+        "reverted"
+      ],
+      "properties": {
+        "postings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/posting"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "insertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedByTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertsTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "reverted": {
+          "type": "boolean"
+        },
+        "postCommitVolumes": {
+          "$ref": "#/definitions/postCommitVolumes"
+        }
+      }
+    },
+    "createdTransaction": {
+      "type": "object",
+      "required": [
+        "transaction"
+      ],
+      "properties": {
+        "transaction": {
+          "$ref": "#/definitions/transaction"
+        },
+        "accountMetadata": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/metadata"
+          }
+        },
+        "chapterId": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "revertedTransaction": {
+      "type": "object",
+      "required": [
+        "revertedTransactionId",
+        "revertTransaction"
+      ],
+      "properties": {
+        "revertedTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertTransaction": {
+          "$ref": "#/definitions/transaction"
+        }
+      }
+    },
+    "savedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "metadata"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "deletedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "key"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "createdLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadataSchema": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "mode": {
+          "type": "integer"
+        },
+        "mirrorSource": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "accountTypes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "defaultEnforcementMode": {
+          "type": "integer"
+        }
+      }
+    },
+    "deletedLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "deletedAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "deletedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "skippedOrder": {
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "TRANSACTION_REFERENCE_CONFLICT",
+            "TRANSACTION_ALREADY_REVERTED",
+            "METADATA_NOT_FOUND",
+            "ACCOUNT_TYPE_ALREADY_EXISTS",
+            "ACCOUNT_TYPE_NOT_FOUND"
+          ]
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apply": {
+      "type": "object",
+      "required": [
+        "ledgerName",
+        "log"
+      ],
+      "properties": {
+        "ledgerName": {
+          "type": "string"
+        },
+        "log": {
+          "type": "object",
+          "required": [
+            "type",
+            "data",
+            "date",
+            "id"
+          ],
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object"
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "COMMITTED_TRANSACTION"
+          ]
+        },
+        "log": {
+          "type": "object",
+          "properties": {
+            "payload": {
+              "type": "object",
+              "required": [
+                "apply"
+              ],
+              "properties": {
+                "apply": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/apply"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "log": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "enum": [
+                                "NEW_TRANSACTION"
+                              ]
+                            },
+                            "data": {
+                              "type": "object",
+                              "required": [
+                                "createdTransaction"
+                              ],
+                              "properties": {
+                                "createdTransaction": {
+                                  "$ref": "#/definitions/createdTransaction"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/events/generated/ledger/v3.0.0/CREATED_LEDGER.json
+++ b/events/generated/ledger/v3.0.0/CREATED_LEDGER.json
@@ -1,0 +1,474 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "type",
+    "ledger",
+    "date",
+    "logSequence",
+    "log"
+  ],
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "logSequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "log": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "payload"
+      ],
+      "properties": {
+        "sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload": {
+          "type": "object"
+        },
+        "receipt": {
+          "type": "string"
+        },
+        "responseSignature": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "definitions": {
+    "metadataValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/metadataValue"
+      }
+    },
+    "posting": {
+      "type": "object",
+      "required": [
+        "source",
+        "destination",
+        "amount",
+        "asset",
+        "color"
+      ],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolume": {
+      "type": "object",
+      "required": [
+        "asset",
+        "color",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolumes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/postCommitVolume"
+        }
+      }
+    },
+    "transaction": {
+      "type": "object",
+      "required": [
+        "postings",
+        "metadata",
+        "id",
+        "reverted"
+      ],
+      "properties": {
+        "postings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/posting"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "insertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedByTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertsTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "reverted": {
+          "type": "boolean"
+        },
+        "postCommitVolumes": {
+          "$ref": "#/definitions/postCommitVolumes"
+        }
+      }
+    },
+    "createdTransaction": {
+      "type": "object",
+      "required": [
+        "transaction"
+      ],
+      "properties": {
+        "transaction": {
+          "$ref": "#/definitions/transaction"
+        },
+        "accountMetadata": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/metadata"
+          }
+        },
+        "chapterId": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "revertedTransaction": {
+      "type": "object",
+      "required": [
+        "revertedTransactionId",
+        "revertTransaction"
+      ],
+      "properties": {
+        "revertedTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertTransaction": {
+          "$ref": "#/definitions/transaction"
+        }
+      }
+    },
+    "savedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "metadata"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "deletedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "key"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "createdLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadataSchema": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "mode": {
+          "type": "integer"
+        },
+        "mirrorSource": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "accountTypes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "defaultEnforcementMode": {
+          "type": "integer"
+        }
+      }
+    },
+    "deletedLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "deletedAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "deletedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "skippedOrder": {
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "TRANSACTION_REFERENCE_CONFLICT",
+            "TRANSACTION_ALREADY_REVERTED",
+            "METADATA_NOT_FOUND",
+            "ACCOUNT_TYPE_ALREADY_EXISTS",
+            "ACCOUNT_TYPE_NOT_FOUND"
+          ]
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apply": {
+      "type": "object",
+      "required": [
+        "ledgerName",
+        "log"
+      ],
+      "properties": {
+        "ledgerName": {
+          "type": "string"
+        },
+        "log": {
+          "type": "object",
+          "required": [
+            "type",
+            "data",
+            "date",
+            "id"
+          ],
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object"
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "CREATED_LEDGER"
+          ]
+        },
+        "log": {
+          "type": "object",
+          "properties": {
+            "payload": {
+              "type": "object",
+              "required": [
+                "createLedger"
+              ],
+              "properties": {
+                "createLedger": {
+                  "$ref": "#/definitions/createdLedger"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/events/generated/ledger/v3.0.0/DELETED_LEDGER.json
+++ b/events/generated/ledger/v3.0.0/DELETED_LEDGER.json
@@ -1,0 +1,474 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "type",
+    "ledger",
+    "date",
+    "logSequence",
+    "log"
+  ],
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "logSequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "log": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "payload"
+      ],
+      "properties": {
+        "sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload": {
+          "type": "object"
+        },
+        "receipt": {
+          "type": "string"
+        },
+        "responseSignature": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "definitions": {
+    "metadataValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/metadataValue"
+      }
+    },
+    "posting": {
+      "type": "object",
+      "required": [
+        "source",
+        "destination",
+        "amount",
+        "asset",
+        "color"
+      ],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolume": {
+      "type": "object",
+      "required": [
+        "asset",
+        "color",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolumes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/postCommitVolume"
+        }
+      }
+    },
+    "transaction": {
+      "type": "object",
+      "required": [
+        "postings",
+        "metadata",
+        "id",
+        "reverted"
+      ],
+      "properties": {
+        "postings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/posting"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "insertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedByTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertsTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "reverted": {
+          "type": "boolean"
+        },
+        "postCommitVolumes": {
+          "$ref": "#/definitions/postCommitVolumes"
+        }
+      }
+    },
+    "createdTransaction": {
+      "type": "object",
+      "required": [
+        "transaction"
+      ],
+      "properties": {
+        "transaction": {
+          "$ref": "#/definitions/transaction"
+        },
+        "accountMetadata": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/metadata"
+          }
+        },
+        "chapterId": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "revertedTransaction": {
+      "type": "object",
+      "required": [
+        "revertedTransactionId",
+        "revertTransaction"
+      ],
+      "properties": {
+        "revertedTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertTransaction": {
+          "$ref": "#/definitions/transaction"
+        }
+      }
+    },
+    "savedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "metadata"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "deletedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "key"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "createdLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadataSchema": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "mode": {
+          "type": "integer"
+        },
+        "mirrorSource": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "accountTypes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "defaultEnforcementMode": {
+          "type": "integer"
+        }
+      }
+    },
+    "deletedLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "deletedAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "deletedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "skippedOrder": {
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "TRANSACTION_REFERENCE_CONFLICT",
+            "TRANSACTION_ALREADY_REVERTED",
+            "METADATA_NOT_FOUND",
+            "ACCOUNT_TYPE_ALREADY_EXISTS",
+            "ACCOUNT_TYPE_NOT_FOUND"
+          ]
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apply": {
+      "type": "object",
+      "required": [
+        "ledgerName",
+        "log"
+      ],
+      "properties": {
+        "ledgerName": {
+          "type": "string"
+        },
+        "log": {
+          "type": "object",
+          "required": [
+            "type",
+            "data",
+            "date",
+            "id"
+          ],
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object"
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "DELETED_LEDGER"
+          ]
+        },
+        "log": {
+          "type": "object",
+          "properties": {
+            "payload": {
+              "type": "object",
+              "required": [
+                "deleteLedger"
+              ],
+              "properties": {
+                "deleteLedger": {
+                  "$ref": "#/definitions/deletedLedger"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/events/generated/ledger/v3.0.0/DELETED_METADATA.json
+++ b/events/generated/ledger/v3.0.0/DELETED_METADATA.json
@@ -1,0 +1,504 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "type",
+    "ledger",
+    "date",
+    "logSequence",
+    "log"
+  ],
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "logSequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "log": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "payload"
+      ],
+      "properties": {
+        "sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload": {
+          "type": "object"
+        },
+        "receipt": {
+          "type": "string"
+        },
+        "responseSignature": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "definitions": {
+    "metadataValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/metadataValue"
+      }
+    },
+    "posting": {
+      "type": "object",
+      "required": [
+        "source",
+        "destination",
+        "amount",
+        "asset",
+        "color"
+      ],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolume": {
+      "type": "object",
+      "required": [
+        "asset",
+        "color",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolumes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/postCommitVolume"
+        }
+      }
+    },
+    "transaction": {
+      "type": "object",
+      "required": [
+        "postings",
+        "metadata",
+        "id",
+        "reverted"
+      ],
+      "properties": {
+        "postings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/posting"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "insertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedByTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertsTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "reverted": {
+          "type": "boolean"
+        },
+        "postCommitVolumes": {
+          "$ref": "#/definitions/postCommitVolumes"
+        }
+      }
+    },
+    "createdTransaction": {
+      "type": "object",
+      "required": [
+        "transaction"
+      ],
+      "properties": {
+        "transaction": {
+          "$ref": "#/definitions/transaction"
+        },
+        "accountMetadata": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/metadata"
+          }
+        },
+        "chapterId": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "revertedTransaction": {
+      "type": "object",
+      "required": [
+        "revertedTransactionId",
+        "revertTransaction"
+      ],
+      "properties": {
+        "revertedTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertTransaction": {
+          "$ref": "#/definitions/transaction"
+        }
+      }
+    },
+    "savedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "metadata"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "deletedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "key"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "createdLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadataSchema": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "mode": {
+          "type": "integer"
+        },
+        "mirrorSource": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "accountTypes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "defaultEnforcementMode": {
+          "type": "integer"
+        }
+      }
+    },
+    "deletedLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "deletedAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "deletedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "skippedOrder": {
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "TRANSACTION_REFERENCE_CONFLICT",
+            "TRANSACTION_ALREADY_REVERTED",
+            "METADATA_NOT_FOUND",
+            "ACCOUNT_TYPE_ALREADY_EXISTS",
+            "ACCOUNT_TYPE_NOT_FOUND"
+          ]
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apply": {
+      "type": "object",
+      "required": [
+        "ledgerName",
+        "log"
+      ],
+      "properties": {
+        "ledgerName": {
+          "type": "string"
+        },
+        "log": {
+          "type": "object",
+          "required": [
+            "type",
+            "data",
+            "date",
+            "id"
+          ],
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object"
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "DELETED_METADATA"
+          ]
+        },
+        "log": {
+          "type": "object",
+          "properties": {
+            "payload": {
+              "type": "object",
+              "required": [
+                "apply"
+              ],
+              "properties": {
+                "apply": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/apply"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "log": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "enum": [
+                                "DELETE_METADATA"
+                              ]
+                            },
+                            "data": {
+                              "type": "object",
+                              "required": [
+                                "deletedMetadata"
+                              ],
+                              "properties": {
+                                "deletedMetadata": {
+                                  "$ref": "#/definitions/deletedMetadata"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/events/generated/ledger/v3.0.0/REVERTED_TRANSACTION.json
+++ b/events/generated/ledger/v3.0.0/REVERTED_TRANSACTION.json
@@ -1,0 +1,504 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "type",
+    "ledger",
+    "date",
+    "logSequence",
+    "log"
+  ],
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "logSequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "log": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "payload"
+      ],
+      "properties": {
+        "sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload": {
+          "type": "object"
+        },
+        "receipt": {
+          "type": "string"
+        },
+        "responseSignature": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "definitions": {
+    "metadataValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/metadataValue"
+      }
+    },
+    "posting": {
+      "type": "object",
+      "required": [
+        "source",
+        "destination",
+        "amount",
+        "asset",
+        "color"
+      ],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolume": {
+      "type": "object",
+      "required": [
+        "asset",
+        "color",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolumes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/postCommitVolume"
+        }
+      }
+    },
+    "transaction": {
+      "type": "object",
+      "required": [
+        "postings",
+        "metadata",
+        "id",
+        "reverted"
+      ],
+      "properties": {
+        "postings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/posting"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "insertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedByTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertsTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "reverted": {
+          "type": "boolean"
+        },
+        "postCommitVolumes": {
+          "$ref": "#/definitions/postCommitVolumes"
+        }
+      }
+    },
+    "createdTransaction": {
+      "type": "object",
+      "required": [
+        "transaction"
+      ],
+      "properties": {
+        "transaction": {
+          "$ref": "#/definitions/transaction"
+        },
+        "accountMetadata": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/metadata"
+          }
+        },
+        "chapterId": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "revertedTransaction": {
+      "type": "object",
+      "required": [
+        "revertedTransactionId",
+        "revertTransaction"
+      ],
+      "properties": {
+        "revertedTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertTransaction": {
+          "$ref": "#/definitions/transaction"
+        }
+      }
+    },
+    "savedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "metadata"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "deletedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "key"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "createdLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadataSchema": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "mode": {
+          "type": "integer"
+        },
+        "mirrorSource": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "accountTypes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "defaultEnforcementMode": {
+          "type": "integer"
+        }
+      }
+    },
+    "deletedLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "deletedAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "deletedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "skippedOrder": {
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "TRANSACTION_REFERENCE_CONFLICT",
+            "TRANSACTION_ALREADY_REVERTED",
+            "METADATA_NOT_FOUND",
+            "ACCOUNT_TYPE_ALREADY_EXISTS",
+            "ACCOUNT_TYPE_NOT_FOUND"
+          ]
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apply": {
+      "type": "object",
+      "required": [
+        "ledgerName",
+        "log"
+      ],
+      "properties": {
+        "ledgerName": {
+          "type": "string"
+        },
+        "log": {
+          "type": "object",
+          "required": [
+            "type",
+            "data",
+            "date",
+            "id"
+          ],
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object"
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "REVERTED_TRANSACTION"
+          ]
+        },
+        "log": {
+          "type": "object",
+          "properties": {
+            "payload": {
+              "type": "object",
+              "required": [
+                "apply"
+              ],
+              "properties": {
+                "apply": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/apply"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "log": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "enum": [
+                                "REVERTED_TRANSACTION"
+                              ]
+                            },
+                            "data": {
+                              "type": "object",
+                              "required": [
+                                "revertedTransaction"
+                              ],
+                              "properties": {
+                                "revertedTransaction": {
+                                  "$ref": "#/definitions/revertedTransaction"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/events/generated/ledger/v3.0.0/SAVED_METADATA.json
+++ b/events/generated/ledger/v3.0.0/SAVED_METADATA.json
@@ -1,0 +1,504 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "type",
+    "ledger",
+    "date",
+    "logSequence",
+    "log"
+  ],
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "logSequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "log": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "payload"
+      ],
+      "properties": {
+        "sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload": {
+          "type": "object"
+        },
+        "receipt": {
+          "type": "string"
+        },
+        "responseSignature": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "definitions": {
+    "metadataValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/metadataValue"
+      }
+    },
+    "posting": {
+      "type": "object",
+      "required": [
+        "source",
+        "destination",
+        "amount",
+        "asset",
+        "color"
+      ],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolume": {
+      "type": "object",
+      "required": [
+        "asset",
+        "color",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolumes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/postCommitVolume"
+        }
+      }
+    },
+    "transaction": {
+      "type": "object",
+      "required": [
+        "postings",
+        "metadata",
+        "id",
+        "reverted"
+      ],
+      "properties": {
+        "postings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/posting"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "insertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedByTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertsTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "reverted": {
+          "type": "boolean"
+        },
+        "postCommitVolumes": {
+          "$ref": "#/definitions/postCommitVolumes"
+        }
+      }
+    },
+    "createdTransaction": {
+      "type": "object",
+      "required": [
+        "transaction"
+      ],
+      "properties": {
+        "transaction": {
+          "$ref": "#/definitions/transaction"
+        },
+        "accountMetadata": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/metadata"
+          }
+        },
+        "chapterId": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "revertedTransaction": {
+      "type": "object",
+      "required": [
+        "revertedTransactionId",
+        "revertTransaction"
+      ],
+      "properties": {
+        "revertedTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertTransaction": {
+          "$ref": "#/definitions/transaction"
+        }
+      }
+    },
+    "savedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "metadata"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "deletedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "key"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "createdLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadataSchema": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "mode": {
+          "type": "integer"
+        },
+        "mirrorSource": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "accountTypes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "defaultEnforcementMode": {
+          "type": "integer"
+        }
+      }
+    },
+    "deletedLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "deletedAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "deletedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "skippedOrder": {
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "TRANSACTION_REFERENCE_CONFLICT",
+            "TRANSACTION_ALREADY_REVERTED",
+            "METADATA_NOT_FOUND",
+            "ACCOUNT_TYPE_ALREADY_EXISTS",
+            "ACCOUNT_TYPE_NOT_FOUND"
+          ]
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apply": {
+      "type": "object",
+      "required": [
+        "ledgerName",
+        "log"
+      ],
+      "properties": {
+        "ledgerName": {
+          "type": "string"
+        },
+        "log": {
+          "type": "object",
+          "required": [
+            "type",
+            "data",
+            "date",
+            "id"
+          ],
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object"
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "SAVED_METADATA"
+          ]
+        },
+        "log": {
+          "type": "object",
+          "properties": {
+            "payload": {
+              "type": "object",
+              "required": [
+                "apply"
+              ],
+              "properties": {
+                "apply": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/apply"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "log": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "enum": [
+                                "SET_METADATA"
+                              ]
+                            },
+                            "data": {
+                              "type": "object",
+                              "required": [
+                                "savedMetadata"
+                              ],
+                              "properties": {
+                                "savedMetadata": {
+                                  "$ref": "#/definitions/savedMetadata"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/events/generated/ledger/v3.0.0/SKIPPED_ORDER.json
+++ b/events/generated/ledger/v3.0.0/SKIPPED_ORDER.json
@@ -1,0 +1,496 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "type",
+    "ledger",
+    "date",
+    "logSequence",
+    "log"
+  ],
+  "properties": {
+    "type": {
+      "type": "string"
+    },
+    "ledger": {
+      "type": "string",
+      "minLength": 1
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "logSequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "log": {
+      "type": "object",
+      "required": [
+        "sequence",
+        "payload"
+      ],
+      "properties": {
+        "sequence": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "payload": {
+          "type": "object"
+        },
+        "receipt": {
+          "type": "string"
+        },
+        "responseSignature": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    }
+  },
+  "definitions": {
+    "metadataValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/metadataValue"
+      }
+    },
+    "posting": {
+      "type": "object",
+      "required": [
+        "source",
+        "destination",
+        "amount",
+        "asset",
+        "color"
+      ],
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "amount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolume": {
+      "type": "object",
+      "required": [
+        "asset",
+        "color",
+        "input",
+        "output"
+      ],
+      "properties": {
+        "asset": {
+          "type": "string"
+        },
+        "color": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      }
+    },
+    "postCommitVolumes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/postCommitVolume"
+        }
+      }
+    },
+    "transaction": {
+      "type": "object",
+      "required": [
+        "postings",
+        "metadata",
+        "id",
+        "reverted"
+      ],
+      "properties": {
+        "postings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/posting"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "insertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revertedByTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertsTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "reverted": {
+          "type": "boolean"
+        },
+        "postCommitVolumes": {
+          "$ref": "#/definitions/postCommitVolumes"
+        }
+      }
+    },
+    "createdTransaction": {
+      "type": "object",
+      "required": [
+        "transaction"
+      ],
+      "properties": {
+        "transaction": {
+          "$ref": "#/definitions/transaction"
+        },
+        "accountMetadata": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/metadata"
+          }
+        },
+        "chapterId": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "revertedTransaction": {
+      "type": "object",
+      "required": [
+        "revertedTransactionId",
+        "revertTransaction"
+      ],
+      "properties": {
+        "revertedTransactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "revertTransaction": {
+          "$ref": "#/definitions/transaction"
+        }
+      }
+    },
+    "savedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "metadata"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "metadata": {
+          "$ref": "#/definitions/metadata"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "deletedMetadata": {
+      "type": "object",
+      "required": [
+        "targetType",
+        "key"
+      ],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "TRANSACTION"
+          ]
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "transactionId": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "accountId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "ACCOUNT"
+              ]
+            }
+          }
+        },
+        {
+          "required": [
+            "transactionId"
+          ],
+          "properties": {
+            "targetType": {
+              "enum": [
+                "TRANSACTION"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "createdLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "metadataSchema": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "mode": {
+          "type": "integer"
+        },
+        "mirrorSource": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "accountTypes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "defaultEnforcementMode": {
+          "type": "integer"
+        }
+      }
+    },
+    "deletedLedger": {
+      "type": "object",
+      "required": [
+        "name",
+        "deletedAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "deletedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "skippedOrder": {
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": [
+            "TRANSACTION_REFERENCE_CONFLICT",
+            "TRANSACTION_ALREADY_REVERTED",
+            "METADATA_NOT_FOUND",
+            "ACCOUNT_TYPE_ALREADY_EXISTS",
+            "ACCOUNT_TYPE_NOT_FOUND"
+          ]
+        },
+        "context": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "apply": {
+      "type": "object",
+      "required": [
+        "ledgerName",
+        "log"
+      ],
+      "properties": {
+        "ledgerName": {
+          "type": "string"
+        },
+        "log": {
+          "type": "object",
+          "required": [
+            "type",
+            "data",
+            "date",
+            "id"
+          ],
+          "properties": {
+            "type": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object"
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "id": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "SKIPPED_ORDER"
+          ]
+        },
+        "log": {
+          "type": "object",
+          "properties": {
+            "payload": {
+              "type": "object",
+              "required": [
+                "apply"
+              ],
+              "properties": {
+                "apply": {
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/apply"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "log": {
+                          "type": "object",
+                          "properties": {
+                            "type": {
+                              "enum": [
+                                "ORDER_SKIPPED"
+                              ]
+                            },
+                            "data": {
+                              "$ref": "#/definitions/skippedOrder"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/events/index.js
+++ b/events/index.js
@@ -2,29 +2,69 @@ const fs = require("fs/promises");
 const path = require("path");
 const yaml = require('yaml');
 
+const VERSION_BASE_FILE = 'base.yaml';
+
+async function sortedDirectories(directory) {
+    return (await fs.readdir(directory, { withFileTypes: true }))
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort();
+}
+
+async function sortedEventFiles(directory) {
+    return (await fs.readdir(directory, { withFileTypes: true }))
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.yaml') && entry.name !== VERSION_BASE_FILE)
+        .map((entry) => entry.name)
+        .sort();
+}
+
+async function readVersionBase(versionDirectory) {
+    try {
+        return await fs.readFile(path.join(versionDirectory, VERSION_BASE_FILE), { encoding: 'utf8' });
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return null;
+        }
+        throw error;
+    }
+}
+
+function composeSchema(rawDefaultBase, rawVersionBase, rawEventData) {
+    const event = yaml.parse(rawEventData);
+    if (rawVersionBase !== null) {
+        const base = yaml.parse(rawVersionBase);
+        base.allOf = [...(base.allOf || []), event];
+        return base;
+    }
+
+    const base = yaml.parse(rawDefaultBase);
+    base.properties.payload = event;
+    return base;
+}
+
 (async () => {
 
     const rawBase = await fs.readFile(path.join(__dirname, "base.yaml"), { encoding: 'utf8' });
     const aggregated = {};
 
-    for(const service of await fs.readdir(path.join(__dirname, "services"))) {
+    for(const service of await sortedDirectories(path.join(__dirname, "services"))) {
         aggregated[service] = {};
-        for(const version of await fs.readdir(path.join(__dirname, 'services', service))) {
+        for(const version of await sortedDirectories(path.join(__dirname, 'services', service))) {
             aggregated[service][version] = {};
-            for(const event of await fs.readdir(path.join(__dirname, 'services', service, version))) {
-                const rawEventData = await fs.readFile(path.join(__dirname, 'services', service, version, event), { encoding: 'utf8' });
-                const base = yaml.parse(rawBase);
-                base.properties.payload = yaml.parse(rawEventData);
+            const versionDirectory = path.join(__dirname, 'services', service, version);
+            const rawVersionBase = await readVersionBase(versionDirectory);
+            for(const event of await sortedEventFiles(versionDirectory)) {
+                const rawEventData = await fs.readFile(path.join(versionDirectory, event), { encoding: 'utf8' });
+                const schema = composeSchema(rawBase, rawVersionBase, rawEventData);
                 const directory = path.join(__dirname, 'generated', service, version);
                 await fs.mkdir(directory, { recursive: true });
-                await fs.writeFile(path.join(directory, event.replace('.yaml', '.json')), JSON.stringify(base, null, 2));
+                await fs.writeFile(path.join(directory, event.replace('.yaml', '.json')), JSON.stringify(schema, null, 2));
 
-                aggregated[service][version][event.replace('.yaml', '')] = base;
+                aggregated[service][version][event.replace('.yaml', '')] = schema;
             }
         }
     }
 
-    console.log(aggregated);
     const aggregatedJSON = JSON.stringify(aggregated, null, 2);
     await fs.writeFile(path.join(__dirname, 'generated', 'all.json'), aggregatedJSON);
 

--- a/events/services/ledger/v3.0.0/COMMITTED_TRANSACTION.yaml
+++ b/events/services/ledger/v3.0.0/COMMITTED_TRANSACTION.yaml
@@ -1,0 +1,31 @@
+type: object
+properties:
+  type:
+    enum:
+      - COMMITTED_TRANSACTION
+  log:
+    type: object
+    properties:
+      payload:
+        type: object
+        required:
+          - apply
+        properties:
+          apply:
+            allOf:
+              - $ref: "#/definitions/apply"
+              - type: object
+                properties:
+                  log:
+                    type: object
+                    properties:
+                      type:
+                        enum:
+                          - NEW_TRANSACTION
+                      data:
+                        type: object
+                        required:
+                          - createdTransaction
+                        properties:
+                          createdTransaction:
+                            $ref: "#/definitions/createdTransaction"

--- a/events/services/ledger/v3.0.0/CREATED_LEDGER.yaml
+++ b/events/services/ledger/v3.0.0/CREATED_LEDGER.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  type:
+    enum:
+      - CREATED_LEDGER
+  log:
+    type: object
+    properties:
+      payload:
+        type: object
+        required:
+          - createLedger
+        properties:
+          createLedger:
+            $ref: "#/definitions/createdLedger"

--- a/events/services/ledger/v3.0.0/DELETED_LEDGER.yaml
+++ b/events/services/ledger/v3.0.0/DELETED_LEDGER.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  type:
+    enum:
+      - DELETED_LEDGER
+  log:
+    type: object
+    properties:
+      payload:
+        type: object
+        required:
+          - deleteLedger
+        properties:
+          deleteLedger:
+            $ref: "#/definitions/deletedLedger"

--- a/events/services/ledger/v3.0.0/DELETED_METADATA.yaml
+++ b/events/services/ledger/v3.0.0/DELETED_METADATA.yaml
@@ -1,0 +1,31 @@
+type: object
+properties:
+  type:
+    enum:
+      - DELETED_METADATA
+  log:
+    type: object
+    properties:
+      payload:
+        type: object
+        required:
+          - apply
+        properties:
+          apply:
+            allOf:
+              - $ref: "#/definitions/apply"
+              - type: object
+                properties:
+                  log:
+                    type: object
+                    properties:
+                      type:
+                        enum:
+                          - DELETE_METADATA
+                      data:
+                        type: object
+                        required:
+                          - deletedMetadata
+                        properties:
+                          deletedMetadata:
+                            $ref: "#/definitions/deletedMetadata"

--- a/events/services/ledger/v3.0.0/REVERTED_TRANSACTION.yaml
+++ b/events/services/ledger/v3.0.0/REVERTED_TRANSACTION.yaml
@@ -1,0 +1,31 @@
+type: object
+properties:
+  type:
+    enum:
+      - REVERTED_TRANSACTION
+  log:
+    type: object
+    properties:
+      payload:
+        type: object
+        required:
+          - apply
+        properties:
+          apply:
+            allOf:
+              - $ref: "#/definitions/apply"
+              - type: object
+                properties:
+                  log:
+                    type: object
+                    properties:
+                      type:
+                        enum:
+                          - REVERTED_TRANSACTION
+                      data:
+                        type: object
+                        required:
+                          - revertedTransaction
+                        properties:
+                          revertedTransaction:
+                            $ref: "#/definitions/revertedTransaction"

--- a/events/services/ledger/v3.0.0/SAVED_METADATA.yaml
+++ b/events/services/ledger/v3.0.0/SAVED_METADATA.yaml
@@ -1,0 +1,31 @@
+type: object
+properties:
+  type:
+    enum:
+      - SAVED_METADATA
+  log:
+    type: object
+    properties:
+      payload:
+        type: object
+        required:
+          - apply
+        properties:
+          apply:
+            allOf:
+              - $ref: "#/definitions/apply"
+              - type: object
+                properties:
+                  log:
+                    type: object
+                    properties:
+                      type:
+                        enum:
+                          - SET_METADATA
+                      data:
+                        type: object
+                        required:
+                          - savedMetadata
+                        properties:
+                          savedMetadata:
+                            $ref: "#/definitions/savedMetadata"

--- a/events/services/ledger/v3.0.0/SKIPPED_ORDER.yaml
+++ b/events/services/ledger/v3.0.0/SKIPPED_ORDER.yaml
@@ -1,0 +1,26 @@
+type: object
+properties:
+  type:
+    enum:
+      - SKIPPED_ORDER
+  log:
+    type: object
+    properties:
+      payload:
+        type: object
+        required:
+          - apply
+        properties:
+          apply:
+            allOf:
+              - $ref: "#/definitions/apply"
+              - type: object
+                properties:
+                  log:
+                    type: object
+                    properties:
+                      type:
+                        enum:
+                          - ORDER_SKIPPED
+                      data:
+                        $ref: "#/definitions/skippedOrder"

--- a/events/services/ledger/v3.0.0/base.yaml
+++ b/events/services/ledger/v3.0.0/base.yaml
@@ -1,0 +1,296 @@
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+  - type
+  - ledger
+  - date
+  - logSequence
+  - log
+properties:
+  type:
+    type: string
+  ledger:
+    type: string
+    minLength: 1
+  date:
+    type: string
+    format: date-time
+  logSequence:
+    type: integer
+    minimum: 1
+  log:
+    type: object
+    required:
+      - sequence
+      - payload
+    properties:
+      sequence:
+        type: integer
+        minimum: 1
+      payload:
+        type: object
+      receipt:
+        type: string
+      responseSignature:
+        type: object
+        additionalProperties: true
+definitions:
+  metadataValue:
+    oneOf:
+      - type: string
+      - type: integer
+      - type: boolean
+      - type: "null"
+  metadata:
+    type: object
+    additionalProperties:
+      $ref: "#/definitions/metadataValue"
+  posting:
+    type: object
+    required:
+      - source
+      - destination
+      - amount
+      - asset
+      - color
+    properties:
+      source:
+        type: string
+      destination:
+        type: string
+      amount:
+        type: integer
+        minimum: 0
+      asset:
+        type: string
+      color:
+        type: string
+  postCommitVolume:
+    type: object
+    required:
+      - asset
+      - color
+      - input
+      - output
+    properties:
+      asset:
+        type: string
+      color:
+        type: string
+      input:
+        type: string
+      output:
+        type: string
+  postCommitVolumes:
+    type: object
+    additionalProperties:
+      type: array
+      items:
+        $ref: "#/definitions/postCommitVolume"
+  transaction:
+    type: object
+    required:
+      - postings
+      - metadata
+      - id
+      - reverted
+    properties:
+      postings:
+        type: array
+        items:
+          $ref: "#/definitions/posting"
+      metadata:
+        $ref: "#/definitions/metadata"
+      timestamp:
+        type: string
+        format: date-time
+      reference:
+        type: string
+      id:
+        type: integer
+        minimum: 1
+      insertedAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
+      revertedAt:
+        type: string
+        format: date-time
+      revertedByTransactionId:
+        type: integer
+        minimum: 1
+      revertsTransactionId:
+        type: integer
+        minimum: 1
+      reverted:
+        type: boolean
+      postCommitVolumes:
+        $ref: "#/definitions/postCommitVolumes"
+  createdTransaction:
+    type: object
+    required:
+      - transaction
+    properties:
+      transaction:
+        $ref: "#/definitions/transaction"
+      accountMetadata:
+        type: object
+        additionalProperties:
+          $ref: "#/definitions/metadata"
+      chapterId:
+        type: integer
+        minimum: 1
+  revertedTransaction:
+    type: object
+    required:
+      - revertedTransactionId
+      - revertTransaction
+    properties:
+      revertedTransactionId:
+        type: integer
+        minimum: 1
+      revertTransaction:
+        $ref: "#/definitions/transaction"
+  savedMetadata:
+    type: object
+    required:
+      - targetType
+      - metadata
+    properties:
+      targetType:
+        type: string
+        enum:
+          - ACCOUNT
+          - TRANSACTION
+      accountId:
+        type: string
+      transactionId:
+        type: integer
+        minimum: 1
+      metadata:
+        $ref: "#/definitions/metadata"
+    oneOf:
+      - required:
+          - accountId
+        properties:
+          targetType:
+            enum:
+              - ACCOUNT
+      - required:
+          - transactionId
+        properties:
+          targetType:
+            enum:
+              - TRANSACTION
+  deletedMetadata:
+    type: object
+    required:
+      - targetType
+      - key
+    properties:
+      targetType:
+        type: string
+        enum:
+          - ACCOUNT
+          - TRANSACTION
+      accountId:
+        type: string
+      transactionId:
+        type: integer
+        minimum: 1
+      key:
+        type: string
+    oneOf:
+      - required:
+          - accountId
+        properties:
+          targetType:
+            enum:
+              - ACCOUNT
+      - required:
+          - transactionId
+        properties:
+          targetType:
+            enum:
+              - TRANSACTION
+  createdLedger:
+    type: object
+    required:
+      - name
+      - createdAt
+    properties:
+      name:
+        type: string
+      createdAt:
+        type: string
+        format: date-time
+      metadataSchema:
+        type: object
+        additionalProperties: true
+      mode:
+        type: integer
+      mirrorSource:
+        type: object
+        additionalProperties: true
+      accountTypes:
+        type: object
+        additionalProperties:
+          type: object
+      defaultEnforcementMode:
+        type: integer
+  deletedLedger:
+    type: object
+    required:
+      - name
+      - deletedAt
+    properties:
+      name:
+        type: string
+      deletedAt:
+        type: string
+        format: date-time
+  skippedOrder:
+    type: object
+    required:
+      - reason
+    properties:
+      reason:
+        type: string
+        enum:
+          - TRANSACTION_REFERENCE_CONFLICT
+          - TRANSACTION_ALREADY_REVERTED
+          - METADATA_NOT_FOUND
+          - ACCOUNT_TYPE_ALREADY_EXISTS
+          - ACCOUNT_TYPE_NOT_FOUND
+      context:
+        type: object
+        additionalProperties:
+          type: string
+  apply:
+    type: object
+    required:
+      - ledgerName
+      - log
+    properties:
+      ledgerName:
+        type: string
+      log:
+        type: object
+        required:
+          - type
+          - data
+          - date
+          - id
+        properties:
+          type:
+            type: string
+          data:
+            type: object
+          date:
+            type: string
+            format: date-time
+          id:
+            type: integer
+            minimum: 1

--- a/libs/events/generated/all.json
+++ b/libs/events/generated/all.json
@@ -643,6 +643,3468 @@
           "payload"
         ]
       }
+    },
+    "v3.0.0": {
+      "COMMITTED_TRANSACTION": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "COMMITTED_TRANSACTION"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "NEW_TRANSACTION"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "object",
+                                    "required": [
+                                      "createdTransaction"
+                                    ],
+                                    "properties": {
+                                      "createdTransaction": {
+                                        "$ref": "#/definitions/createdTransaction"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "CREATED_LEDGER": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "CREATED_LEDGER"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "createLedger"
+                    ],
+                    "properties": {
+                      "createLedger": {
+                        "$ref": "#/definitions/createdLedger"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "DELETED_LEDGER": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "DELETED_LEDGER"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "deleteLedger"
+                    ],
+                    "properties": {
+                      "deleteLedger": {
+                        "$ref": "#/definitions/deletedLedger"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "DELETED_METADATA": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "DELETED_METADATA"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "DELETE_METADATA"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "object",
+                                    "required": [
+                                      "deletedMetadata"
+                                    ],
+                                    "properties": {
+                                      "deletedMetadata": {
+                                        "$ref": "#/definitions/deletedMetadata"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "REVERTED_TRANSACTION": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "REVERTED_TRANSACTION"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "REVERTED_TRANSACTION"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "object",
+                                    "required": [
+                                      "revertedTransaction"
+                                    ],
+                                    "properties": {
+                                      "revertedTransaction": {
+                                        "$ref": "#/definitions/revertedTransaction"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "SAVED_METADATA": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "SAVED_METADATA"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "SET_METADATA"
+                                    ]
+                                  },
+                                  "data": {
+                                    "type": "object",
+                                    "required": [
+                                      "savedMetadata"
+                                    ],
+                                    "properties": {
+                                      "savedMetadata": {
+                                        "$ref": "#/definitions/savedMetadata"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "SKIPPED_ORDER": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "required": [
+          "type",
+          "ledger",
+          "date",
+          "logSequence",
+          "log"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "ledger": {
+            "type": "string",
+            "minLength": 1
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "logSequence": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "log": {
+            "type": "object",
+            "required": [
+              "sequence",
+              "payload"
+            ],
+            "properties": {
+              "sequence": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "payload": {
+                "type": "object"
+              },
+              "receipt": {
+                "type": "string"
+              },
+              "responseSignature": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "definitions": {
+          "metadataValue": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/metadataValue"
+            }
+          },
+          "posting": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination",
+              "amount",
+              "asset",
+              "color"
+            ],
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "destination": {
+                "type": "string"
+              },
+              "amount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolume": {
+            "type": "object",
+            "required": [
+              "asset",
+              "color",
+              "input",
+              "output"
+            ],
+            "properties": {
+              "asset": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "input": {
+                "type": "string"
+              },
+              "output": {
+                "type": "string"
+              }
+            }
+          },
+          "postCommitVolumes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/postCommitVolume"
+              }
+            }
+          },
+          "transaction": {
+            "type": "object",
+            "required": [
+              "postings",
+              "metadata",
+              "id",
+              "reverted"
+            ],
+            "properties": {
+              "postings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/posting"
+                }
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "reference": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "insertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "revertedByTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertsTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "reverted": {
+                "type": "boolean"
+              },
+              "postCommitVolumes": {
+                "$ref": "#/definitions/postCommitVolumes"
+              }
+            }
+          },
+          "createdTransaction": {
+            "type": "object",
+            "required": [
+              "transaction"
+            ],
+            "properties": {
+              "transaction": {
+                "$ref": "#/definitions/transaction"
+              },
+              "accountMetadata": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/metadata"
+                }
+              },
+              "chapterId": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "revertedTransaction": {
+            "type": "object",
+            "required": [
+              "revertedTransactionId",
+              "revertTransaction"
+            ],
+            "properties": {
+              "revertedTransactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "revertTransaction": {
+                "$ref": "#/definitions/transaction"
+              }
+            }
+          },
+          "savedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "metadata"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "metadata": {
+                "$ref": "#/definitions/metadata"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "deletedMetadata": {
+            "type": "object",
+            "required": [
+              "targetType",
+              "key"
+            ],
+            "properties": {
+              "targetType": {
+                "type": "string",
+                "enum": [
+                  "ACCOUNT",
+                  "TRANSACTION"
+                ]
+              },
+              "accountId": {
+                "type": "string"
+              },
+              "transactionId": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "key": {
+                "type": "string"
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "ACCOUNT"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "transactionId"
+                ],
+                "properties": {
+                  "targetType": {
+                    "enum": [
+                      "TRANSACTION"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "createdLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "createdAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "metadataSchema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mode": {
+                "type": "integer"
+              },
+              "mirrorSource": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "accountTypes": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "defaultEnforcementMode": {
+                "type": "integer"
+              }
+            }
+          },
+          "deletedLedger": {
+            "type": "object",
+            "required": [
+              "name",
+              "deletedAt"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "deletedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "skippedOrder": {
+            "type": "object",
+            "required": [
+              "reason"
+            ],
+            "properties": {
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "TRANSACTION_REFERENCE_CONFLICT",
+                  "TRANSACTION_ALREADY_REVERTED",
+                  "METADATA_NOT_FOUND",
+                  "ACCOUNT_TYPE_ALREADY_EXISTS",
+                  "ACCOUNT_TYPE_NOT_FOUND"
+                ]
+              },
+              "context": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "apply": {
+            "type": "object",
+            "required": [
+              "ledgerName",
+              "log"
+            ],
+            "properties": {
+              "ledgerName": {
+                "type": "string"
+              },
+              "log": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "data",
+                  "date",
+                  "id"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "object"
+                  },
+                  "date": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                }
+              }
+            }
+          }
+        },
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "SKIPPED_ORDER"
+                ]
+              },
+              "log": {
+                "type": "object",
+                "properties": {
+                  "payload": {
+                    "type": "object",
+                    "required": [
+                      "apply"
+                    ],
+                    "properties": {
+                      "apply": {
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/apply"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "log": {
+                                "type": "object",
+                                "properties": {
+                                  "type": {
+                                    "enum": [
+                                      "ORDER_SKIPPED"
+                                    ]
+                                  },
+                                  "data": {
+                                    "$ref": "#/definitions/skippedOrder"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
     }
   },
   "orchestration": {


### PR DESCRIPTION
## Summary

- add schemas for every Ledger v3 event currently emitted by the event sink to NATS and Kafka
- model the Ledger v3 envelope as type, ledger, date, logSequence, and the complete log
- support version-specific event envelopes while preserving the historical Stack payload envelope
- keep legacy Ledger event lookup working for event types that only exist in v1/v2
- regenerate both canonical and legacy event catalogues

## Ledger v3 events

- COMMITTED_TRANSACTION
- REVERTED_TRANSACTION
- SAVED_METADATA
- DELETED_METADATA
- CREATED_LEDGER
- DELETED_LEDGER
- SKIPPED_ORDER

## Validation

- cd events && go test ./...
- cd events && go vet ./...
- nix develop -c just generate-events
- Ledger release/v3.0 targeted event conversion and JSON serialization tests
- exact comparison between the Ledger EventType enum and the generated v3 catalogue
- generated catalogue reproducibility and canonical/legacy checksum equality
- git diff --check

## Notes

The schemas are based on the current formancehq/ledger release/v3.0 sink serialization. NATS and Kafka share the same serialized event envelope; only transport routing differs.